### PR TITLE
fix module naming in crowlib

### DIFF
--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -21,23 +21,23 @@ end
 local function closelibs()
     -- set whole list of libs to nil to close them
     -- TODO does this free the RAM used by 'dofile'?
-    input  = nil
-    output = nil
-    asl    = nil
-    asllib = nil
-    metro  = nil
-    ii     = nil
+    Input  = nil
+    Output = nil
+    Asl    = nil
+    Asllib = nil
+    Metro  = nil
+    II     = nil
 end
 
 function _crow.libs( lib )
     if lib == nil then
         -- load all
-        input  = dofile('lua/input.lua')
-        output = dofile('lua/output.lua')
-        asl    = dofile('lua/asl.lua')
-        asllib = dofile('lua/asllib.lua')
-        metro  = dofile('lua/metro.lua')
-        ii     = dofile('lua/ii.lua')
+        Input  = dofile('lua/input.lua')
+        Output = dofile('lua/output.lua')
+        Asl    = dofile('lua/asl.lua')
+        Asllib = dofile('lua/asllib.lua')
+        Metro  = dofile('lua/metro.lua')
+        II     = dofile('lua/ii.lua')
     elseif type(lib) == 'table' then
         -- load the list 
     else
@@ -82,21 +82,21 @@ end
 --- Input
 input = {1,2}
 for chan = 1, #input do
-    input[chan] = input.new( chan )
+    input[chan] = Input.new( chan )
 end
 
 --- Output
-out = {1,2,3,4}
-for chan = 1, #out do
-    out[chan] = output.new( chan )
+output = {1,2,3,4}
+for chan = 1, #output do
+    output[chan] = Output.new( chan )
 end
 
 --- Asl
 function toward_handler( id ) end -- do nothing if Asl not active
 -- if defined, make sure active before setting up actions and banging
-if asl then
+if Asl then
     toward_handler = function( id )
-        out[id].asl:step()
+        output[id].asl:step()
     end
 end
 -- TODO should 'go_toward' be called 'slew'???

--- a/lua/default.lua
+++ b/lua/default.lua
@@ -14,14 +14,14 @@ end
 -- by the setup otherwise? i don't understand why the table access doesn't cause
 -- the library to be loaded, have default event, then apply the .event here to
 -- overwrite it?
-local ignore = ii.txi.get
-ii.txi.event = function( e, data )
-    if e == 'value' then debug_usart('value='..data)
-    end
-end
+--local ignore = II.txi.get
+--II.txi.event = function( e, data )
+--    if e == 'value' then debug_usart('value='..data)
+--    end
+--end
 
-local position = 0
-function count(c)
-    position = position + 1
-    print(position)
-end
+--local position = 0
+--function count(c)
+--    position = position + 1
+--    print(position)
+--end


### PR DESCRIPTION
this was broken in a previous PR (sorry!)
this PR fixes naming collisions where user-tables would overwrite the modules the modules they were meant to inherit from.

this fixes basic behaviour and LFOs should be back after applying this patch.

needs eventual update to match norns see #59.