### PR TITLE
calibration engine hooked up to lua and user interface refined

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,3 +552,29 @@ ii.jf.event( event, data )
 end
 
 ```
+
+## Calibration
+
+crow has an in-built calibration mechansim to allow the inputs and outputs to
+accurately follow and output values. This functionality is primarily for use with
+volt-per-octave signals, though of course this accuracy can be used for any number
+of other purposes!
+
+All modules come pre-calibrated from the factory, so you'll likely never need to
+think about this, but just in case, recalibration and data inspection is allowed.
+
+### Cal.test()
+
+The `Cal.test()` function causes crow to re-run the calibration process.
+
+**You must remove all patch cables from the jacks for this process to work correctly!**
+Calling `test` without any arguments runs the calibration as per normal, while
+runing `test('default')` will not run the calibration process, but instead return
+to default values, in case you're having problems with the calibration process.
+
+### Cal.print()
+
+This helper function is just for debugging purposes. Calling it will simply dump
+a list of values showing the scaling & translation of voltages that were measured
+during the calibratin process. If you're really curious try resetting to the defaults
+then printing, followed by a `test()` and `print` to see the difference.

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -15,7 +15,8 @@
 #include "lib/bootloader.h" // bootloader_enter()
 #include "lib/metro.h"      // metro_start() metro_stop() metro_set_time()
 #include "lib/io.h"         // IO_GetADC()
-#include "../ll/random.h"      // Random_Get()
+#include "../ll/random.h"   // Random_Get()
+#include "../ll/adda.h"     // CAL_Recalibrate() CAL_PrintCalibration()
 
 // Lua libs wrapped in C-headers: Note the extra '.h'
 #include "lua/bootstrap.lua.h" // MUST LOAD THIS MANUALLY FIRST
@@ -27,19 +28,21 @@
 #include "lua/output.lua.h"
 #include "lua/ii.lua.h"
 #include "build/iihelp.lua.h"    // generated lua stub for loading i2c modules
+#include "lua/calibrate.lua.h"
 
 #include "build/ii_lualink.h" // generated C header for linking to lua
 
 const struct lua_lib_locator Lua_libs[] =
-    { { "lua_crowlib", lua_crowlib }
-    , { "lua_asl"    , lua_asl     }
-    , { "lua_asllib" , lua_asllib  }
-    , { "lua_metro"  , lua_metro   }
-    , { "lua_input"  , lua_input   }
-    , { "lua_output" , lua_output  }
-    , { "lua_ii"     , lua_ii      }
-    , { "build_iihelp", build_iihelp }
-    , { NULL         , NULL        }
+    { { "lua_crowlib"   , lua_crowlib   }
+    , { "lua_asl"       , lua_asl       }
+    , { "lua_asllib"    , lua_asllib    }
+    , { "lua_metro"     , lua_metro     }
+    , { "lua_input"     , lua_input     }
+    , { "lua_output"    , lua_output    }
+    , { "lua_ii"        , lua_ii        }
+    , { "build_iihelp"  , build_iihelp  }
+    , { "lua_calibrate" , lua_calibrate }
+    , { NULL            , NULL          }
     };
 
 // Basic crow script
@@ -334,6 +337,18 @@ static int _random_get( lua_State* L )
     return 1;
 }
 
+static int _calibrate_now( lua_State* L )
+{
+    CAL_Recalibrate( (lua_gettop(L)) ); // if arg present, use defaults
+    lua_settop(L, 0);
+    return 0;
+}
+static int _calibrate_print( lua_State* L )
+{
+    CAL_PrintCalibration();
+    return 0;
+}
+
 // array of all the available functions
 static const struct luaL_Reg libCrow[]=
         // bootstrap
@@ -364,6 +379,9 @@ static const struct luaL_Reg libCrow[]=
     , { "metro_set_time"   , _metro_set_time   }
         // random
     , { "random_get"       , _random_get       }
+        // calibration
+    , { "calibrate_now"    , _calibrate_now    }
+    , { "calibrate_print"  , _calibrate_print  }
 
     , { NULL               , NULL              }
     };

--- a/ll/adda.c
+++ b/ll/adda.c
@@ -7,6 +7,7 @@
 #include "../lib/flash.h"              // FLASH_*_t
 #include "cal_ll.h"      // CAL_LL_Init(),
 #include "../lib/slopes.h"             // S_toward()
+#include "../lib/caw.h" // Caw_send_raw
 
 float _CAL_ADC_GetAverage( uint8_t chan );
 
@@ -47,7 +48,6 @@ IO_block_t* CAL_BlockProcess( IO_block_t* b );
 
 void CAL_ReadFlash( void )
 {
-    printf("loading calibration data\n");
     if( !Flash_read_calibration( (uint8_t*)(&cal)
                                , sizeof(CAL_chan_t) * (2+4)
                                ) ){
@@ -59,6 +59,7 @@ void CAL_ReadFlash( void )
             DAC_CalibrateOffset( j, cal.dac[j].shift );
             DAC_CalibrateScalar( j, cal.dac[j].scale );
         }
+        //CAL_PrintCalibration();
         cal.stage = CAL_none;
     } else {
         printf("calibration readout failed\n");
@@ -67,7 +68,7 @@ void CAL_ReadFlash( void )
 
 void CAL_WriteFlash( void )
 {
-    printf("saving calibration data\n");
+    printf("Saving calibration data\n");
     if( Flash_write_calibration( (uint8_t*)(&cal)
                                , sizeof(CAL_chan_t) * (2+4)
                                ) ){
@@ -85,7 +86,7 @@ uint16_t ADDA_Init( void )
             );
     CAL_LL_Init();
     cal.stage = CAL_none;
-    if( !Flash_is_calibrated() ){ CAL_Recalibrate(); }
+    if( !Flash_is_calibrated() ){ CAL_Recalibrate(0); }
     else{                         CAL_ReadFlash(); }
     return ADDA_BLOCK_SIZE;
 }
@@ -246,7 +247,7 @@ CAL_stage_t CAL_is_calibrating( void )
     return cal.stage;
 }
 
-void CAL_Recalibrate( void )
+void CAL_Recalibrate( uint8_t use_defaults )
 {
     // use default values
     for( int j=0; j<2; j++ ){
@@ -257,6 +258,28 @@ void CAL_Recalibrate( void )
         DAC_CalibrateOffset( j, 0.0 );
         DAC_CalibrateScalar( j, 1.0 );
     }
-    cal.stage = CAL_in_shift;
-    cal.avg_count = AVERAGE_COUNT;
+    if( !use_defaults ){ // causes recalibration to run
+        cal.stage = CAL_in_shift;
+        cal.avg_count = AVERAGE_COUNT;
+    }
+}
+
+void CAL_PrintCalibration( void )
+{
+    char pc[64];
+    uint8_t len = 0;
+    snprintf(pc,63,"IO Calibration Data:");
+    Caw_send_raw( (uint8_t*)pc, len );
+    for( int j=0; j<2; j++ ){
+        len = snprintf(pc, 63, " adc %f, %f\n"
+                      , (double)cal.adc[j].shift, (double)cal.adc[j].scale );
+        if(len > 63){ len = 63; }
+        Caw_send_raw( (uint8_t*)pc, len );
+    }
+    for( int j=0; j<4; j++ ){
+        len = snprintf(pc, 63, " dac %f, %f\n"
+                      , (double)cal.dac[j].shift, (double)cal.dac[j].scale );
+        if(len > 63){ len = 63; }
+        Caw_send_raw( (uint8_t*)pc, len );
+    }
 }

--- a/ll/adda.h
+++ b/ll/adda.h
@@ -24,4 +24,5 @@ float ADDA_GetADCValue( uint8_t channel );
 IO_block_t* IO_BlockProcess( IO_block_t* b );
 
 // calibration
-void CAL_Recalibrate( void );
+void CAL_Recalibrate( uint8_t use_defaults );
+void CAL_PrintCalibration( void );


### PR DESCRIPTION
Allows ins & outs to be recalibrated from lua, or reset to defaults. There is also a command allowing to print out the values stored in calibration storage to confirm the values are ballpark correct.

See the README for usage.

Solves first 2 checkboxes of issue #39 