### PR TITLE
I2C events, pullups & helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,6 +553,11 @@ end
 
 ```
 
+Note that by default the `event()` defaults to a satellite action which is
+`^^II.<module>(<event>,<value>)`
+for eg:
+`^^II.txi('value', 0.1)`
+
 ## Calibration
 
 crow has an in-built calibration mechansim to allow the inputs and outputs to

--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ no changes are required to the default setup on crow. Simply use:
 
 crow has default actions to handle these messages, though like most things in crow
 they can be redefined for our own purposes by editing the functions in the table
-`ii._c`. Try printing the follower-help with `ii._c.help()` for a list of functions
+`II._c`. Try printing the follower-help with `II._c.help()` for a list of functions
 that can be redefined.
 
 #### A crow call
@@ -474,7 +474,7 @@ teletype:
 `CROW.CALL2 1 V 1`
 This should add 1 volt to the first output jack on crow.
 
-We can then redefine the function at `ii._c.call2()` to call our `add_to_output()`
+We can then redefine the function at `II._c.call2()` to call our `add_to_output()`
 function.
 
 #### Calling with context
@@ -493,7 +493,7 @@ local actions=
 , add_random    = function(arg) add_to_output(arg, semitone(Math.rand())) end
 }
 
-ii._c.call2 = function(cmd, arg2)
+II._c.call2 = function(cmd, arg2)
     actions[cmd](arg2)
 end
 ```
@@ -508,17 +508,17 @@ Then on teletype:
 ### Leading the i2c bus
 
 You can get a list of supported i2c devices by typing:
-`ii.help()`
+`II.help()`
 
 All the returned devices can themselves be queried for their available functions.
-`ii.<module>.help()`, or eg: `ii.jf.help()`
+`II.<module>.help()`, or eg: `II.jf.help()`
 
 These functions are formatted in such a way that you can directly copy-and-paste
 these help files into your script.
 
 #### Commands / Setters
 Remote devices can be controlled with `commands`. These are listed first by the
-help() functions. eg: `ii.jf.trigger( channel, state )`. These are typically called
+`help()` functions. eg: `II.jf.trigger( channel, state )`. These are typically called
 'setters' when described in the teletype context.
 
 You can call these like regular functions and they will send their commands over the
@@ -537,15 +537,15 @@ crow's query -> event model separates the *request* from the *response*. While
 this approach is a little more complex, it allows crow to do a great many *other*
 things while it waits for a response to it's request.
 
-First you use `ii.<module>.get( name, ... )`, which again can be copied directly
+First you use `II.<module>.get( name, ... )`, which again can be copied directly
 from the device's help() call. The `...` here refers to a variable list of arguments
 which might be none at all! eg:
-`ii.jf.get( 'run_mode' )`
+`II.jf.get( 'run_mode' )`
 
 Then you can declare an `event` action to handle the response from the device.
 Copy it from the help() printout! it should look something like:
 ```
-ii.jf.event( event, data )
+II.jf.event( event, data )
     if event == 'run_mode' then
         -- the state of 'run_mode' is in the 'data' variable!
     end

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ function init()
 end
 
 input[1].change = function(state)
-    ii.wslash.record(state)
+    II.wslash.record(state)
 end
 ```
 

--- a/lib/ii.c
+++ b/lib/ii.c
@@ -30,6 +30,12 @@ const char* II_list_modules( void )
 {
     return ii_module_list;
 }
+
+const char* II_list_cmds( uint8_t address )
+{
+    return ii_list_commands(address);
+}
+
 void II_set_pullups( uint8_t state )
 {
     I2C_SetPullups(state);

--- a/lib/ii.c
+++ b/lib/ii.c
@@ -30,6 +30,10 @@ const char* II_list_modules( void )
 {
     return ii_module_list;
 }
+void II_set_pullups( uint8_t state )
+{
+    I2C_SetPullups(state);
+}
 
 uint8_t II_get_address( void )
 {

--- a/lib/ii.h
+++ b/lib/ii.h
@@ -24,6 +24,8 @@ void II_deinit( void );
 
 const char* II_list_modules( void );
 
+void II_set_pullups( uint8_t state );
+
 uint8_t II_get_address( void );
 void II_set_address( uint8_t address );
 

--- a/lib/ii.h
+++ b/lib/ii.h
@@ -23,6 +23,7 @@ uint8_t II_init( uint8_t address );
 void II_deinit( void );
 
 const char* II_list_modules( void );
+const char* II_list_cmds( uint8_t address );
 
 void II_set_pullups( uint8_t state );
 

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -235,7 +235,7 @@ static int _send_usb( lua_State *L )
 static int _ii_list_modules( lua_State *L )
 {
     Caw_send_luachunk( (char*)II_list_modules() );
-    printf( "%s\n",(char*)II_list_modules() );
+    printf( "printing ii help\n" );
     return 0;
 }
 
@@ -243,7 +243,7 @@ static int _ii_list_commands( lua_State *L )
 {
     uint8_t address = luaL_checkinteger(L, 1);
     printf("i2c help %i\n", address);
-    //Caw_send_luachunk( (char*)II_list_modules() );
+    Caw_send_luachunk( (char*)II_list_cmds(address) );
     return 0;
 }
 

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -242,6 +242,13 @@ static int _ii_list_commands( lua_State *L )
     //Caw_send_luachunk( (char*)II_list_modules() );
     return 0;
 }
+
+static int _ii_pullup( lua_State *L )
+{
+    II_set_pullups( luaL_checkinteger(L, 1) );
+    return 0;
+}
+
 static int _ii_set( lua_State *L )
 {
     printf("lua ii broadcast\n");
@@ -348,6 +355,7 @@ static const struct luaL_Reg libCrow[]=
         // i2c
     , { "ii_list_modules"  , _ii_list_modules  }
     , { "ii_list_commands" , _ii_list_commands }
+    , { "ii_pullup"        , _ii_pullup        }
     , { "ii_set"           , _ii_set           }
     , { "ii_get"           , _ii_get           }
     , { "ii_address"       , _ii_address       }

--- a/ll/i2c.c
+++ b/ll/i2c.c
@@ -88,6 +88,7 @@ uint8_t I2C_is_boot( void )
     // set to OD to ensure no damage by i2c line
     // FIXME is this necessary, or does DeInit set the pin to tristate?
 	gpio.Mode      = GPIO_MODE_AF_OD;
+	gpio.Pull      = GPIO_NOPULL;
 	HAL_GPIO_Init( I2Cx_SCL_GPIO_PORT, &gpio );
 
 	HAL_GPIO_DeInit( I2Cx_SCL_GPIO_PORT, I2Cx_SCL_PIN );
@@ -169,7 +170,10 @@ PE=0 - Write PE=1.
 	    I2C_DeInit();
         I2C_Init( temp_addr );
     } else {
-	    printf("I2C_ERROR %i\n", (int)h->ErrorCode);
+        if( h->ErrorCode == 2 ){ printf("!I2C: lines are low. try II.pullup(1)\n"); }
+        else{
+	        printf("I2C_ERROR %i\n", (int)h->ErrorCode);
+        }
     }
 uint32_t old_primask = __get_PRIMASK();
 __disable_irq();
@@ -337,6 +341,9 @@ void I2C_SetPullups( uint8_t state )
 	gpio.Pull      = (state) ? GPIO_PULLUP : GPIO_NOPULL;
 	gpio.Speed     = GPIO_SPEED_FREQ_HIGH;
 	gpio.Alternate = I2Cx_SCL_SDA_AF;
+
+	HAL_GPIO_DeInit( I2Cx_SCL_GPIO_PORT, I2Cx_SCL_PIN );
+	HAL_GPIO_DeInit( I2Cx_SDA_GPIO_PORT, I2Cx_SDA_PIN );
 	HAL_GPIO_Init( I2Cx_SCL_GPIO_PORT, &gpio );
 }
 

--- a/ll/i2c.c
+++ b/ll/i2c.c
@@ -327,6 +327,19 @@ void I2C_BufferRx( uint8_t* data )
     i2c_state.b_count++;
 }
 
+void I2C_SetPullups( uint8_t state )
+{
+    // FIXME is this possible? do we need to deinit first?
+	GPIO_InitTypeDef gpio;
+	gpio.Pin       = I2Cx_SCL_PIN
+	               | I2Cx_SDA_PIN;
+	gpio.Mode      = GPIO_MODE_AF_OD;
+	gpio.Pull      = (state) ? GPIO_PULLUP : GPIO_NOPULL;
+	gpio.Speed     = GPIO_SPEED_FREQ_HIGH;
+	gpio.Alternate = I2Cx_SCL_SDA_AF;
+	HAL_GPIO_Init( I2Cx_SCL_GPIO_PORT, &gpio );
+}
+
 uint8_t I2C_GetAddress( void )
 {
     return i2c_handle.Init.OwnAddress1;

--- a/ll/i2c.h
+++ b/ll/i2c.h
@@ -62,6 +62,9 @@ void HAL_I2C_AddrCallback( I2C_HandleTypeDef* h
 	                     , uint16_t           AddrMatchCode
 	                     );
 void I2C_BufferRx( uint8_t* data );
+
+void I2C_SetPullups( uint8_t state );
+
 uint8_t I2C_GetAddress( void );
 void I2C_SetAddress( uint8_t address );
 uint8_t* I2C_PopFollowBuffer( void );

--- a/lua/ii.lua
+++ b/lua/ii.lua
@@ -39,6 +39,8 @@ function ii_handler( addr, cmd, data )
     ii[name].event(ii[name].e[cmd], data)
 end
 
+function ii.e( name, event, data ) _c.tell('II.'..name,event,data) end
+
 ii._c =
     { cmds = { [1]='out'
              , [2]='slew'

--- a/lua/ii.lua
+++ b/lua/ii.lua
@@ -21,6 +21,10 @@ function ii.m_help( address )
     ii_list_commands( address )
 end
 
+function ii.pullup( state )
+    ii_pullup(state)
+end
+
 -- TODO is it possible to just define ii.set from c directly?
 function ii.set( address, cmd, ... )
     ii_set( address, cmd, ... )

--- a/util/ii_gen.lua
+++ b/util/ii_gen.lua
@@ -185,7 +185,7 @@ function make_iihelp(files)
 .. '    rawset(II,n,dofile(string.format(\'build/ii_%s.lua\',n)))\n'
 .. '    new = rawget(II,n)\n'
 .. '    --rawset(new,name,n)\n'
-.. '    --rawset(new,help,self.help)\n'
+.. '    rawset(rawget(II,n),\'help\',self.help)\n'
 .. '    return rawget(new, ix)\n'
 .. 'end\n'
 .. 'setmetatable(is, is)\n\n'

--- a/util/ii_gen.lua
+++ b/util/ii_gen.lua
@@ -202,7 +202,8 @@ function make_lua(f)
             .. lua_cmds(f)
             .. lua_getters(f)
             .. lua_events(f)
-            .. 'function ' .. f.lua_name .. '.event(e,data)end\n'
+            .. 'function ' .. f.lua_name
+                .. '.event(e,data)II.e(\'' .. f.lua_name .. '\',e,data)end\n'
             .. 'print\'' .. f.lua_name .. ' loaded\'\n'
             .. 'return ' .. f.lua_name .. '\n'
     return l

--- a/util/ii_gen.lua
+++ b/util/ii_gen.lua
@@ -3,7 +3,7 @@ get_offset = 0x80
 -- generate a printable c-string describing the module's commands
 function generate_prototypes( d )
     local prototypes = ''
-    local proto_prefix = 'ii.' .. d.lua_name .. '.'
+    local proto_prefix = 'II.' .. d.lua_name .. '.'
     for _,v in ipairs( d.commands ) do
         local s = '"' .. proto_prefix .. v.name .. '( '
         if type(v.args[1]) == 'table' then -- more than 1 arg
@@ -33,7 +33,7 @@ end
 
 function generate_getters( d )
     local getters = ''
-    local get_prefix = '"ii.' .. d.lua_name .. '.get( \''
+    local get_prefix = '"II.' .. d.lua_name .. '.get( \''
 
     -- commands that have standard getters
     for _,v in ipairs( d.commands ) do
@@ -77,7 +77,7 @@ function generate_events( d )
         return false
     end
 
-    local events = '"ii.' .. d.lua_name .. '.event = function( e, data )\\n\\r"\n'
+    local events = '"II.' .. d.lua_name .. '.event = function( e, data )\\n\\r"\n'
 
     local overloaded = has_get_cmd(d)
     if overloaded then
@@ -123,7 +123,7 @@ end
 function lua_cmds(f)
     local c = ''
     for _,v in ipairs( f.commands ) do
-        c = c .. 'function ' .. f.lua_name .. '.' .. v.name .. '(...)ii.set('
+        c = c .. 'function ' .. f.lua_name .. '.' .. v.name .. '(...)II.set('
           .. f.i2c_address .. ',' .. v.cmd .. ',...)end\n'
     end
     return c
@@ -143,7 +143,7 @@ function lua_getters(f)
     end
     g = g .. '}\n'
 
-    g = g .. 'function ' .. f.lua_name .. '.get(name,...)ii.get('
+    g = g .. 'function ' .. f.lua_name .. '.get(name,...)II.get('
       .. f.i2c_address .. ',' .. f.lua_name .. '.g[name],...)end\n'
     return g
 end
@@ -173,7 +173,7 @@ function make_iihelp(files)
 .. 'function is.new( name, address )\n'
 .. '    local self = {}\n'
 .. '    self.name = name\n'
-.. '    self.help = function() ii.m_help(address) end\n'
+.. '    self.help = function() II.m_help(address) end\n'
 .. '    setmetatable( self, is )\n'
 .. '    is.lu[address] = name\n'
 .. '    return self\n'
@@ -182,8 +182,8 @@ function make_iihelp(files)
 .. 'is.__index = function( self, ix )\n'
 .. '    local n = self.name\n'
 .. '    local h = self.help\n'
-.. '    rawset(ii,n,dofile(string.format(\'build/ii_%s.lua\',n)))\n'
-.. '    new = rawget(ii,n)\n'
+.. '    rawset(II,n,dofile(string.format(\'build/ii_%s.lua\',n)))\n'
+.. '    new = rawget(II,n)\n'
 .. '    --rawset(new,name,n)\n'
 .. '    --rawset(new,help,self.help)\n'
 .. '    return rawget(new, ix)\n'
@@ -369,8 +369,8 @@ function make_c(f)
         c = c .. '"' .. f.lua_name .. '\\t-- ' .. f.module_name .. '\\n\\r"\n'
     end
     c = c .. '"\\n\\r"\n'
-          .. '"--- See a module\'s commands with \'ii.<module>.help()\'\\n\\r"\n'
-          .. '"ii.jf.help()\\n\\r"\n'
+          .. '"--- See a module\'s commands with \'II.<module>.help()\'\\n\\r"\n'
+          .. '"II.jf.help()\\n\\r"\n'
           .. ';\n'
     for _,f in ipairs(files) do
         c = c .. c_cmds(f)


### PR DESCRIPTION
`II.pullup(state)`
Turns on STM32 i2c pullups. These resistors are 40k each so somewhat out of spec [2k2, 10k], but thankfully on the too-weak side. In practice turning them on made communication with TXi & W/ work though was not stress tested. This capability could be activated on W/ as well.
Solves #41.

`II.<module>.help()`
Prints a list of the devices supported functions (as far as crow is aware). This help list is autogenerated from the i2c descriptor file (in lua/ii/*.lua), and is directly copy&paste-able prototypes.

`II.<module>.event()`
The event handler sends a `^^` message to the remote-host. Thus norns or another host should match on:
`II.<module>(event,value)`
Note the allcaps `II`. It's unclear to me if the dot-notation is the right way to do namespacing in the remote context.

**Autoload II submodules as needed**
When a module is first used, but not currently in RAM, it will `dofile()` the library & save to the `II` table. This means the user can interact as if all module's II tables are loaded, but we only suffer the RAM hit when the module is actually invoked. The modules are stored in Flash as C-strings like everything else.
Solves #29.

**README**
Updated to reflect that all calls to `II` must be capitalized. This could be changed in future, but for now it works so I'm just making it all consistent.