### PR TITLE
print now automatically attempt to stringify non-string types

### DIFF
--- a/lua/bootstrap.lua
+++ b/lua/bootstrap.lua
@@ -20,7 +20,7 @@ print = function(...)
             printResult = printResult .. '\t' .. args[i]
         end
     end
-    print_serial(printResult)
+    print_serial(tostring(printResult))
 end
 
 -- nb: this is basically the inverse of l2h.lua (but we don't want that at RT)


### PR DESCRIPTION
like normal lua `print`.
allows tables to be printed which will just show their memory address.