### PR TITLE
Input module bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For a developer focused intro, see [readme-development.md](readme-development.md
 
 crow is many things, but here's some starters:
 - Eurorack module. 2hp. +60mA, -15mA (TODO confirm).
-- Hardware i/o: 2inputs, 2outputs, 16bit, [-5v,+10v] range
+- Hardware i/o: 2inputs, 4outputs, 16bit, [-5v,+10v] range
 - Full lua environment, 64kB of local script storage
 - USB device, for communicating text(!)
 - i2c leader & follower, multiple crows can share responsibilities
@@ -192,12 +192,12 @@ you used will be applied, falling back to the default if it's your first time.
 Remembering the number and order of these arguments can be a pain, so you can also
 setup the mode in a different manner, explicitly naming your parameters:
 ```
-input[2]{ mode    = 'stream'
-        , time    = 0.1
+input[2]{ mode = 'stream'
+        , time = 0.1
         }
 ```
 The above code will act identically to our above `mode` function call, but now it's
-clear to us (and *future* us) what the `0.1` refers to, time!
+clear to us (and *future* us) what the `0.1` refers to- *time*!
 
 This style is more useful for 'change' mode as there are more arguments:
 ```
@@ -209,7 +209,7 @@ input[1]{ mode       = 'change'
 ```
 `input[1]` chooses the first channel (upper most jack on crow).
 `mode = 'change'` means we'll receive events when the threshold is crossed.
-`threshold = 1.0` sets the detection level to 1 volt. above this is 'high', and below is 'low'
+`threshold = 1.0` sets the detection level to +1 volt. above this is 'high', and below is 'low'
 `hysteresis = 0.2` modifies the 'threshold' value depending on which direction the
 signal is moving. If the signal is low, output won't switch high until reaching 1.1V,
 but once the signal has gone high it won't switch low until passing beneath 0.9V.
@@ -217,7 +217,7 @@ The difference here is 0.2V and is known as hysteresis. Hysteresis is useful to 
 'bouncy' switching when the input signal is near the threshold point.
 `direction = 'rising'` means the event will *only* happen when the threshold goes
 from low to high. When the signal returns to the low state, no event is created.
-Other options are 'falling' for only at the *end* or a gate, or 'both' which creates
+Other options are 'falling' for only at the *end* of a gate, or 'both' which creates
 events on both the high and low going transitions.
 
 Additional modes are forthcoming in future updates for more sophisticated event
@@ -270,7 +270,7 @@ To do the same from Max, you can send the (get_cv x) message to the left input.
 
 There is also a standard function call to setup these functions which is more terse:
 ```
-input[1].mode( 'none' ) -- deactivated, but can still be queried
+input[1].mode( 'none' ) -- deactivated, but can still be queried with `.query()`
 input[2].mode( 'stream', 0.05 ) -- sends 20 values per second
 input[1].mode( 'change' ) -- default gate detector
 ```

--- a/lib/detect.c
+++ b/lib/detect.c
@@ -59,15 +59,19 @@ void Detect( Detect_t* self, float level )
             break;
 
         case Detect_CHANGE:
-            if( self->state ){
+            if( self->state ){ // high to low
                 if( level < (self->change.threshold - self->change.hysteresis) ){
                     self->state = 0;
-                    (*self->action)( self->channel, (float)self->state );
+                    if( self->direction != 1 ){ // not 'rising' only
+                        (*self->action)( self->channel, (float)self->state );
+                    }
                 }
-            } else {
+            } else { // low to high
                 if( level > (self->change.threshold + self->change.hysteresis) ){
                     self->state = 1;
-                    (*self->action)( self->channel, (float)self->state );
+                    if( self->direction != -1 ){ // not 'falling' only
+                        (*self->action)( self->channel, (float)self->state );
+                    }
                 }
             }
             break;

--- a/lib/detect.c
+++ b/lib/detect.c
@@ -62,14 +62,14 @@ void Detect( Detect_t* self, float level )
             if( self->state ){ // high to low
                 if( level < (self->change.threshold - self->change.hysteresis) ){
                     self->state = 0;
-                    if( self->direction != 1 ){ // not 'rising' only
+                    if( self->change.direction != 1 ){ // not 'rising' only
                         (*self->action)( self->channel, (float)self->state );
                     }
                 }
             } else { // low to high
                 if( level > (self->change.threshold + self->change.hysteresis) ){
                     self->state = 1;
-                    if( self->direction != -1 ){ // not 'falling' only
+                    if( self->change.direction != -1 ){ // not 'falling' only
                         (*self->action)( self->channel, (float)self->state );
                     }
                 }

--- a/ll/ads131.c
+++ b/ll/ads131.c
@@ -186,16 +186,16 @@ void ADC_UnpickleBlock( float*   unpickled
 {
     float* unpick = unpickled;
     // Return current buf
-    for( uint8_t j=1; j<=adc_count; j++ ){
+    for( uint8_t j=0; j<adc_count; j++ ){
         // cast to signed -> cast to float -> scale -> shift
-        float once = ((float)((int16_t*)aRxBuffer)[j])
+        float once = ((float)((int16_t*)aRxBuffer)[j+1]) // +1 past status byte
                         * adc_calibrated_scalar[j]
                         + adc_calibrated_shift[j];
         float c    = 1.0 / bsize;
         for( uint16_t i=0; i<bsize; i++ ){
-            *unpick++ = last[j-1] + (c * (i+1))*(once - last[j-1]);
+            *unpick++ = last[j] + (c * (i+1))*(once - last[j]);
         }
-        last[j-1] = once;
+        last[j] = once;
     }
 
 

--- a/lua/input.lua
+++ b/lua/input.lua
@@ -92,10 +92,13 @@ Input.__call = function(self, ...)
     if #args == 0 then
         return Input.get_value(self)
     else -- table call
+        local m = 0
+        --if #args[1] == 0 then _ end -- implies empty table call
         for k,v in pairs( args[1] ) do
-            --if k == nil then _ end -- implies empty table call
+            if k == 'mode' then m = v end -- defer mode change after setting params
             self[k] = v
         end
+        if m ~= 0 then self.mode = m end -- apply mode change
     end
 end
 

--- a/lua/input.lua
+++ b/lua/input.lua
@@ -89,9 +89,9 @@ end
 
 Input.__call = function(self, ...)
     local args = {...}
-    if args == nil then
+    if #args == 0 then
         return Input.get_value(self)
-    else -- assume table
+    else -- table call
         for k,v in pairs( args ) do
             self.k = v
         end

--- a/lua/input.lua
+++ b/lua/input.lua
@@ -79,9 +79,9 @@ end
 
 Input.__index = function(self, ix)
     if     ix == 'value' then
-      return Input.get_value(self)
+        return Input.get_value(self)
     elseif ix == 'query' then
-      _c.tell('query',self.channel,Input.get_value(self))
+        return function() _c.tell('ret_cv',self.channel,Input.get_value(self)) end
     elseif ix == 'mode'  then
         return function(...) Input.set_mode( self, ...) end
     end

--- a/lua/input.lua
+++ b/lua/input.lua
@@ -92,8 +92,9 @@ Input.__call = function(self, ...)
     if #args == 0 then
         return Input.get_value(self)
     else -- table call
-        for k,v in pairs( args ) do
-            self.k = v
+        for k,v in pairs( args[1] ) do
+            --if k == nil then _ end -- implies empty table call
+            self[k] = v
         end
     end
 end

--- a/lua/input.lua
+++ b/lua/input.lua
@@ -81,7 +81,7 @@ Input.__index = function(self, ix)
     if     ix == 'value' then
       return Input.get_value(self)
     elseif ix == 'query' then
-      _c.tell('query',Input.channel,Input.get_value(self))
+      _c.tell('query',self.channel,Input.get_value(self))
     elseif ix == 'mode'  then
         return function(...) Input.set_mode( self, ...) end
     end


### PR DESCRIPTION
- Fix bug where input[2] would always return junk. input[1] was incorrectly using input[2]'s calibration data (even though they were identical).

- Fix bug where `input[n]()` (ie __call metamethod) wouldn't return the input value (did nothing).

- Fix bug where `input[n]{...}` (ie __call metamethod) would fail to apply changes to the input library. fixes #73 

- fixes #75 though might just be proving there was no problem.

- The 'direction' parameter is no longer ignored (was previously always 'both') and correctly sends interrupts on the appropriate edges.

- `input[n].query()` now grabs the input's value, wraps it, and sends to remote host.

- Fix issue where `input[n]{...}` calls which included setting 'mode' might not apply parameters until 2nd call. The `mode` call (which triggers C library fn) is now deferred to the end of the table call.

- Updated README with small clarifications & pointers