### PR TITLE
Userscript save/load to flash & print-to-usb reliability

### DIFF
--- a/lib/caw.c
+++ b/lib/caw.c
@@ -106,7 +106,7 @@ C_cmd_t Caw_try_receive( void )
         }
         if( _is_multiline( (char*)buf ) ){
             multiline ^= 1;
-            if(!multiline){ printf("%s\n",reader); }
+            //if(!multiline){ printf("%s\n",reader); } // prints complete multiline
             return (multiline) ? C_none : C_repl;
         }
     // receive code for repl/flash

--- a/lib/flash.h
+++ b/lib/flash.h
@@ -26,7 +26,8 @@ typedef struct FLASH_Store {
 uint8_t Flash_is_user_script( void );
 void Flash_clear_user_script( void );
 uint8_t Flash_write_user_script( char* script, uint32_t length );
-uint8_t Flash_read_user_script( char* buffer, uint16_t* len );
+uint16_t Flash_read_user_scriptlen( void );
+uint8_t Flash_read_user_script( char* buffer );
 
 uint8_t Flash_is_calibrated( void );
 void Flash_clear_calibration( void );

--- a/lib/flash.h
+++ b/lib/flash.h
@@ -10,7 +10,8 @@
 // 64kB user script
 #define USER_SCRIPT_LOCATION 0x08010000
 #define USER_SCRIPT_SECTOR   FLASH_SECTOR_4
-#define USER_SCRIPT_SIZE     (0x10000 - 4)
+//#define USER_SCRIPT_SIZE     (0x10000 - 4)
+#define USER_SCRIPT_SIZE     (0x1000 - 4)
 
 typedef enum { FLASH_Status_Init  = 0
              , FLASH_Status_Saved = 1

--- a/lib/repl.c
+++ b/lib/repl.c
@@ -13,7 +13,7 @@ char*       new_script;
 uint16_t    new_script_len;
 
 // prototypes
-static void REPL_new_script_buffer( void );
+static void REPL_new_script_buffer( uint32_t len );
 static void REPL_receive_script( char* buf, uint32_t len, ErrorHandler_t errfn );
 
 // public interface
@@ -22,8 +22,9 @@ void REPL_init( lua_State* lua )
     Lua = lua;
 
     if( Flash_is_user_script() ){
-        REPL_new_script_buffer();
-        if( Flash_read_user_script( new_script, &new_script_len )
+        new_script_len = Flash_read_user_scriptlen();
+        REPL_new_script_buffer( new_script_len );
+        if( Flash_read_user_script( new_script )
          || Lua_eval( Lua, new_script
                          , new_script_len
                          , Caw_send_luaerror
@@ -39,7 +40,7 @@ void REPL_mode( L_repl_mode mode )
 {
     repl_mode = mode;
     if( repl_mode == REPL_reception ){ // begin a new transmission
-        REPL_new_script_buffer();
+        REPL_new_script_buffer( USER_SCRIPT_SIZE );
     } else { // end of a transmission
         if( !Lua_eval( Lua, new_script
                           , new_script_len
@@ -74,9 +75,9 @@ void REPL_eval( char* buf, uint32_t len, ErrorHandler_t errfn )
 void REPL_print_script( void )
 {
     if( Flash_is_user_script() ){
-        REPL_new_script_buffer();
-        Flash_read_user_script( new_script, &new_script_len );
-        uint16_t send_len = new_script_len;
+        REPL_new_script_buffer( Flash_read_user_scriptlen() );
+        Flash_read_user_script( new_script );
+        uint16_t send_len = Flash_read_user_scriptlen();
         uint8_t page_count = 0;
         while( send_len > 0x200 ){
             Caw_send_raw( (uint8_t*)&new_script[(page_count++)*0x200], 0x200 );
@@ -96,10 +97,10 @@ static void REPL_receive_script( char* buf, uint32_t len, ErrorHandler_t errfn )
     new_script_len += len;
 }
 
-static void REPL_new_script_buffer( void )
+static void REPL_new_script_buffer( uint32_t len )
 {
     // TODO call to Lua to free resources from current script
-    new_script = malloc(USER_SCRIPT_SIZE);
+    new_script = malloc(len);
     if(new_script == NULL){
         Caw_send_luachunk("!script: out of memory");
         //(*errfn)("!script: out of memory");

--- a/lib/repl.c
+++ b/lib/repl.c
@@ -50,6 +50,7 @@ void REPL_mode( L_repl_mode mode )
             if( Flash_write_user_script( new_script
                                        , new_script_len
                                        ) ){
+                printf("flash write failed\n");
                 Caw_send_luachunk("flash write failed");
             }
             printf("script saved\n");
@@ -102,6 +103,7 @@ static void REPL_new_script_buffer( uint32_t len )
     // TODO call to Lua to free resources from current script
     new_script = malloc(len);
     if(new_script == NULL){
+        printf("out of mem\n");
         Caw_send_luachunk("!script: out of memory");
         //(*errfn)("!script: out of memory");
         return; // how to deal with this situation?


### PR DESCRIPTION
- Detection mechanism  for whether a userscript is saved in flash improved from a single bit to a 4bit magic number (was responding incorrectly)

- `^^s` and `^^e` pairs could fail due to out-of-memory issues. script buffer has been (temporarily) reduced to 4kB to avoid hitting this limit.
fixes #78 

- RAM footprint of flash access has been reduced when loading or printing the existing userscript (would previously, temporarily allocate the full 64kB buffer).

- debugging info has been cleaned up to alert failure cases (though a failing malloc seems to freeze the whole system).