### PR TITLE
TTY reliability update & Max object fixes

### DIFF
--- a/lib/caw.c
+++ b/lib/caw.c
@@ -25,18 +25,24 @@ void Caw_send_raw( uint8_t* buf, uint32_t len )
 // luachunk expects a \0 terminated string
 void Caw_send_luachunk( char* text )
 {
+    const uint8_t newline[] = "\n\r";
+uint32_t old_primask = __get_PRIMASK();
+__disable_irq();
     USB_tx_enqueue( (uint8_t*)text, strlen(text) );
-    uint8_t newline[] = "\n\r";
-    USB_tx_enqueue( newline, 2 );
+    USB_tx_enqueue( (uint8_t*)newline, 2 );
+__set_PRIMASK( old_primask );
 }
 
 void Caw_send_luaerror( char* error_msg )
 {
-    uint8_t leader[] = "\\";
-    USB_tx_enqueue( leader, 1 );
+    const uint8_t leader[] = "\\";
+    const uint8_t newline[] = "\n\r";
+uint32_t old_primask = __get_PRIMASK();
+__disable_irq();
+    USB_tx_enqueue( (uint8_t*)leader, 1 );
     USB_tx_enqueue( (uint8_t*)error_msg, strlen(error_msg) );
-    uint8_t newline[] = "\n\r";
-    USB_tx_enqueue( newline, 2 );
+    USB_tx_enqueue( (uint8_t*)newline, 2 );
+__set_PRIMASK( old_primask );
 }
 
 void Caw_send_value( uint8_t type, float value )

--- a/max/crow-max-testharness.maxpat
+++ b/max/crow-max-testharness.maxpat
@@ -38,14 +38,42 @@
 		"subpatcher_template" : "",
 		"boxes" : [ 			{
 				"box" : 				{
+					"id" : "obj-17",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 199.5, 249.666687, 135.0, 22.0 ],
+					"presentation_rect" : [ 183.999985, 246.666687, 0.0, 0.0 ],
+					"style" : "",
+					"text" : "input[1].mode('change')"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-4",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 231.999985, 312.666687, 122.0, 22.0 ],
+					"presentation_rect" : [ 231.999985, 312.666687, 0.0, 0.0 ],
+					"style" : "",
+					"text" : "input[1].mode('none')"
+				}
+
+			}
+, 			{
+				"box" : 				{
 					"id" : "obj-31",
 					"maxclass" : "message",
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 213.999985, 280.666687, 164.0, 22.0 ],
+					"patching_rect" : [ 213.999985, 280.666687, 171.0, 22.0 ],
 					"style" : "",
-					"text" : "\"input[1].mode('stream', 0.1)\""
+					"text" : "\"input[1].mode('stream', 0.01)\""
 				}
 
 			}
@@ -520,9 +548,9 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 237.333313, 417.0, 162.166687, 35.0 ],
+					"patching_rect" : [ 237.333313, 417.0, 20.166687, 35.0 ],
 					"style" : "",
-					"text" : "15\t\n\r"
+					"text" : "15"
 				}
 
 			}
@@ -717,6 +745,15 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-13", 0 ],
+					"disabled" : 0,
+					"hidden" : 0,
+					"source" : [ "obj-17", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-15", 0 ],
 					"disabled" : 0,
 					"hidden" : 0,
@@ -802,6 +839,15 @@
 					"disabled" : 0,
 					"hidden" : 0,
 					"source" : [ "obj-31", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-13", 0 ],
+					"disabled" : 0,
+					"hidden" : 0,
+					"source" : [ "obj-4", 0 ]
 				}
 
 			}

--- a/max/crow.maxpat
+++ b/max/crow.maxpat
@@ -9,7 +9,7 @@
 			"modernui" : 1
 		}
 ,
-		"rect" : [ 781.0, 696.0, 570.0, 347.0 ],
+		"rect" : [ 230.0, 640.0, 570.0, 347.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
@@ -78,7 +78,7 @@
 , 			{
 				"box" : 				{
 					"id" : "obj-2",
-					"items" : [ "Bluetooth-Modem", ",", "Bluetooth-Incoming-Port", ",", "BoseColorIISoundLink-SP", ",", "BoseColorIISoundLink-SP-1", ",", "usbmodem1411" ],
+					"items" : [ "Bluetooth-Modem", ",", "Bluetooth-Incoming-Port", ",", "BoseColorIISoundLink-SP", ",", "BoseColorIISoundLink-SP-1", ",", "usbmodem1431" ],
 					"maxclass" : "umenu",
 					"numinlets" : 1,
 					"numoutlets" : 3,
@@ -182,7 +182,7 @@
 							"modernui" : 1
 						}
 ,
-						"rect" : [ 1310.0, 138.0, 902.0, 411.0 ],
+						"rect" : [ 217.0, 173.0, 902.0, 411.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -210,6 +210,47 @@
 						"style" : "",
 						"subpatcher_template" : "",
 						"boxes" : [ 							{
+								"box" : 								{
+									"id" : "obj-19",
+									"maxclass" : "message",
+									"numinlets" : 2,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 11.0, 146.0, 137.0, 22.0 ],
+									"presentation_rect" : [ 11.0, 146.0, 0.0, 0.0 ],
+									"style" : "",
+									"text" : "symbol usbmodem1411"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-10",
+									"maxclass" : "message",
+									"numinlets" : 2,
+									"numoutlets" : 1,
+									"outlettype" : [ "" ],
+									"patching_rect" : [ 21.0, 185.0, 138.0, 22.0 ],
+									"presentation_rect" : [ 21.0, 183.0, 0.0, 0.0 ],
+									"style" : "",
+									"text" : "symbol usbmodem1421"
+								}
+
+							}
+, 							{
+								"box" : 								{
+									"id" : "obj-53",
+									"maxclass" : "newobj",
+									"numinlets" : 3,
+									"numoutlets" : 3,
+									"outlettype" : [ "bang", "bang", "" ],
+									"patching_rect" : [ 389.0, 264.0, 50.0, 22.0 ],
+									"style" : "",
+									"text" : "sel 0 -1"
+								}
+
+							}
+, 							{
 								"box" : 								{
 									"id" : "obj-7",
 									"maxclass" : "newobj",
@@ -280,7 +321,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 389.0, 266.0, 121.0, 22.0 ],
+									"patching_rect" : [ 389.0, 306.0, 121.0, 22.0 ],
 									"style" : "",
 									"text" : "prepend from_length"
 								}
@@ -293,9 +334,9 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 32.0, 221.0, 137.0, 22.0 ],
+									"patching_rect" : [ 32.0, 221.0, 138.0, 22.0 ],
 									"style" : "",
-									"text" : "symbol usbmodem1411"
+									"text" : "symbol usbmodem1431"
 								}
 
 							}
@@ -575,9 +616,9 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"patching_rect" : [ 431.0, 101.0, 58.0, 22.0 ],
+									"patching_rect" : [ 431.0, 101.0, 51.0, 22.0 ],
 									"style" : "",
-									"text" : "metro 30"
+									"text" : "metro 5"
 								}
 
 							}
@@ -588,9 +629,9 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "int", "" ],
-									"patching_rect" : [ 364.0, 156.0, 92.0, 22.0 ],
+									"patching_rect" : [ 364.0, 156.0, 93.0, 22.0 ],
 									"style" : "",
-									"text" : "serial a 115200"
+									"text" : "serial a 460800"
 								}
 
 							}
@@ -614,7 +655,7 @@
 									"maxclass" : "outlet",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 364.0, 319.0, 30.0, 30.0 ],
+									"patching_rect" : [ 364.0, 359.0, 30.0, 30.0 ],
 									"style" : ""
 								}
 
@@ -642,6 +683,15 @@
 									"disabled" : 0,
 									"hidden" : 0,
 									"source" : [ "obj-1", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-35", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
+									"source" : [ "obj-10", 0 ]
 								}
 
 							}
@@ -728,6 +778,15 @@
 							}
 , 							{
 								"patchline" : 								{
+									"destination" : [ "obj-35", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
+									"source" : [ "obj-19", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
 									"destination" : [ "obj-8", 0 ],
 									"disabled" : 0,
 									"hidden" : 0,
@@ -764,10 +823,28 @@
 							}
 , 							{
 								"patchline" : 								{
-									"destination" : [ "obj-57", 0 ],
+									"destination" : [ "obj-53", 0 ],
 									"disabled" : 0,
 									"hidden" : 0,
 									"source" : [ "obj-28", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-10", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
+									"source" : [ "obj-29", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-19", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
+									"source" : [ "obj-29", 0 ]
 								}
 
 							}
@@ -854,6 +931,15 @@
 							}
 , 							{
 								"patchline" : 								{
+									"destination" : [ "obj-57", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
+									"source" : [ "obj-53", 2 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
 									"destination" : [ "obj-8", 0 ],
 									"disabled" : 0,
 									"hidden" : 0,
@@ -899,10 +985,28 @@
 							}
 , 							{
 								"patchline" : 								{
+									"destination" : [ "obj-10", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
+									"source" : [ "obj-7", 0 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
 									"destination" : [ "obj-11", 0 ],
 									"disabled" : 0,
 									"hidden" : 0,
 									"source" : [ "obj-7", 1 ]
+								}
+
+							}
+, 							{
+								"patchline" : 								{
+									"destination" : [ "obj-19", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
+									"source" : [ "obj-7", 0 ]
 								}
 
 							}

--- a/max/crow.maxpat
+++ b/max/crow.maxpat
@@ -217,7 +217,6 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 11.0, 146.0, 137.0, 22.0 ],
-									"presentation_rect" : [ 11.0, 146.0, 0.0, 0.0 ],
 									"style" : "",
 									"text" : "symbol usbmodem1411"
 								}
@@ -231,7 +230,6 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 21.0, 185.0, 138.0, 22.0 ],
-									"presentation_rect" : [ 21.0, 183.0, 0.0, 0.0 ],
 									"style" : "",
 									"text" : "symbol usbmodem1421"
 								}
@@ -629,9 +627,9 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "int", "" ],
-									"patching_rect" : [ 364.0, 156.0, 93.0, 22.0 ],
+									"patching_rect" : [ 364.0, 156.0, 99.0, 22.0 ],
 									"style" : "",
-									"text" : "serial a 460800"
+									"text" : "serial a 1000000"
 								}
 
 							}

--- a/max/crowmax.lua
+++ b/max/crowmax.lua
@@ -10,6 +10,7 @@ local cmd_rxd    = 0
 function from( byte )
 	table.insert( cmd_bytes, byte )
 	cmd_rxd = cmd_rxd + 1
+	--TODO split on '\n\r' pair not just end-of-packet
 	if cmd_rxd == cmd_length then
     	eval( bytes_to_string( cmd_bytes))
 		cmd_bytes  = {}
@@ -27,13 +28,15 @@ end
 function eval( str )
 	if #str == 0 then return end
 	local split = string.find( str, "\r" )
-	local now = str:sub( 1, split)	
+	local now = str:sub( 1, split)
 	if string.find( now, "^%^%^") then
 		pcall( loadstring( now:sub(3)))
     else
         to_max_print( now )
     end
-	eval( str:sub( split+1))
+	if split ~= nil then --in case of dropped \r
+		eval( str:sub( split+1))
+	end
 end
 
 --- Request/callback pairs

--- a/usbd/usbd_cdc_interface.c
+++ b/usbd/usbd_cdc_interface.c
@@ -55,10 +55,10 @@
 #define APP_TX_DATA_SIZE  256
 
 // Private vars
-USBD_CDC_LineCodingTypeDef LineCoding = { 460800 // baud rate
-                                        , 0x00   // stop bits-1
-                                        , 0x00   // parity - none
-                                        , 0x08   // nb. of bits 8
+USBD_CDC_LineCodingTypeDef LineCoding = { 1000000 // baud rate
+                                        , 0x00    // stop bits-1
+                                        , 0x00    // parity - none
+                                        , 0x08    // nb. of bits 8
                                         };
 
 uint8_t UserRxBuffer[APP_RX_DATA_SIZE];

--- a/usbd/usbd_cdc_interface.c
+++ b/usbd/usbd_cdc_interface.c
@@ -55,7 +55,7 @@
 #define APP_TX_DATA_SIZE  256
 
 // Private vars
-USBD_CDC_LineCodingTypeDef LineCoding = { 115200 // baud rate
+USBD_CDC_LineCodingTypeDef LineCoding = { 460800 // baud rate
                                         , 0x00   // stop bits-1
                                         , 0x00   // parity - none
                                         , 0x08   // nb. of bits 8

--- a/usbd/usbd_cdc_interface.c
+++ b/usbd/usbd_cdc_interface.c
@@ -241,7 +241,7 @@ static void TIM_Config(void)
     //     + Counter direction = Up
     //
     USBTimHandle.Init.Period = (CDC_POLLING_INTERVAL*1000) - 1;
-    USBTimHandle.Init.Prescaler = 84-1;
+    USBTimHandle.Init.Prescaler = 108-1;//84-1;
     USBTimHandle.Init.ClockDivision = 0;
     USBTimHandle.Init.CounterMode = TIM_COUNTERMODE_UP;
     USBTimHandle.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;

--- a/usbd/usbd_cdc_interface.c
+++ b/usbd/usbd_cdc_interface.c
@@ -51,8 +51,8 @@
 #include "../ll/debug_usart.h" // debug printing
 
 // Private define
-#define APP_RX_DATA_SIZE  1024
-#define APP_TX_DATA_SIZE  1024
+#define APP_RX_DATA_SIZE  256
+#define APP_TX_DATA_SIZE  256
 
 // Private vars
 USBD_CDC_LineCodingTypeDef LineCoding = { 115200 // baud rate

--- a/usbd/usbd_cdc_interface.h
+++ b/usbd/usbd_cdc_interface.h
@@ -67,7 +67,7 @@
 
 /* Periodically, the state of the buffer "UserTxBuffer" is checked.
    The period depends on CDC_POLLING_INTERVAL */
-#define CDC_POLLING_INTERVAL             15 /* in ms. The max is 65 and the min is 1 */
+#define CDC_POLLING_INTERVAL             5 /* in ms. The max is 65 and the min is 1 */
 
 extern USBD_CDC_ItfTypeDef  USBD_CDC_fops;
 


### PR DESCRIPTION
**warning** serial port baudrate is changed to 460800 (115200 *4) for higher throughput. needs to be updated in `druid` etc.

LMK if changing the baudrate isn't possible in `druid` and I can roll back.

A bunch of changes / refinements to the TTY driver to help improve reliability. I'm now able to stream 2 channels of Input data every 5ms with no crashes to Max. Still seeing reliability issues on Windows though.
Improves #77 but leaving open as it doesn't seem finished.

- Increase USB baudrate for higher-throughput. Reliability seems stable.
- USB Transfer (crow->host) is now on 5ms period. Could likely still go faster
- Max [serial] object matches crow baudrate & faster polling (tried down to 2ms with no problem on OSX).
- Case where a `\r` character is lost no longer causes Lua to fail in Max
- USB driver no longer abandons data if the driver isn't yet ready when the interrupt occurs (waits til next period).
- Max object autoconnects to 3 different ports. Improvements requested in #20 
- Avoid automatic line-endings in caw.c being postponed to next USB interrupt