### PR TITLE
Calibrate lib cleanup

### DIFF
--- a/lib/flash.c
+++ b/lib/flash.c
@@ -90,7 +90,6 @@ uint8_t Flash_is_calibrated( void )
 
 void Flash_clear_calibration( void )
 {
-    printf("clear user script\n");
     clear_flash( CALIBRATION_SECTOR, CALIBRATION_LOCATION );
 }
 

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -27,6 +27,7 @@ local function closelibs()
     Asllib = nil
     Metro  = nil
     II     = nil
+    Cal    = nil
 end
 
 function _crow.libs( lib )
@@ -38,6 +39,7 @@ function _crow.libs( lib )
         Asllib = dofile('lua/asllib.lua')
         Metro  = dofile('lua/metro.lua')
         II     = dofile('lua/ii.lua')
+        Cal    = dofile('lua/calibrate.lua')
     elseif type(lib) == 'table' then
         -- load the list 
     else


### PR DESCRIPTION
`Cal` library is now included by `crowlib.lua` by default. I think this might have got lost in a revert ages ago. Users can call functions as outlined in the README, rather than calling the C-hooks directly.

Added (and fixed incorrect) messages to the user (and debug port) to make it clear when calibration is underway. Prettier-print for `Cal.print()` now, and if default calibration is active it doesn't print the (incorrect) data in flash, but just a 'using defaults' message.

Improves but doesn't complete #39 