### PR TITLE
Metro syntax follows updated norns

### DIFF
--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -26,6 +26,7 @@ local function closelibs()
     Asl    = nil
     Asllib = nil
     Metro  = nil
+    metro  = nil --alias
     II     = nil
 end
 
@@ -37,6 +38,7 @@ function _crow.libs( lib )
         Asl    = dofile('lua/asl.lua')
         Asllib = dofile('lua/asllib.lua')
         Metro  = dofile('lua/metro.lua')
+        metro  = Metro --alias
         II     = dofile('lua/ii.lua')
     elseif type(lib) == 'table' then
         -- load the list 

--- a/lua/default.lua
+++ b/lua/default.lua
@@ -4,8 +4,6 @@ function init()
         output[c].asl:action()
     end
 
-    metro = Metro.assign_all()
-
     ii.txi.get( 'value', 1 )
     --input[1].mode('change', 0.5, 0.1, 'both')
 end

--- a/lua/metro.lua
+++ b/lua/metro.lua
@@ -50,19 +50,6 @@ function Metro.init (arg, arg_time, arg_count)
     return nil
 end
 
---- helper fn to auto-assign timers in crow env
---
-function Metro.assign_all()
-    local m = {}
-    for c=1,Metro.num_script_metros do
-        m[c] = Metro.init{ event = function(count) _c.tell('metro',c,count) end
-                         , time  = 1.0
-                         , count = -1
-                         }
-    end
-    return m
-end
-
 function Metro.free(id)
     Metro.metros[id]:stop()
     Metro.available[id] = true


### PR DESCRIPTION
Finally understood the way that user could type `metro[n]` to access a metro -- Didn't realize this was being done with a metatable!

Removed the `assign_all()` function as it doesn't really make sense. It makes the Max patch look cool when you click a message and start seeing timing bangs appear, but there is zero use-case I can imagine where that's actually useful (ie. if you need a timer in Max, you use [metro], not request crow to send you updates).

Sorry for being dense on this!

Fixes #23 