### PR TITLE
Hotfix for 115200 usb baud & usb_rx overflow

### DIFF
--- a/max/crow.maxpat
+++ b/max/crow.maxpat
@@ -627,9 +627,9 @@
 									"numinlets" : 1,
 									"numoutlets" : 2,
 									"outlettype" : [ "int", "" ],
-									"patching_rect" : [ 364.0, 156.0, 99.0, 22.0 ],
+									"patching_rect" : [ 364.0, 156.0, 92.0, 22.0 ],
 									"style" : "",
-									"text" : "serial a 1000000"
+									"text" : "serial a 115200"
 								}
 
 							}

--- a/usbd/usbd_cdc_interface.c
+++ b/usbd/usbd_cdc_interface.c
@@ -203,7 +203,9 @@ uint8_t USB_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 // on interrupt add to the queue
 static int8_t CDC_Itf_Receive( uint8_t* buf, uint32_t *len )
 {
-    if( *len > APP_RX_DATA_SIZE ){ *len = APP_RX_DATA_SIZE; }
+    if( (UserRxBufPtrIn + *len) > APP_RX_DATA_SIZE ){
+        *len = APP_RX_DATA_SIZE - UserRxBufPtrIn; // stop buffer overflow
+    }
     memcpy( &UserRxBuffer[UserRxBufPtrIn]
           , buf
           , *len

--- a/usbd/usbd_cdc_interface.c
+++ b/usbd/usbd_cdc_interface.c
@@ -55,7 +55,7 @@
 #define APP_TX_DATA_SIZE  256
 
 // Private vars
-USBD_CDC_LineCodingTypeDef LineCoding = { 1000000 // baud rate
+USBD_CDC_LineCodingTypeDef LineCoding = { 115200  // baud rate
                                         , 0x00    // stop bits-1
                                         , 0x00    // parity - none
                                         , 0x08    // nb. of bits 8


### PR DESCRIPTION
Revert baudrate to 115200 for easier integration with existing tools.
Also fix a bug in the usb reception driver which would allow out-of-range pointer accesses to the reception buffer in an overflow situation.