### PR TITLE
Communication reliability & stability fixes

### DIFF
--- a/lib/caw.c
+++ b/lib/caw.c
@@ -19,7 +19,10 @@ uint8_t Caw_Init( void ) //TODO fnptr of callback )
 
 void Caw_send_raw( uint8_t* buf, uint32_t len )
 {
+uint32_t old_primask = __get_PRIMASK();
+__disable_irq();
     USB_tx_enqueue( buf, len );
+__set_PRIMASK( old_primask );
 }
 
 // luachunk expects a \0 terminated string

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -144,6 +144,34 @@ static int _print_serial( lua_State *L )
     lua_settop(L, 0);
     return 0;
 }
+static int _print_tell( lua_State *L )
+{
+    int nargs = lua_gettop(L);
+    char teller[60];
+    // nb: luaL_checkstring() will coerce ints & nums into strings
+    switch( nargs ){
+        case 0:
+            return luaL_error(L, "no event to tell.");
+        case 1:
+            sprintf( teller, "^^%s()", luaL_checkstring(L, 1) );
+            break;
+        case 2:
+            sprintf( teller, "^^%s(%s)", luaL_checkstring(L, 1)
+                                       , luaL_checkstring(L, 2) );
+            break;
+        case 3:
+            sprintf( teller, "^^%s(%s,%s)", luaL_checkstring(L, 1)
+                                          , luaL_checkstring(L, 2)
+                                          , luaL_checkstring(L, 3) );
+            break;
+        default:
+            return luaL_error(L, "too many args to tell.");
+    }
+    Caw_send_luachunk( teller );
+    lua_pop( L, nargs );
+    lua_settop(L, 0);
+    return 0;
+}
 static int _bootloader( lua_State *L )
 {
     bootloader_enter();
@@ -362,6 +390,7 @@ static const struct luaL_Reg libCrow[]=
     { { "c_dofile"         , _dofile           }
     , { "debug_usart"      , _debug            }
     , { "print_serial"     , _print_serial     }
+    , { "tell"             , _print_tell       }
         // system
     , { "sys_bootloader"   , _bootloader       }
     //, { "sys_cpu_load"     , _sys_cpu          }

--- a/lua/bootstrap.lua
+++ b/lua/bootstrap.lua
@@ -7,8 +7,9 @@
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 -- must set garbage collection faster than normal or lua VM stack overflows!
 -- TODO: optimize this choice of value
-collectgarbage('setpause', 100) --default 200
---collectgarbage('setstepmul', 400) --default 200
+-- setpause of 60 seems to give best results for very fast input[n].mode('stream')
+collectgarbage('setpause', 60) --default 200
+collectgarbage('setstepmul', 180) --default 200
 -- !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 print = function(...)

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -58,27 +58,16 @@ _crow.libs()
 -- they return values wrapped in strings that can be used in Lua directly
 -- via dostring
 
-function _crow.make_cmd( event_name, ... )
-    local out_string = string.format('^^%s(',event_name)
-    local args = {...}
-    local arg_len = #args
-    if arg_len > 0 then
-        for i=1,arg_len-1 do
-            out_string = out_string .. args[i] .. ',' -- can't use .format bc ?type
-        end
-        out_string = out_string .. args[arg_len]
-    end
-    return out_string .. ')'
-end
-
+--TODO tell should be in c-fns table, not _crow table?
 function _crow.tell( event_name, ... )
-    print(_crow.make_cmd( event_name, ... ))
+    tell( event_name, ... )
 end
 
-function get_out( channel ) _crow.tell( 'out_cv', channel, get_state(channel)) end
---function get_cv( channel )  _crow.tell( 'ret_cv', channel, io_get_input(channel)) end
+function get_out( channel )
+    _c.tell( 'out_cv', channel, get_state( channel ))
+end
 function get_cv( channel )
-    _c.tell('ret_cv',channel,io_get_input( channel ))
+    _c.tell( 'ret_cv', channel, io_get_input( channel ))
 end
 
 
@@ -116,11 +105,6 @@ function LL_get_state( id )
     return get_state(id)
 end
 
-
-
-adc_remote = function(chan)
-    get_cv(chan)
-end
 
 --- II default actions
 --TODO int16 conversion should be rolled into i2c generation tool

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -174,4 +174,9 @@ end
 
 print'crowlib loaded'
 
+-- cleanup all unused lua objects before releasing to the userscript
+-- call twice to ensure all finalizers are caught
+collectgarbage()
+collectgarbage()
+
 return _crow


### PR DESCRIPTION
1. `_c.tell()` function for sending call-able lua functions over USB is now run directly in C rather than lua. This dramatically improves stability by reducing lua memory footprint (string manipulations are greedy, would cause lua heap overflow) and time-spent-in-lua as the function simply forwards its values to C. Using `sprintf()` for formatting, currently limited to 3 args, but easy to add capacity for more by extending switch statement in lib/lualink.c. I'm seeing a 10x increase in time-to-crash with this change alone.

2. Garbage collection configuration has been updated to improve stability during high throughput situations.  Current settings were determined through trial & error seeing optimizing for maximum time-to-crash under an intense input & output library callback routine. Note, the GC is run twice (2nd time needed to free finalizers) at the end of `crowlib.lua` to force lua to it's minimum memory footprint before initializing the userscript. 

3. `Caw_send_raw()` now IRQ blocks while it copies to the usb_tx buffer.