### PR TITLE
USB stability improvements

### DIFF
--- a/usbd/usbd_cdc_interface.c
+++ b/usbd/usbd_cdc_interface.c
@@ -64,7 +64,6 @@ USBD_CDC_LineCodingTypeDef LineCoding = { 115200  // baud rate
 uint8_t UserRxBuffer[APP_RX_DATA_SIZE];
 uint8_t UserTxBuffer[APP_TX_DATA_SIZE];
 uint32_t UserTxBufPtrIn  = 0;
-uint32_t UserTxBufPtrOut = 0;
 uint32_t UserRxBufPtrIn  = 0;
 
 TIM_HandleTypeDef  USBTimHandle;
@@ -170,11 +169,11 @@ uint8_t USB_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
     if( htim == &USBTimHandle ){ // protect as it's called from timer lib
         uint32_t buffptr;
         uint32_t buffsize;
-        if( UserTxBufPtrOut != UserTxBufPtrIn ){
-            buffsize = UserTxBufPtrIn;
+        if( UserTxBufPtrIn != 0 ){
+            buffsize = UserTxBufPtrIn; // because TxPtrOut === 0
             if(buffsize >= APP_TX_DATA_SIZE){
-                printf("overflow %i\n",buffsize);
-                buffsize = APP_TX_DATA_SIZE-1;
+                //printf("overflow %i\n",(int)buffsize);
+                buffsize = APP_TX_DATA_SIZE;
             }
             buffptr = 0;
             USBD_CDC_SetTxBuffer( &USBD_Device
@@ -187,7 +186,6 @@ uint8_t USB_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
             if( (error = USBD_CDC_TransmitPacket(&USBD_Device)) == USBD_OK ){
                 // only clear data if no error
                 UserTxBufPtrIn = 0;
-                UserTxBufPtrOut = 0;
             } else if( error == USBD_FAIL ){
                 printf("CDC_tx failed %i\n", error);
             }

--- a/usbd/usbd_conf.c
+++ b/usbd/usbd_conf.c
@@ -218,6 +218,24 @@ void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd)
   }  
 }
 
+// custom malloc because the USBD driver seems to need it's buffer
+// initialized to 1s rather than 0s? without this, we were seeing
+// errors in usb initialization after a software restart.
+void* malloc1( size_t size )
+{
+    void* retval = malloc(size);
+    // failure protect
+    if( retval != NULL ){
+        // initialize to ones
+        uint8_t* p = (uint8_t*)retval;
+        for( int i=0; i<size; i++ ){
+            *(p + i) = 0xFF;
+        }
+    }
+    return retval;
+}
+
+
 /*******************************************************************************
                        LL Driver Callbacks (PCD -> USB Device Library)
 *******************************************************************************/

--- a/usbd/usbd_conf.h
+++ b/usbd/usbd_conf.h
@@ -67,7 +67,8 @@
 
 /* Exported macro ------------------------------------------------------------*/
 /* Memory management macros */   
-#define USBD_malloc               malloc
+void* malloc1( size_t size ); // like calloc, but sets to ones (??!?!?!)
+#define USBD_malloc               malloc1
 #define USBD_free                 free
 #define USBD_memset               memset
 #define USBD_memcpy               memcpy


### PR DESCRIPTION
Just 2 changes that make a massive difference to usb stability.

(Almost) Stable test case -- this finally crashed after ~10minutes of abuse:
- Running all 4 channels of ASL as LFOs with 33-133hz cycles
- Streaming both ADC channels at 200Hz (5ms intervals)
nb: There are some inaccuracies of data transmission. Seems caused by crow's tx buffer filling up, and the last message being split across neighbouring transmission packets. This could likely be fixed on the host implementation side.

Changes:
1. The 'pointer' variables into usbrx&tx buffers are clarified to reflect the way the queue is simply resetting. Previously this was a circular buffer, but was stripped back for simplicity, now the code reflects the simpler approach.
2. When pushing data to the usb_tx buffer it will now correctly limit the length of an overflowing message to exactly fill the buffer, discarding trailing characters (should this discard the whole packet?)
3. Fixed the edge case of the usb_rx buffer overflow bug that was mostly fixed in my previous PR.
4. The USB allocator has been customized to force all bytes to 0xFF. This solves a problem where usb transmission to the host would fail after every second soft restart, but not after a cold restart (usb_rx would continue to work regardless). Seemed to be something with an ongoing transfer being incomplete when resetting. Zero'ing the buffer caused it to fail *every* time, but `one-ing` the buffer makes it work reliably after both hard & soft reset. This feels like an error in the USB library, but I preferred this solution as it doesn't require changes to the STM library.

I'm going to say fixes #77 .