### PR TITLE
Release mode (deactivate debugging)

### DIFF
--- a/syscalls.c
+++ b/syscalls.c
@@ -5,6 +5,7 @@
 
 int _write(int file, char* data, int len)
 {
+#ifndef RELEASE
 #ifdef TRACE
     int count = len;
     while(count--){
@@ -13,6 +14,7 @@ int _write(int file, char* data, int len)
 #else // TRACE using USART to debug
     U_Print(data,len); // enqueues a string
 #endif // TRACE
+#endif // RELEASE
     return len;
 }
 

--- a/usbd/usbd_cdc_interface.c
+++ b/usbd/usbd_cdc_interface.c
@@ -64,7 +64,6 @@ USBD_CDC_LineCodingTypeDef LineCoding = { 115200  // baud rate
 uint8_t UserRxBuffer[APP_RX_DATA_SIZE];
 uint8_t UserTxBuffer[APP_TX_DATA_SIZE];
 uint32_t UserTxBufPtrIn  = 0;
-uint32_t UserTxBufPtrOut = 0;
 uint32_t UserRxBufPtrIn  = 0;
 
 TIM_HandleTypeDef  USBTimHandle;
@@ -170,11 +169,11 @@ uint8_t USB_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
     if( htim == &USBTimHandle ){ // protect as it's called from timer lib
         uint32_t buffptr;
         uint32_t buffsize;
-        if( UserTxBufPtrOut != UserTxBufPtrIn ){
-            buffsize = UserTxBufPtrIn;
+        if( UserTxBufPtrIn != 0 ){
+            buffsize = UserTxBufPtrIn; // because TxPtrOut === 0
             if(buffsize >= APP_TX_DATA_SIZE){
-                printf("overflow %i\n",buffsize);
-                buffsize = APP_TX_DATA_SIZE-1;
+                //printf("overflow %i\n",(int)buffsize);
+                buffsize = APP_TX_DATA_SIZE;
             }
             buffptr = 0;
             USBD_CDC_SetTxBuffer( &USBD_Device
@@ -187,7 +186,6 @@ uint8_t USB_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
             if( (error = USBD_CDC_TransmitPacket(&USBD_Device)) == USBD_OK ){
                 // only clear data if no error
                 UserTxBufPtrIn = 0;
-                UserTxBufPtrOut = 0;
             } else if( error == USBD_FAIL ){
                 printf("CDC_tx failed %i\n", error);
             }

--- a/usbd/usbd_conf.c
+++ b/usbd/usbd_conf.c
@@ -218,6 +218,24 @@ void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd)
   }  
 }
 
+// custom malloc because the USBD driver seems to need it's buffer
+// initialized to 1s rather than 0s? without this, we were seeing
+// errors in usb initialization after a software restart.
+void* malloc1( size_t size )
+{
+    void* retval = malloc(size);
+    // failure protect
+    if( retval != NULL ){
+        // initialize to ones
+        uint8_t* p = (uint8_t*)retval;
+        for( int i=0; i<size; i++ ){
+            *(p + i) = 0xFF;
+        }
+    }
+    return retval;
+}
+
+
 /*******************************************************************************
                        LL Driver Callbacks (PCD -> USB Device Library)
 *******************************************************************************/

--- a/usbd/usbd_conf.h
+++ b/usbd/usbd_conf.h
@@ -67,7 +67,8 @@
 
 /* Exported macro ------------------------------------------------------------*/
 /* Memory management macros */   
-#define USBD_malloc               malloc
+void* malloc1( size_t size ); // like calloc, but sets to ones (??!?!?!)
+#define USBD_malloc               malloc1
 #define USBD_free                 free
 #define USBD_memset               memset
 #define USBD_memcpy               memcpy


### PR DESCRIPTION
This adds support for the `R=1` compiler flag already in the Makefile.

Simply deactivates USART debugging or ST-TRACE debugging messages. Basically means `printf` becomes a do-nothing function to reduce data throughput / save a few cycles.