### PR TITLE
USB IRQ activation follows host presence

### DIFF
--- a/usbd/usbd_cdc_interface.c
+++ b/usbd/usbd_cdc_interface.c
@@ -88,11 +88,8 @@ USBD_CDC_ItfTypeDef USBD_CDC_fops = { CDC_Itf_Init
 /* Private functions ---------------------------------------------------------*/
 void CDC_main_init()
 {
-    //CDC_Itf_Init();
     USBD_CDC_SetTxBuffer(&USBD_Device, UserTxBuffer, 0);
     USBD_CDC_SetRxBuffer(&USBD_Device, UserRxBuffer);
-    TIM_Config();
-    HAL_TIM_Base_Start_IT(&USBTimHandle);
 }
 static int8_t CDC_Itf_Init(void)
 {
@@ -101,20 +98,24 @@ static int8_t CDC_Itf_Init(void)
 
     TIM_Config();
     if( HAL_TIM_Base_Start_IT(&USBTimHandle) != HAL_OK ){
-        printf("!tim_start\n");
+        printf("!usb tim_start\n");
         return USBD_FAIL;
     }
 
     //TODO add lua callback when USB connects/disconnects
     //     also provide a flag to check that status
-    printf("usb_init\n");
+    printf("USB_Init\n");
 
     return (USBD_OK);
 }
 
 static int8_t CDC_Itf_DeInit(void)
 {
-    printf("TODO: CDC_Itf_DeInit\n");
+    if( HAL_TIM_Base_Stop_IT(&USBTimHandle) != HAL_OK ){
+        printf("!usb tim_stop\n");
+        return USBD_FAIL;
+    }
+    printf("USB_DeInit\n");
     return (USBD_OK);
 }
 

--- a/usbd/usbd_conf.c
+++ b/usbd/usbd_conf.c
@@ -48,8 +48,6 @@
 /* Includes ------------------------------------------------------------------*/
 #include "usbd_main.h"
 
-#include "../ll/debug_usart.h"
-
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
@@ -380,7 +378,7 @@ USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)
   hpcd.Init.phy_itface = PCD_PHY_EMBEDDED;
   hpcd.Init.Sof_enable = 0;
   hpcd.Init.speed = PCD_SPEED_FULL;
-  hpcd.Init.vbus_sensing_enable = 0;
+  hpcd.Init.vbus_sensing_enable = 1;
   hpcd.Init.lpm_enable = 0;
   
   /* Link The driver to the stack */


### PR DESCRIPTION
crow now monitors VBUS pin to track whether a host is connected (determined based on whether +5v is detected on the VBUS line).

The usb_tx timer interrupt is activated / deactivated based on this vbus state. This avoids the `CDC_tx failed 2` error being flooded to the debug terminal, and also passively ensures resilience to repeated connect/disconnect cycles of the USB port.

With this PR, crow is able to connect to a host, start streaming a high-throughput set of information to the host, disconnect, reconnect, and will continue streaming values once the host re-connects to crow.

Solves #103 