### PR TITLE
RELEASE mode (deactivates debugging messages)

### DIFF
--- a/syscalls.c
+++ b/syscalls.c
@@ -5,6 +5,7 @@
 
 int _write(int file, char* data, int len)
 {
+#ifndef RELEASE
 #ifdef TRACE
     int count = len;
     while(count--){
@@ -13,6 +14,7 @@ int _write(int file, char* data, int len)
 #else // TRACE using USART to debug
     U_Print(data,len); // enqueues a string
 #endif // TRACE
+#endif // RELEASE
     return len;
 }
 


### PR DESCRIPTION
This adds support for the `R=1` compiler flag already in the Makefile.

Simply deactivates USART debugging or ST-TRACE debugging messages. Basically means `printf` becomes a do-nothing function to reduce data throughput / save a few cycles.