### PR TITLE
lualink wraps the event_post functions, rather than calling via events.h

### DIFF
--- a/lib/detect.c
+++ b/lib/detect.c
@@ -1,5 +1,4 @@
 #include "detect.h"
-#include "events.h"
 
 #include <stdlib.h>
 
@@ -64,24 +63,14 @@ void Detect( Detect_t* self, float level )
                 if( level < (self->change.threshold - self->change.hysteresis) ){
                     self->state = 0;
                     if( self->change.direction != 1 ){ // not 'rising' only
-                        //(*self->action)( self->channel, (float)self->state );
-                        event_t e;
-                        e.type = E_change;
-                        e.index = self->channel;
-                        e.data = (float)self->state;
-                        event_post(&e);
+                        (*self->action)( self->channel, (float)self->state );
                     }
                 }
             } else { // low to high
                 if( level > (self->change.threshold + self->change.hysteresis) ){
                     self->state = 1;
                     if( self->change.direction != -1 ){ // not 'falling' only
-                        //(*self->action)( self->channel, (float)self->state );
-                        event_t e;
-                        e.type = E_change;
-                        e.index = self->channel;
-                        e.data = (float)self->state;
-                        event_post(&e);
+                        (*self->action)( self->channel, (float)self->state );
                     }
                 }
             }


### PR DESCRIPTION
small change to better isolate the `detect` library with the intention of it being reusable in other systems.

with these changes the detect library is agnostic to what happens when a threshold change is detected, leaving that decision to the user program.

slopes.c will be similar, but obviously there are other changes that need to be made there!

i'll make a new issue about formally moving these libraries out of the crow repo for once they've crystalized into a finished form.