### PR TITLE
update style for fnptr calls & braces for single-line ifs

### DIFF
--- a/main.c
+++ b/main.c
@@ -52,8 +52,6 @@ int main(void)
 
     CDC_main_init(); // FIXME: stops crash when starting without usb connected
 
-    event_t e;
-
     while(1){
         U_PrintNow();
         switch( Caw_try_receive() ){ // true on pressing 'enter'
@@ -71,8 +69,10 @@ int main(void)
         }
         Random_Update();
         // check/execute single event
-        if (event_next(&e))
-            (app_event_handlers)[e.type](&e);
+        event_t e;
+        if( event_next(&e) ){
+            (*app_event_handlers[e.type])(&e);
+        }
     }
 }
 


### PR DESCRIPTION
switched the fnptr call to the 'classic' style, to match the other calls in the project. makes it clearer it's a fnptr and not a regular function imo.

rest of the codebase is using braces on all ifs even single-liners.

reduced the scope of the event_t in main to (infinitesimally) minimize stack usage.