### PR TITLE
Slopes now callback via the event system. isolate event system.

### DIFF
--- a/lib/detect.c
+++ b/lib/detect.c
@@ -1,5 +1,4 @@
 #include "detect.h"
-#include "events.h"
 
 #include <stdlib.h>
 
@@ -64,24 +63,14 @@ void Detect( Detect_t* self, float level )
                 if( level < (self->change.threshold - self->change.hysteresis) ){
                     self->state = 0;
                     if( self->change.direction != 1 ){ // not 'rising' only
-                        //(*self->action)( self->channel, (float)self->state );
-                        event_t e;
-                        e.type = E_change;
-                        e.index = self->channel;
-                        e.data = (float)self->state;
-                        event_post(&e);
+                        (*self->action)( self->channel, (float)self->state );
                     }
                 }
             } else { // low to high
                 if( level > (self->change.threshold + self->change.hysteresis) ){
                     self->state = 1;
                     if( self->change.direction != -1 ){ // not 'falling' only
-                        //(*self->action)( self->channel, (float)self->state );
-                        event_t e;
-                        e.type = E_change;
-                        e.index = self->channel;
-                        e.data = (float)self->state;
-                        event_post(&e);
+                        (*self->action)( self->channel, (float)self->state );
                     }
                 }
             }

--- a/lib/io.c
+++ b/lib/io.c
@@ -6,7 +6,6 @@
 #include "slopes.h"            // S_init(), S_step_v()
 #include "detect.h"            // Detect_init(), Detect(), Detect_ix_to_p()
 #include "metro.h"
-#include "events.h"
 
 #include "lualink.h"           // L_handle_in_stream (pass this in as ptr?)
 
@@ -87,14 +86,4 @@ void IO_SetADCaction( uint8_t channel, const char* mode )
         default: break;
     }
     // set the appropriate fn to be called in ADC dsp loop
-}
-
-void IO_handle_timer( uint8_t channel )
-{
-    event_t e;
-    e.type = E_stream;
-    e.index = channel;
-    e.data = IO_GetADC(channel);
-    event_post(&e);
-    //L_handle_in_stream( channel, IO_GetADC(channel) );
 }

--- a/lib/io.h
+++ b/lib/io.h
@@ -9,5 +9,3 @@ void IO_Process( void );
 
 float IO_GetADC( uint8_t channel );
 void IO_SetADCaction( uint8_t channel, const char* mode );
-
-extern void IO_handle_timer( uint8_t channel );

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -514,12 +514,18 @@ void L_handle_metro( const int id, const int stage)
     }
 }
 
+void L_queue_in_stream( int id )
+{
+    event_t e = { .type  = E_stream
+                , .index = id
+                , .data  = IO_GetADC(id)
+                };
+    event_post(&e);
+}
 void L_handle_in_stream( int id, float value )
 {
     lua_getglobal(L, "stream_handler");
     lua_pushinteger(L, id+1); // 1-ix'd
-    if( value > 10.0 ){ value = 10.0; }
-    if( value < -5.0 ){ value = -5.0; }
     lua_pushnumber(L, value);
     if( lua_pcall(L, 2, 0, 0) != LUA_OK ){
         Caw_send_luachunk("error: input stream");

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -53,10 +53,6 @@ const struct lua_lib_locator Lua_libs[] =
 static void Lua_linkctolua( lua_State* L );
 static float Lua_check_memory( void );
 
-// Event enqueue wrappers
-static void L_queue_change( int id, float state );
-
-
 void _printf(char* error_message)
 {
     printf("%s\n",error_message);
@@ -189,7 +185,7 @@ static int _go_toward( lua_State *L )
             , luaL_checknumber(L, 2)
             , luaL_checknumber(L, 3) * 1000.0
             , SHAPE_Linear // Shape_t
-            , L_handle_toward
+            , L_queue_toward
             );
     lua_pop( L, 4 );
     lua_settop(L, 0);
@@ -480,6 +476,13 @@ void Lua_crowbegin( void )
 }
 
 // Public Callbacks from C to Lua
+void L_queue_toward( int id )
+{
+    event_t e = { .type  = E_toward
+                , .index = id
+                };
+    event_post(&e);
+}
 void L_handle_toward( int id )
 {
     lua_getglobal(L, "toward_handler");
@@ -491,6 +494,14 @@ void L_handle_toward( int id )
     }
 }
 
+void L_queue_metro( int id, int state )
+{
+    event_t e = { .type  = E_metro
+                , .index = id
+                , .data  = state
+                };
+    event_post(&e);
+}
 void L_handle_metro( const int id, const int stage)
 {
     lua_getglobal(L, "metro_handler");
@@ -517,7 +528,7 @@ void L_handle_in_stream( int id, float value )
     }
 }
 
-static void L_queue_change( int id, float state )
+void L_queue_change( int id, float state )
 {
     event_t e = { .type  = E_change
                 , .index = id

--- a/lib/lualink.h
+++ b/lib/lualink.h
@@ -19,6 +19,12 @@ uint8_t Lua_eval( lua_State*     L
                 );
 void Lua_load_default_script( void );
 
+// Event enqueue wrappers
+extern void L_queue_toward( int id );
+extern void L_queue_metro( int id, int state );
+extern void L_queue_in_stream( int id );
+extern void L_queue_change( int id, float state );
+
 // Callback declarations
 extern void L_handle_toward( int id );
 extern void L_handle_metro( const int id, const int stage);

--- a/lib/metro.c
+++ b/lib/metro.c
@@ -6,7 +6,6 @@
 #include "../ll/timers.h"      // _Init() _Start() _Stop() _Set_Params()
 #include "lualink.h"           // L_handle_metro()
 #include "io.h"                // IO_handle_timer
-#include "events.h"
 
 typedef enum { METRO_STATUS_RUNNING
              , METRO_STATUS_STOPPED
@@ -85,14 +84,9 @@ static void Metro_bang( int ix )
 {
     // TODO confirm lua(1) makes a single tick
     if( ix < 2 ){
-        IO_handle_timer( ix );
+        L_queue_in_stream( ix );
     } else {
-        event_t e;
-        e.type = E_metro;
-        e.index = ix;
-        e.data = metros[ix].stage;
-        event_post(&e);
-        //L_handle_metro( ix, metros[ix].stage );
+        L_queue_metro( ix, metros[ix].stage );
     }
     metros[ix].stage++;
     //FIXME next line causes system not to load?


### PR DESCRIPTION
slopes.c now allows the `(*self->action)()` call to happen asynchronously. just waits at the end of the current slope until the event system calls the next slope via the `toward()` function.
- this introduces 1-32 samples (<1 dsp block) of jittery-delay. i've opened #112 to address this.

events.h is now *only* accessed from lualink.c and main.c. the idea is that the events queue is owned by the lua environment. this arrangement adds minimal overhead, but makes maintenance far simpler (i think?!)
- this adds a `L_queue_*` function beside each `L_handle_*` function in lualink  which just wraps the `event_post` call.

side note: no longer clipping the adc range in the callback to lua. this vals are inherently limited in the driver. i actually think the reason this was here is that it stopped the lua env crashing way back before we realized the crashes were caused by the GC settings.

//

i'm running the same stress test as before and after 30mins have yet to see a crash!