### PR TITLE
Allow >64byte messages from crow. improve max response to high through rx.

### DIFF
--- a/max/crowmax.lua
+++ b/max/crowmax.lua
@@ -10,10 +10,11 @@ local cmd_rxd    = 0
 function from( byte )
 	table.insert( cmd_bytes, byte )
 	cmd_rxd = cmd_rxd + 1
-	--TODO split on '\n\r' pair not just end-of-packet
 	if cmd_rxd == cmd_length then
-    	eval( bytes_to_string( cmd_bytes))
-		cmd_bytes  = {}
+		if cmd_bytes[#cmd_bytes] == 13 then -- check for carriage return
+			eval( bytes_to_string( cmd_bytes))
+			cmd_bytes  = {}
+		end
 		cmd_length = -1
 		cmd_rxd    = 0
     end


### PR DESCRIPTION
crow now handles long chunks of text from a host. fixes many crashes in both script upload and live execution modes. previously was limited to 64byte messages.
crow now throws an error to the user if they overflow the input buffer from a host (1024 bytes), and discards the incomplete data.
this should enable upload of many / most crow-length lua scripts, though if broken into chunks longer chunks should also be possible.
fixes #115 

max parser is updated for resilience to high throughput from crow. this was causing dropouts (and crashes?) when the max (usb?) buffer overflowed 1020 bytes. we now just store the string and keep collecting til the next newline is detected, then eval.