### PR TITLE
update i2c address to range starting at 0x01

### DIFF
--- a/lib/ii.h
+++ b/lib/ii.h
@@ -13,10 +13,10 @@
 
 #define II_GET             128  // cmd >= are getter requests
 
-typedef enum{ II_CROW  = 0x78
-            , II_CROW2 = 0x79
-            , II_CROW3 = 0x7a
-            , II_CROW4 = 0x7b
+typedef enum{ II_CROW  = 0x01
+            , II_CROW2 = 0x02
+            , II_CROW3 = 0x03
+            , II_CROW4 = 0x04
 } II_ADDR_t;
 
 uint8_t II_init( uint8_t address );

--- a/lua/ii/crow.lua
+++ b/lua/ii/crow.lua
@@ -1,7 +1,7 @@
 do return
 { module_name  = 'crow'
-, manufacturer = 'monome & mannequins'
-, i2c_address  = 0x78
+, manufacturer = 'monome & whimsical raps'
+, i2c_address  = 0x01
 , lua_name     = 'crow'
 , commands     =
   { { name = 'output'


### PR DESCRIPTION
fixes #54 

0x01-0x04 range selected as per @tehn 's thought. leaves the WR range (0x7*) more open.