### PR TITLE
Restartable ASLs (and other fixes)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TARGET=crow
 EXECUTABLE=$(TARGET).elf
 
-VERSION=0.0.0
+VERSION=0.0.2
 
 CUBE=submodules/STM32_Cube_F7/Drivers
 HALS=$(CUBE)/STM32F7xx_HAL_Driver/Src

--- a/README.md
+++ b/README.md
@@ -406,6 +406,18 @@ output[1].asl.action =
 ```
 Then start it as above with `output[1].asl:action()`, note the colon (method) call!
 
+There is a syntax shortcut to assign an action and start it immediately. Rather than
+assigning with `=` you can method-call (`:`) action with an ASL argument. Looks like:
+
+```
+output[1].asl:action( -- note the parens & method call
+    loop{ toward( 5.0, 0.0, 'linear' )
+        , toward( 0.0, 1.0, 'linear' )
+        }) -- method calls ends here
+```
+
+### volts
+
 It can be useful to query the current output value of an output. Rather than setting
 'volts' as above, you can query it like so:
 `v = output[1].volts`

--- a/lua/asl.lua
+++ b/lua/asl.lua
@@ -53,6 +53,11 @@ end
 -- this is a *private* method
 -- FIXME should be local?
 function Asl:do_action( dir )
+    local t = type(dir)
+    if t == 'table' or t == 'thread' then
+        Asl.set_action(self,dir) -- assign new action. dir is an ASL!
+        dir = true           -- call it!
+    end
     dir = dir or true -- default to rising action
     self.hold = dir
     if self.co ~= nil then
@@ -86,9 +91,10 @@ Asl.__newindex = function(self, ix, val)
 end
 
 -- call the member 'action' to start the asl coroutine
+--   if called w a table arg, treat it as a new ASL to run immediately
 Asl.__index = function(self, ix)
     if ix == 'action' then
-        return function(...) Asl.do_action( self, ...) end
+        return function(self,a) Asl.do_action(self,a) end
     elseif ix == 'step' then return Asl.step
     elseif ix == 'init' then return Asl.init end
 end

--- a/lua/asl.lua
+++ b/lua/asl.lua
@@ -174,7 +174,7 @@ function loop( fns )
     end)
 end
 
-function thread( fns )
+function weave( fns )
     return coroutine.create(function( self )
         while true do
             seq_coroutines( self, fns, 2 )

--- a/lua/asl.lua
+++ b/lua/asl.lua
@@ -57,6 +57,7 @@ function Asl:do_action( dir )
     self.hold = dir
     if self.co ~= nil then
         if self.locked ~= true then
+            self.cc = true -- reactivate if finished
             -- TODO need to restart if true
             -- TODO jump to release if false
             self:step()

--- a/tests/asl.lua
+++ b/tests/asl.lua
@@ -97,14 +97,13 @@ function run_tests()
           , {2, {1,3,3,'expo'}}
           )
 
-    -- sequence with restart
+    -- sequence with instant actions
     _t.run( function(count)
                 local sl = Asl.new(1)
                 sl.action = { toward( 1,1,'linear' )
+                            , toward{ ['here'] = 4 }
                             , toward( 3,3,'expo' )
                             }
-                sl:action()
-                for i=1,2 do sl:step() end
                 sl:action()
                 for i=1,count do sl:step() end
                 return get_last_toward()
@@ -114,14 +113,14 @@ function run_tests()
           , {2, {1,3,3,'expo'}}
           )
 
-
-    -- sequence with instant actions
+    -- sequence with restart after finish
     _t.run( function(count)
                 local sl = Asl.new(1)
                 sl.action = { toward( 1,1,'linear' )
-                            , toward{ ['here'] = 4 }
                             , toward( 3,3,'expo' )
                             }
+                sl:action()
+                for i=1,2 do sl:step() end
                 sl:action()
                 for i=1,count do sl:step() end
                 return get_last_toward()

--- a/tests/asl.lua
+++ b/tests/asl.lua
@@ -259,16 +259,16 @@ function run_tests()
           , {5, {1,5,5,'linear'}}
           )
 
-    -- thread{}
+    -- weave{}
     _t.run( function(count)
                 local sl = Asl.new(1)
-                sl.action = thread{ loop{ toward( 1, 1 )
-                                        , toward( 2, 1 )
-                                        }
-                                  , loop{ toward( 3, 1 )
-                                        , toward( 4, 1 )
-                                        }
-                                  }
+                sl.action = weave{ loop{ toward( 1, 1 )
+                                       , toward( 2, 1 )
+                                       }
+                                 , loop{ toward( 3, 1 )
+                                       , toward( 4, 1 )
+                                       }
+                                 }
                 sl:action()
                 for i=1,count do sl:step() end
                 return get_last_toward()

--- a/tests/asl.lua
+++ b/tests/asl.lua
@@ -97,6 +97,23 @@ function run_tests()
           , {2, {1,3,3,'expo'}}
           )
 
+    -- sequence with restart
+    _t.run( function(count)
+                local sl = Asl.new(1)
+                sl.action = { toward( 1,1,'linear' )
+                            , toward( 3,3,'expo' )
+                            }
+                sl:action()
+                for i=1,2 do sl:step() end
+                sl:action()
+                for i=1,count do sl:step() end
+                return get_last_toward()
+            end
+          , {0, {1,1,1,'linear'}}
+          , {1, {1,3,3,'expo'}}
+          , {2, {1,3,3,'expo'}}
+          )
+
 
     -- sequence with instant actions
     _t.run( function(count)
@@ -239,6 +256,8 @@ function run_tests()
           , {1, {1,3,3,'linear'}}
           , {2, {1,5,5,'linear'}}
           , {3, {1,3,3,'linear'}}
+          , {4, {1,3,3,'linear'}}
+          , {5, {1,5,5,'linear'}}
           )
 
     -- thread{}


### PR DESCRIPTION
1. after a (non-looping) ASL completes, you can restart it with `myAsl:action()`
2. added tests for the above
3. corrected the message passing of this^ method call so it can take an argument
4. added handling of this^ method call so it can take an ASL directly and execute it
5. rename `thread` to `weave` as it maps more directly, and `thread` already means too many things in computer land.

(fyi, i think `weave` is undocumented. it takes a table of ASLs and calls them interleaved, one-toward each. will be really nice for writing sequences! also- it was unintended behaviour from before where `loop` would nest outside-in)

fixes #89 