### PR TITLE
clear usb buffers on init. add 100ms delay before tx begins

### DIFF
--- a/main.c
+++ b/main.c
@@ -29,6 +29,7 @@ int main(void)
     events_init();
     Metro_Init();
     Caw_Init();
+    CDC_clear_buffers();
     II_init( II_CROW );
     Random_Init();
 
@@ -37,7 +38,6 @@ int main(void)
     IO_Start(); // must start IO before running lua init() script
     Lua_crowbegin();
 
-    CDC_main_init(); // FIXME: stops crash when starting without usb connected
 
     while(1){
         U_PrintNow();

--- a/usbd/usbd_cdc_interface.c
+++ b/usbd/usbd_cdc_interface.c
@@ -84,17 +84,25 @@ USBD_CDC_ItfTypeDef USBD_CDC_fops = { CDC_Itf_Init
                                     , CDC_Itf_Receive
                                     };
 
-/* Private functions ---------------------------------------------------------*/
-void CDC_main_init()
+/* Public functions ---------------------------------------------------------*/
+void CDC_clear_buffers( void )
 {
-    USBD_CDC_SetTxBuffer(&USBD_Device, UserTxBuffer, 0);
+    for( int i=0; i<APP_RX_DATA_SIZE; i++ ){ UserRxBuffer[i] = 0; }
+    for( int i=0; i<APP_TX_DATA_SIZE; i++ ){ UserTxBuffer[i] = 0; }
+    UserTxBufPtrIn  = 0;
+    UserRxBufPtrIn  = 0;
     USBD_CDC_SetRxBuffer(&USBD_Device, UserRxBuffer);
+    USBD_CDC_SetTxBuffer(&USBD_Device, UserTxBuffer, 0);
 }
+
+int timerdelay = 0;
+/* Private functions ---------------------------------------------------------*/
 static int8_t CDC_Itf_Init(void)
 {
-    USBD_CDC_SetTxBuffer(&USBD_Device, UserTxBuffer, 0);
     USBD_CDC_SetRxBuffer(&USBD_Device, UserRxBuffer);
+    USBD_CDC_SetTxBuffer(&USBD_Device, UserTxBuffer, 0);
 
+    timerdelay = 20;
     TIM_Config();
     if( HAL_TIM_Base_Start_IT(&USBTimHandle) != HAL_OK ){
         printf("!usb tim_start\n");
@@ -119,7 +127,7 @@ static int8_t CDC_Itf_DeInit(void)
 }
 
 static int8_t CDC_Itf_Control (uint8_t cmd, uint8_t* pbuf, uint16_t length)
-{ 
+{
     // Most of this is unimplemented!
     switch( cmd ){
         case CDC_SEND_ENCAPSULATED_COMMAND: printf("itf:send_cmd\n");     break;
@@ -174,6 +182,7 @@ void USB_tx_enqueue( uint8_t* buf, uint32_t len )
 uint8_t USB_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 {
     if( htim == &USBTimHandle ){ // protect as it's called from timer lib
+        if( timerdelay ){ timerdelay--; return 1; }
         uint32_t buffptr;
         uint32_t buffsize;
         if( UserTxBufPtrIn != 0 ){
@@ -236,10 +245,10 @@ __set_PRIMASK( old_primask );
 }
 
 static void TIM_Config(void)
-{  
+{
     // Set TIMu instance
     USBTimHandle.Instance = TIMu;
-  
+
     TIMu_CLK_ENABLE();
     // Initialize TIM3 peripheral as follow:
     //     + Period = 10000 - 1

--- a/usbd/usbd_cdc_interface.c
+++ b/usbd/usbd_cdc_interface.c
@@ -102,7 +102,7 @@ static int8_t CDC_Itf_Init(void)
     USBD_CDC_SetRxBuffer(&USBD_Device, UserRxBuffer);
     USBD_CDC_SetTxBuffer(&USBD_Device, UserTxBuffer, 0);
 
-    timerdelay = 20;
+    timerdelay = 100 / CDC_POLLING_INTERVAL;
     TIM_Config();
     if( HAL_TIM_Base_Start_IT(&USBTimHandle) != HAL_OK ){
         printf("!usb tim_start\n");

--- a/usbd/usbd_cdc_interface.h
+++ b/usbd/usbd_cdc_interface.h
@@ -71,7 +71,7 @@
 
 extern USBD_CDC_ItfTypeDef  USBD_CDC_fops;
 
-void CDC_main_init();
+void CDC_clear_buffers();
 
 void USB_tx_enqueue( uint8_t* buf, uint32_t len );
 uint8_t USB_rx_dequeue( uint8_t** buf, uint32_t* len );


### PR DESCRIPTION
2 things:

1. make sure we're zero-ing out the `User*xBuffer` arrays. it *shouldn't* matter, but better safe than sorry.

2. add an arbitrary delay into the usb transmit timer to avoid the ECHO issue seen on norns.

the issue we're seeing is that the norns usb driver is echoing all chars back to crow. this happens until norns completes the `tcsetattr` call in `dev_crow_init`. a delay of 100ms was found to reliably avoid the issue (20x restarts with no occurrence).

i believe it should be possible to avoid this issue by changing the initialization routine on norns, but this solution works for now.