### PR TITLE
ASL rewritten to use nested tables & closures (no coroutines)

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,9 +389,6 @@ or you can use the short-cut:
 
 *tech note: `output[n].action` is actually a shortcut for `output[n].asl.action`*
 
-*ed note: Is this a bad idea? Send a string to do output actions? Could be the ASL*
-*interactive commands like "press", "release", "begin", "pause". Like a micro-repl.*
-
 Or set the output to a value directly, deactivating the current action:
 `output[1].volts = 2.0` 2 volts.
 
@@ -411,18 +408,6 @@ output[1].action =
         }
 ```
 Then start it as above with `output[1]:action()`, note the colon (method) call!
-
-There is a syntax shortcut to assign an action and start it immediately. Rather than
-assigning with `=` you can method-call (`:`) action with an ASL argument. Looks like:
-
-```
-output[1].asl:action( -- note the parens & method call
-    loop{ toward( 5.0, 0.0, 'linear' )
-        , toward( 0.0, 1.0, 'linear' )
-        }) -- method calls ends here
-```
-
-### volts
 
 There is a syntax shortcut to assign an action and start it immediately. Rather than
 assigning with `=` you can method-call (`:`) action with an ASL argument. Looks like:

--- a/tests/asl.lua
+++ b/tests/asl.lua
@@ -32,36 +32,36 @@ end
 
 function run_tests()
     -- Asl.new
-    _t.type( {{Asl.new()}   , 'table' } -- should cause warning
+    _t.type( 'Asl.new'
+           , {{Asl.new()}   , 'table' } -- should cause warning
            , {{Asl.new(1)}  , 'table' }
            , {{Asl.new(99)} , 'table' }
            )
-    _t.run( function(id) return Asl.new(id).id end
+    _t.run( 'Asl.new.id'
+          , function(id) return Asl.new(id).id end
           , {2  , 2  }
           , {99 , 99 }
           )
-    _t.run( function(member) return Asl.new(1)[member] end
+    _t.run( 'Asl[member]'
+          , function(member) return Asl.new(1)[member] end
           , {'id'      , 1}
           , {'hold'    , false}
           , {'in_hold' , false}
           , {'locked'  , false}
           )
-
-    -- Asl:init
-    _t.run( function(member) return Asl.init( Asl.new(1) )[member] end
+    _t.run( 'Asl.init'
+          , function(member) return Asl.init( Asl.new(1) )[member] end
           , {'hold'    , false}
           , {'in_hold' , false}
           , {'locked'  , false}
           )
-
-    -- typecheck public methods to ensure inheritance
-    _t.type( {{Asl.new(1).init}   , 'function' }
+    _t.type( 'Inheritance'
+           , {{Asl.new(1).init}   , 'function' }
            , {{Asl.new(1).step}   , 'function' }
            , {{Asl.new(1).action} , 'function' }
            )
-
-    -- coroutine
-    _t.run( function(id,d,t,s)
+    _t.run( 'Standalone toward'
+          , function(id,d,t,s)
                 local sl = Asl.new(id)
                 sl.action = toward( d,t,s )
                 sl:action()
@@ -69,9 +69,8 @@ function run_tests()
             end
           , {{1,2,2,'linear'}, {1,2,2,'linear'}}
           )
-
-    -- sequence
-    _t.run( function(count)
+    _t.run( 'Toward Sequence'
+          , function(count)
                 local sl = Asl.new(1)
                 sl.action = { toward( 1,1,'linear' )
                             , toward( 3,3,'expo' )
@@ -84,9 +83,8 @@ function run_tests()
           , {1, {1,3,3,'expo'}}
           , {2, {1,3,3,'expo'}}
           )
-
-    -- sequence with instant actions
-    _t.run( function(count)
+    _t.run( 'sequence with instant actions'
+          , function(count)
                 local sl = Asl.new(1)
                 sl.action = { toward( 1,1,'linear' )
                             , toward{ now = 4 }
@@ -100,9 +98,8 @@ function run_tests()
           , {1, {1,3,3,'expo'}}
           , {2, {1,3,3,'expo'}}
           )
-
-    -- sequence with restart after finish
-    _t.run( function(count)
+    _t.run( 'sequence with restart after finish'
+          , function(count)
                 local sl = Asl.new(1)
                 sl.action = { toward( 1,1,'linear' )
                             , toward( 3,3,'log' )
@@ -118,8 +115,8 @@ function run_tests()
           , {2, {1,3,3,'log'}}
           )
 
-    -- loop{}
-    _t.run( function(count)
+    _t.run( 'loop{}'
+          , function(count)
                 local sl = Asl.new(1)
                 sl.action = loop{ toward( 1,1 )
                                 , toward( 2,2 )
@@ -133,8 +130,8 @@ function run_tests()
           , {2, {1,1,1,'linear'}} -- fails
           )
 
-    -- nested loop{}
-    _t.run( function(count)
+    _t.run( 'nested loop{}'
+          , function(count)
                 local sl = Asl.new(1)
                 sl.action = loop{ loop{ toward( 1, 1 )
                                       , toward( 2, 1 )
@@ -153,8 +150,8 @@ function run_tests()
           , {3, {1,2,1,'linear'}}
           )
 
-    -- asl_if{}
-    _t.run( function(bool)
+    _t.run( 'asl_if{}'
+          , function(bool)
                 local sl = Asl.new(1)
                 sl.action = { asl_if( function(self) return bool end
                                     , { toward( 3,3 )
@@ -170,8 +167,8 @@ function run_tests()
           , {false, {1,2,2,'linear'}}
           )
 
-    -- asl_wrap{}
-    _t.run( function(count)
+    _t.run( 'asl_wrap{}'
+          , function(count)
                 local sl = Asl.new(1)
                 sl.action = asl_wrap( function() set_last_toward( 'before' ) end
                                     , { toward( 3,3 )
@@ -188,8 +185,8 @@ function run_tests()
           , {2, {1,4,4,'after'}}
           )
 
-    -- nested asl_wrap{}
-    _t.run( function(count)
+    _t.run( 'nested asl_wrap{}'
+          , function(count)
                 local sl = Asl.new(1)
                 sl.action = loop{ asl_wrap( function() set_last_toward( 'before' ) end
                                           , { toward( 3,3 )
@@ -209,8 +206,8 @@ function run_tests()
           , {3, {1,3,3,'linear'}}
           )
 
-    -- times{}
-    _t.run( function(count)
+    _t.run( 'times{}'
+          , function(count)
                 local sl = Asl.new(1)
                 sl.action = { times( 2
                                    , { toward( 3,3 ) }
@@ -227,8 +224,8 @@ function run_tests()
           , {3, {1,5,5,'linear'}}
           )
 
-    -- nested times{}
-    _t.run( function(count)
+    _t.run( 'nested times{}'
+          , function(count)
                 local sl = Asl.new(1)
                 sl.action = loop{ times( 2
                                        , { toward( 3,3 ) }
@@ -247,8 +244,32 @@ function run_tests()
           , {5, {1,5,5,'linear'}}
           )
 
---    -- weave{}
---    _t.run( function(count)
+    _t.run( 'TODO held{}'
+          , function(...)
+                local t = {...}
+                local sl = Asl.new(1)
+                sl.action = { held{ toward( 3,3 )
+                                  , toward( 2,2 )
+                                  }
+                            , toward( 5,5 )
+                            }
+                for i=1,#t do sl:action(t[i]) end
+                return get_last_toward()
+            end
+          , {{''}                 , {1,3,3,'linear'}}
+          , {{'','step'}          , {1,2,2,'linear'}}
+          , {{'','step','step'}   , {1,2,-1,'linear'}}
+          , {{'','restart'}       , {1,3,3,'linear'}} -- FIXME jump back to start
+          , {{'release'}          , {1,5,5,'linear'}}
+          , {{'release','step'}   , {1,5,5,'linear'}}
+          , {{'','release'}       , {1,5,5,'linear'}} -- FIXME jump out of A into R
+          )
+
+-- add a test as above, but held{} wraps a loop{}, and another with weave{} to make
+-- sure we're successfully jumping out of the inner construct
+
+--    _t.run( 'weave'
+--          , function(count)
 --                local sl = Asl.new(1)
 --                sl.action = weave{ loop{ toward( 1, 1 )
 --                                       , toward( 2, 1 )
@@ -268,6 +289,8 @@ function run_tests()
 --          , {4, {1,1,1,'linear'}}
 --          )
 --
+
+
 
 ---- TODO add test for held & lock
 end

--- a/tests/asl.lua
+++ b/tests/asl.lua
@@ -42,7 +42,6 @@ function run_tests()
           )
     _t.run( function(member) return Asl.new(1)[member] end
           , {'id'      , 1}
-          --, {'co'      , {}}
           , {'hold'    , false}
           , {'in_hold' , false}
           , {'locked'  , false}
@@ -50,7 +49,6 @@ function run_tests()
 
     -- Asl:init
     _t.run( function(member) return Asl.init( Asl.new(1) )[member] end
-          --, {'co'      , {}}
           , {'hold'    , false}
           , {'in_hold' , false}
           , {'locked'  , false}

--- a/tests/asl.lua
+++ b/tests/asl.lua
@@ -27,7 +27,7 @@ function get_last_toward()
 end
 
 function LL_get_state( id )
-    return 1.0
+    return last_toward.d
 end
 
 function run_tests()
@@ -62,16 +62,6 @@ function run_tests()
            , {{Asl.new(1).action} , 'function' }
            )
 
-    -- typecheck remaining fns before full test below
-    _t.type( {toward( 1,1,'linear' )                         , 'thread' }
-           , {asl_if( function() return true end, {} )       , 'thread' }
-           , {asl_wrap( function() end, {}, function() end ) , 'thread' }
-           , {loop{}      , 'thread'}
-           , {lock{}      , 'thread'}
-           , {held{}      , 'thread'}
-           , {times(0,{}) , 'thread'}
-           )
-
     -- coroutine
     _t.run( function(id,d,t,s)
                 local sl = Asl.new(id)
@@ -101,7 +91,7 @@ function run_tests()
     _t.run( function(count)
                 local sl = Asl.new(1)
                 sl.action = { toward( 1,1,'linear' )
-                            , toward{ ['here'] = 4 }
+                            , toward{ now = 4 }
                             , toward( 3,3,'expo' )
                             }
                 sl:action()
@@ -117,17 +107,17 @@ function run_tests()
     _t.run( function(count)
                 local sl = Asl.new(1)
                 sl.action = { toward( 1,1,'linear' )
-                            , toward( 3,3,'expo' )
+                            , toward( 3,3,'log' )
                             }
                 sl:action()
                 for i=1,2 do sl:step() end
-                sl:action()
+                sl:action('restart')
                 for i=1,count do sl:step() end
                 return get_last_toward()
             end
           , {0, {1,1,1,'linear'}}
-          , {1, {1,3,3,'expo'}}
-          , {2, {1,3,3,'expo'}}
+          , {1, {1,3,3,'log'}}
+          , {2, {1,3,3,'log'}}
           )
 
     -- loop{}
@@ -142,7 +132,7 @@ function run_tests()
             end
           , {0, {1,1,1,'linear'}}
           , {1, {1,2,2,'linear'}}
-          , {2, {1,1,1,'linear'}}
+          , {2, {1,1,1,'linear'}} -- fails
           )
 
     -- nested loop{}
@@ -176,7 +166,6 @@ function run_tests()
                             , toward( 2,2 )
                             }
                 sl:action()
-                --for i=1,count do sl:step() end
                 return get_last_toward()
             end
           , {true , {1,3,3,'linear'}}
@@ -237,6 +226,7 @@ function run_tests()
           , {0, {1,3,3,'linear'}}
           , {1, {1,3,3,'linear'}}
           , {2, {1,5,5,'linear'}}
+          , {3, {1,5,5,'linear'}}
           )
 
     -- nested times{}
@@ -259,27 +249,27 @@ function run_tests()
           , {5, {1,5,5,'linear'}}
           )
 
-    -- weave{}
-    _t.run( function(count)
-                local sl = Asl.new(1)
-                sl.action = weave{ loop{ toward( 1, 1 )
-                                       , toward( 2, 1 )
-                                       }
-                                 , loop{ toward( 3, 1 )
-                                       , toward( 4, 1 )
-                                       }
-                                 }
-                sl:action()
-                for i=1,count do sl:step() end
-                return get_last_toward()
-            end
-          , {0, {1,1,1,'linear'}}
-          , {1, {1,3,1,'linear'}}
-          , {2, {1,2,1,'linear'}}
-          , {3, {1,4,1,'linear'}}
-          , {4, {1,1,1,'linear'}}
-          )
-
+--    -- weave{}
+--    _t.run( function(count)
+--                local sl = Asl.new(1)
+--                sl.action = weave{ loop{ toward( 1, 1 )
+--                                       , toward( 2, 1 )
+--                                       }
+--                                 , loop{ toward( 3, 1 )
+--                                       , toward( 4, 1 )
+--                                       }
+--                                 }
+--                sl:action()
+--                for i=1,count do sl:step() end
+--                return get_last_toward()
+--            end
+--          , {0, {1,1,1,'linear'}}
+--          , {1, {1,3,1,'linear'}}
+--          , {2, {1,2,1,'linear'}}
+--          , {3, {1,4,1,'linear'}}
+--          , {4, {1,1,1,'linear'}}
+--          )
+--
 
 ---- TODO add test for held & lock
 end

--- a/util/test.lua
+++ b/util/test.lua
@@ -11,7 +11,7 @@
 local Test = {}
 
 -- this is really Test.equality
-function Test.run( fn, ... )
+function Test.run( name, fn, ... )
     local test_cases = {...}
     local failures = 0
     for _,test_case in ipairs( test_cases ) do
@@ -53,15 +53,15 @@ function Test.run( fn, ... )
 
 -- status print
     if failures == 0 then
-        print(#test_cases..' tests passed')
+        print(#test_cases..' tests passed. ' .. name)
     else
         io.write(failures..' tests failed, ')
-        print((#test_cases-failures)..' passed')
+        print((#test_cases-failures)..' passed, in ' .. name)
     end
 end
 
-function Test.type( ... )
-    Test.run( type, ... )
+function Test.type( name, ... )
+    Test.run( name, type, ... )
 end
 
 return Test


### PR DESCRIPTION
This is essentially a reversion to the pre-coroutine implementation. It is far more fleshed out than before, and passing a slew (sorry) of tests (see: tests/asl.lua) for all kinds of constructions. Tested & working on hardware.

fixes #16 which means 'adsr' style functions can be used now. Added the `adsr()` ASL helper to `asllib.lua` and an example of how to hook it up to the input jack to the README (it's super basic!)

Also fixes #126 or means it doesn't need to be implemented. This is because an ASL can sequence *any* arbitrary function so long as it takes the asl as input (it can ignore that), and returns `nil` for an instant action, or `'wait'` (or any non-nil value really) if you want the driver implementation to be locked out. tldr; instead of `toward(...)` you can use `function(self) return 'wait' end` in the asl and the LL driver will just wait wherever it had arrived prior.

Also fixes #72 by adding a number of string arguments to the `:action(...)` method call. See the README changes for usage.