### PR TITLE
update naming conventions & add new hooks for version and identity ^^…

### DIFF
--- a/max/crow-max-testharness.maxpat
+++ b/max/crow-max-testharness.maxpat
@@ -38,6 +38,119 @@
 		"subpatcher_template" : "",
 		"boxes" : [ 			{
 				"box" : 				{
+					"id" : "obj-42",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 1151.5, 307.5, 60.0, 22.0 ],
+					"presentation_rect" : [ 1155.5, 340.0, 0.0, 0.0 ],
+					"style" : "",
+					"text" : "^^identity"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-3",
+					"maxclass" : "comment",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 431.333313, 601.5, 48.0, 20.0 ],
+					"presentation_rect" : [ 431.333313, 599.5, 0.0, 0.0 ],
+					"style" : "",
+					"text" : "'output'"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-8",
+					"maxclass" : "multislider",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"orientation" : 0,
+					"outlettype" : [ "", "" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 502.333313, 659.5, 86.0, 23.5 ],
+					"presentation_rect" : [ 502.333313, 657.5, 0.0, 0.0 ],
+					"setminmax" : [ -5.0, 10.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-9",
+					"maxclass" : "multislider",
+					"numinlets" : 1,
+					"numoutlets" : 2,
+					"orientation" : 0,
+					"outlettype" : [ "", "" ],
+					"parameter_enable" : 0,
+					"patching_rect" : [ 480.333313, 627.000061, 86.0, 23.5 ],
+					"presentation_rect" : [ 480.333313, 625.000061, 0.0, 0.0 ],
+					"setminmax" : [ -5.0, 10.0 ],
+					"style" : ""
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-11",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 413.833313, 659.5, 84.0, 22.0 ],
+					"presentation_rect" : [ 413.833313, 657.5, 0.0, 0.0 ],
+					"style" : "",
+					"text" : "0.629627"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-12",
+					"maxclass" : "message",
+					"numinlets" : 2,
+					"numoutlets" : 1,
+					"outlettype" : [ "" ],
+					"patching_rect" : [ 394.333313, 626.500061, 84.0, 22.0 ],
+					"presentation_rect" : [ 394.333313, 624.500061, 0.0, 0.0 ],
+					"style" : "",
+					"text" : "0.956768"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-35",
+					"maxclass" : "newobj",
+					"numinlets" : 3,
+					"numoutlets" : 3,
+					"outlettype" : [ "", "", "" ],
+					"patching_rect" : [ 459.333313, 538.5, 58.0, 22.0 ],
+					"presentation_rect" : [ 459.333313, 536.5, 0.0, 0.0 ],
+					"style" : "",
+					"text" : "route 1 2"
+				}
+
+			}
+, 			{
+				"box" : 				{
+					"id" : "obj-2",
+					"maxclass" : "newobj",
+					"numinlets" : 1,
+					"numoutlets" : 0,
+					"patching_rect" : [ 395.0, 479.0, 97.0, 22.0 ],
+					"style" : "",
+					"text" : "print unmatched"
+				}
+
+			}
+, 			{
+				"box" : 				{
 					"id" : "obj-83",
 					"maxclass" : "newobj",
 					"numinlets" : 2,
@@ -130,22 +243,9 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 204.333328, 723.0, 59.0, 22.0 ],
+					"patching_rect" : [ 291.833313, 716.0, 59.0, 22.0 ],
 					"style" : "",
 					"text" : "print midi"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-48",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 199.5, 431.833344, 94.0, 22.0 ],
-					"style" : "",
-					"text" : "128 50 64"
 				}
 
 			}
@@ -156,19 +256,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 303.333313, 511.0, 24.0, 24.0 ],
-					"style" : ""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-42",
-					"maxclass" : "button",
-					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "bang" ],
-					"patching_rect" : [ 256.0, 511.0, 24.0, 24.0 ],
+					"patching_rect" : [ 362.333313, 479.0, 24.0, 24.0 ],
 					"style" : ""
 				}
 
@@ -180,62 +268,9 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 361.0, 408.0, 132.0, 22.0 ],
+					"patching_rect" : [ 513.0, 309.0, 132.0, 22.0 ],
 					"style" : "",
 					"text" : "\"input[1].mode = 'midi'\""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-43",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 1093.0, 333.0, 65.0, 22.0 ],
-					"style" : "",
-					"text" : "output[1]()"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-41",
-					"linecount" : 2,
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 1052.0, 275.0, 126.0, 35.0 ],
-					"style" : "",
-					"text" : "\"output[1].asl.action=\n  lfo(1)\""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-39",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 885.0, 245.0, 124.0, 22.0 ],
-					"style" : "",
-					"text" : "\"output[1].volts = 3.0\""
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-38",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 855.0, 187.0, 117.0, 22.0 ],
-					"style" : "",
-					"text" : "print(output[1].volts)"
 				}
 
 			}
@@ -246,7 +281,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 196.0, 218.0, 149.0, 22.0 ],
+					"patching_rect" : [ 624.0, 171.000015, 149.0, 22.0 ],
 					"style" : "",
 					"text" : "\"input[1].mode = 'change'\""
 				}
@@ -259,7 +294,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 298.0, 370.0, 178.0, 22.0 ],
+					"patching_rect" : [ 450.0, 271.0, 178.0, 22.0 ],
 					"style" : "",
 					"text" : "\"input[2].mode('stream', 0.005)\""
 				}
@@ -267,75 +302,13 @@
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-35",
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 1528.0, 899.0, 150.0, 20.0 ],
-					"style" : "",
-					"text" : "128 byte string"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-12",
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 1080.0, 861.500061, 150.0, 20.0 ],
-					"style" : "",
-					"text" : "64 byte string"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-11",
-					"maxclass" : "comment",
-					"numinlets" : 1,
-					"numoutlets" : 0,
-					"patching_rect" : [ 827.0, 828.0, 150.0, 20.0 ],
-					"style" : "",
-					"text" : "32 byte string"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-9",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 615.0, 899.0, 911.0, 22.0 ],
-					"style" : "",
-					"text" : "print(\\\"01010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101\\\")"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-8",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 544.333313, 828.0, 271.0, 22.0 ],
-					"style" : "",
-					"text" : "print(\\\"01010101010101010101010101010101\\\")"
-				}
-
-			}
-, 			{
-				"box" : 				{
 					"id" : "obj-7",
-					"linecount" : 5,
+					"linecount" : 3,
 					"maxclass" : "message",
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 462.0, 752.0, 50.0, 76.0 ],
+					"patching_rect" : [ 922.333313, 422.5, 101.0, 49.0 ],
 					"style" : "",
 					"text" : "tell_crow \"input[1].mode = 'midi'\""
 				}
@@ -343,40 +316,14 @@
 			}
 , 			{
 				"box" : 				{
-					"id" : "obj-3",
-					"maxclass" : "newobj",
-					"numinlets" : 1,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 489.583344, 659.5, 55.0, 22.0 ],
-					"style" : "",
-					"text" : "prepend"
-				}
-
-			}
-, 			{
-				"box" : 				{
-					"id" : "obj-2",
-					"maxclass" : "message",
-					"numinlets" : 2,
-					"numoutlets" : 1,
-					"outlettype" : [ "" ],
-					"patching_rect" : [ 581.833313, 861.500061, 484.0, 22.0 ],
-					"style" : "",
-					"text" : "print(\\\"0101010101010101010101010101010101010101010101010101010101010101\\\")"
-				}
-
-			}
-, 			{
-				"box" : 				{
 					"id" : "obj-34",
 					"maxclass" : "newobj",
-					"numinlets" : 4,
-					"numoutlets" : 4,
-					"outlettype" : [ "", "", "", "" ],
-					"patching_rect" : [ 161.333328, 479.0, 161.0, 22.0 ],
+					"numinlets" : 5,
+					"numoutlets" : 5,
+					"outlettype" : [ "", "", "", "", "" ],
+					"patching_rect" : [ 161.333328, 479.0, 183.0, 22.0 ],
 					"style" : "",
-					"text" : "route ret_cv change_cv midi"
+					"text" : "route stream change midi output"
 				}
 
 			}
@@ -579,7 +526,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 199.5, 249.666687, 135.0, 22.0 ],
+					"patching_rect" : [ 627.5, 202.666702, 135.0, 22.0 ],
 					"style" : "",
 					"text" : "input[1].mode('change')"
 				}
@@ -592,7 +539,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 231.999985, 312.666687, 122.0, 22.0 ],
+					"patching_rect" : [ 660.0, 265.666687, 122.0, 22.0 ],
 					"style" : "",
 					"text" : "input[1].mode('none')"
 				}
@@ -605,7 +552,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 213.999985, 280.666687, 178.0, 22.0 ],
+					"patching_rect" : [ 642.0, 233.666702, 178.0, 22.0 ],
 					"style" : "",
 					"text" : "\"input[1].mode('stream', 0.005)\""
 				}
@@ -619,7 +566,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 695.75, 418.333344, 177.0, 49.0 ],
+					"patching_rect" : [ 1114.75, 415.500031, 177.0, 49.0 ],
 					"style" : "",
 					"text" : "\"input[1].stream = function(val)\n  print(val)\nend\""
 				}
@@ -644,7 +591,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 718.5, 324.666656, 80.0, 22.0 ],
+					"patching_rect" : [ 1111.75, 247.166687, 80.0, 22.0 ],
 					"style" : "",
 					"text" : "^^print_script"
 				}
@@ -656,7 +603,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 639.833313, 158.833359, 111.0, 20.0 ],
+					"patching_rect" : [ 1033.083252, 81.333389, 111.0, 20.0 ],
 					"style" : "",
 					"text" : "system commands"
 				}
@@ -668,7 +615,7 @@
 					"maxclass" : "newobj",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 344.333313, 479.0, 34.0, 22.0 ],
+					"patching_rect" : [ 573.0, 479.0, 34.0, 22.0 ],
 					"style" : "",
 					"text" : "print"
 				}
@@ -681,7 +628,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 704.833313, 296.666656, 56.0, 22.0 ],
+					"patching_rect" : [ 1098.083252, 219.166687, 56.0, 22.0 ],
 					"style" : "",
 					"text" : "^^restart"
 				}
@@ -695,7 +642,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 709.25, 546.500061, 150.0, 183.0 ],
+					"patching_rect" : [ 1128.25, 543.666748, 150.0, 183.0 ],
 					"style" : "",
 					"text" : "\"function init()\n  printversion()\n  counter = Metro.alloc()\n  counter.time = 2.0\n  counter.count = -1\n  counter.callback = count\n  counter:start()\nend\nlocal position = 0\nfunction count(c)\n  position = position + 1\n  print(1000-position)\nend\""
 				}
@@ -708,7 +655,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 340.0, 236.0, 85.0, 22.0 ],
+					"patching_rect" : [ 768.0, 189.000015, 85.0, 22.0 ],
 					"style" : "",
 					"text" : "counter:stop()"
 				}
@@ -722,7 +669,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 922.666687, 635.333313, 137.0, 76.0 ],
+					"patching_rect" : [ 1341.666748, 632.5, 137.0, 76.0 ],
 					"style" : "",
 					"text" : "\"local position = 0\nfunction count(c)\n  position = position + 1\n  print(1000-position)\nend\""
 				}
@@ -735,7 +682,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 489.583344, 194.666672, 36.0, 22.0 ],
+					"patching_rect" : [ 917.583374, 147.666687, 36.0, 22.0 ],
 					"style" : "",
 					"text" : "hello"
 				}
@@ -748,7 +695,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 690.833313, 269.166718, 83.0, 22.0 ],
+					"patching_rect" : [ 1084.083252, 191.666748, 83.0, 22.0 ],
 					"style" : "",
 					"text" : "^^clear_script"
 				}
@@ -761,7 +708,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 595.333313, 88.999992, 34.0, 22.0 ],
+					"patching_rect" : [ 1011.333313, 54.666676, 34.0, 22.0 ],
 					"style" : "",
 					"text" : "init()"
 				}
@@ -775,7 +722,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 959.333313, 436.0, 117.0, 49.0 ],
+					"patching_rect" : [ 1378.333252, 433.166687, 117.0, 49.0 ],
 					"style" : "",
 					"text" : "\"count = function(c)\n  print(1000-c)\nend\""
 				}
@@ -789,7 +736,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 922.666687, 505.0, 150.0, 116.0 ],
+					"patching_rect" : [ 1341.666748, 502.166687, 150.0, 116.0 ],
 					"style" : "",
 					"text" : "\"function init()\n  printversion()\n  counter = Metro.alloc()\n  counter.time = 2.0\n  counter.count = -1\n  counter.callback = count\n  counter:start()\nend\""
 				}
@@ -802,7 +749,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 449.333344, 194.666672, 29.5, 22.0 ],
+					"patching_rect" : [ 877.333374, 147.666687, 29.5, 22.0 ],
 					"style" : "",
 					"text" : "hi"
 				}
@@ -815,7 +762,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 449.333344, 227.333344, 99.0, 22.0 ],
+					"patching_rect" : [ 877.333374, 180.333359, 99.0, 22.0 ],
 					"style" : "",
 					"text" : "sprintf print('%s')"
 				}
@@ -828,7 +775,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 672.833313, 239.833359, 78.0, 22.0 ],
+					"patching_rect" : [ 1066.083252, 162.333389, 78.0, 22.0 ],
 					"style" : "",
 					"text" : "^^bootloader"
 				}
@@ -841,7 +788,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 658.166626, 211.833374, 77.0, 22.0 ],
+					"patching_rect" : [ 1051.416626, 134.333405, 77.0, 22.0 ],
 					"style" : "",
 					"text" : "^^end_script"
 				}
@@ -854,7 +801,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 639.833313, 183.166672, 80.0, 22.0 ],
+					"patching_rect" : [ 1033.083252, 105.666702, 80.0, 22.0 ],
 					"style" : "",
 					"text" : "^^start_script"
 				}
@@ -866,7 +813,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 683.333313, 60.333317, 99.0, 20.0 ],
+					"patching_rect" : [ 1099.333252, 26.0, 99.0, 20.0 ],
 					"style" : "",
 					"text" : "polite bootloader"
 				}
@@ -879,7 +826,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 577.833313, 60.333317, 100.0, 22.0 ],
+					"patching_rect" : [ 993.833313, 26.0, 100.0, 22.0 ],
 					"style" : "",
 					"text" : "sys_bootloader()"
 				}
@@ -891,7 +838,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 581.833313, 7.666656, 107.0, 20.0 ],
+					"patching_rect" : [ 1000.833313, 4.833343, 107.0, 20.0 ],
 					"style" : "",
 					"text" : "messages to crow"
 				}
@@ -904,9 +851,9 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 561.333313, 31.666655, 81.0, 22.0 ],
+					"patching_rect" : [ 1132.5, 277.5, 60.0, 22.0 ],
 					"style" : "",
-					"text" : "printversion()"
+					"text" : "^^version"
 				}
 
 			}
@@ -917,7 +864,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 554.666687, 367.5, 105.0, 22.0 ],
+					"patching_rect" : [ 973.666687, 364.666687, 105.0, 22.0 ],
 					"style" : "",
 					"text" : "prepend tell_crow"
 				}
@@ -994,7 +941,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 668.5, 358.0, 156.0, 33.0 ],
+					"patching_rect" : [ 1087.5, 355.166687, 156.0, 33.0 ],
 					"style" : "",
 					"text" : "tell_crow executes the following raw lua on crow"
 				}
@@ -1018,7 +965,7 @@
 					"maxclass" : "comment",
 					"numinlets" : 1,
 					"numoutlets" : 0,
-					"patching_rect" : [ 344.333313, 450.5, 121.0, 20.0 ],
+					"patching_rect" : [ 547.333313, 450.5, 121.0, 20.0 ],
 					"style" : "",
 					"text" : "messages from crow"
 				}
@@ -1032,7 +979,7 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 383.166626, 479.0, 54.0, 143.0 ],
+					"patching_rect" : [ 609.166626, 479.0, 54.0, 143.0 ],
 					"style" : "",
 					"text" : "\"[string \\\"eval\\\"]:1: unfinished string near ''midi'\n\r\""
 				}
@@ -1058,9 +1005,9 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 170.0, 94.5, 56.0, 22.0 ],
+					"patching_rect" : [ 170.0, 94.5, 70.0, 22.0 ],
 					"style" : "",
-					"text" : "get_cv 1"
+					"text" : "get_input 1"
 				}
 
 			}
@@ -1071,9 +1018,9 @@
 					"numinlets" : 2,
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
-					"patching_rect" : [ 151.0, 45.0, 56.0, 22.0 ],
+					"patching_rect" : [ 151.0, 45.0, 70.0, 22.0 ],
 					"style" : "",
-					"text" : "get_cv 2"
+					"text" : "get_input 2"
 				}
 
 			}
@@ -1192,15 +1139,6 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-13", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
-					"source" : [ "obj-2", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
 					"destination" : [ "obj-15", 1 ],
 					"disabled" : 0,
 					"hidden" : 0,
@@ -1273,6 +1211,15 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-2", 0 ],
+					"disabled" : 0,
+					"hidden" : 0,
+					"source" : [ "obj-34", 4 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-33", 0 ],
 					"disabled" : 0,
 					"hidden" : 0,
@@ -1282,16 +1229,7 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-42", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
-					"source" : [ "obj-34", 2 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-46", 0 ],
+					"destination" : [ "obj-35", 0 ],
 					"disabled" : 0,
 					"hidden" : 0,
 					"source" : [ "obj-34", 3 ]
@@ -1300,10 +1238,10 @@
 			}
 , 			{
 				"patchline" : 				{
-					"destination" : [ "obj-48", 1 ],
+					"destination" : [ "obj-46", 0 ],
 					"disabled" : 0,
 					"hidden" : 0,
-					"source" : [ "obj-34", 2 ]
+					"source" : [ "obj-34", 4 ]
 				}
 
 			}
@@ -1336,6 +1274,42 @@
 			}
 , 			{
 				"patchline" : 				{
+					"destination" : [ "obj-11", 1 ],
+					"disabled" : 0,
+					"hidden" : 0,
+					"source" : [ "obj-35", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-12", 1 ],
+					"disabled" : 0,
+					"hidden" : 0,
+					"source" : [ "obj-35", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-8", 0 ],
+					"disabled" : 0,
+					"hidden" : 0,
+					"source" : [ "obj-35", 1 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
+					"destination" : [ "obj-9", 0 ],
+					"disabled" : 0,
+					"hidden" : 0,
+					"source" : [ "obj-35", 0 ]
+				}
+
+			}
+, 			{
+				"patchline" : 				{
 					"destination" : [ "obj-13", 0 ],
 					"disabled" : 0,
 					"hidden" : 0,
@@ -1349,24 +1323,6 @@
 					"disabled" : 0,
 					"hidden" : 0,
 					"source" : [ "obj-37", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-13", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
-					"source" : [ "obj-38", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-13", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
-					"source" : [ "obj-39", 0 ]
 				}
 
 			}
@@ -1420,16 +1376,7 @@
 					"destination" : [ "obj-13", 0 ],
 					"disabled" : 0,
 					"hidden" : 0,
-					"source" : [ "obj-41", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-13", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
-					"source" : [ "obj-43", 0 ]
+					"source" : [ "obj-42", 0 ]
 				}
 
 			}
@@ -1618,15 +1565,6 @@
 					"destination" : [ "obj-13", 0 ],
 					"disabled" : 0,
 					"hidden" : 0,
-					"source" : [ "obj-8", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-13", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
 					"source" : [ "obj-80", 0 ]
 				}
 
@@ -1646,15 +1584,6 @@
 					"disabled" : 0,
 					"hidden" : 0,
 					"source" : [ "obj-86", 0 ]
-				}
-
-			}
-, 			{
-				"patchline" : 				{
-					"destination" : [ "obj-13", 0 ],
-					"disabled" : 0,
-					"hidden" : 0,
-					"source" : [ "obj-9", 0 ]
 				}
 
 			}

--- a/max/crowmax.lua
+++ b/max/crowmax.lua
@@ -42,16 +42,23 @@ end
 
 --- Request/callback pairs
 -- from max
-function get_cv( channel )
+function get_input( channel )
     tell_crow( "get_cv("..channel..")")
 end
+function get_output( channel )
+    tell_crow( "get_out("..channel..")")
+end
 -- continues to ->
-function ret_cv( channel, value )
-    to_max("ret_cv", channel, value)
+function stream( channel, value )
+    to_max("stream", channel, value)
 end
 
 function change( channel, state )
-    to_max("change_cv", channel, state )
+    to_max("change", channel, state )
+end
+
+function output( channel, state )
+    to_max("output", channel, state )
 end
 
 function midi( ... )
@@ -62,8 +69,8 @@ function version( ... )
     to_max("version", ...)
 end
 
-function crow_id( ... )
-    to_max("id", ...)
+function identity( ... )
+    to_max("identity", ...)
 end
 
 --- Helper conversion functions

--- a/max/help/crow.maxhelp
+++ b/max/help/crow.maxhelp
@@ -2,15 +2,14 @@
 	"patcher" : 	{
 		"fileversion" : 1,
 		"appversion" : 		{
-			"major" : 8,
+			"major" : 7,
 			"minor" : 0,
-			"revision" : 3,
+			"revision" : 6,
 			"architecture" : "x64",
 			"modernui" : 1
 		}
 ,
-		"classnamespace" : "box",
-		"rect" : [ 0.0, 42.0, 2158.0, 1398.0 ],
+		"rect" : [ 0.0, 45.0, 2158.0, 1398.0 ],
 		"bglocked" : 0,
 		"openinpresentation" : 0,
 		"default_fontsize" : 12.0,
@@ -48,14 +47,13 @@
 					"patcher" : 					{
 						"fileversion" : 1,
 						"appversion" : 						{
-							"major" : 8,
+							"major" : 7,
 							"minor" : 0,
-							"revision" : 3,
+							"revision" : 6,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
-						"classnamespace" : "box",
 						"rect" : [ 0.0, 26.0, 2158.0, 1372.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
@@ -93,9 +91,11 @@
 						"description" : "",
 						"digest" : "",
 						"globalpatchername" : "",
+						"style" : "",
 						"tags" : ""
 					}
 ,
+					"style" : "",
 					"text" : "p I2C"
 				}
 
@@ -109,15 +109,16 @@
 					"patcher" : 					{
 						"fileversion" : 1,
 						"appversion" : 						{
-							"major" : 8,
+							"major" : 7,
 							"minor" : 0,
-							"revision" : 3,
+							"revision" : 6,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
-						"classnamespace" : "box",
-						"rect" : [ 0.0, 26.0, 2158.0, 1372.0 ],
+						"rect" : [ 0.0, 71.0, 2158.0, 1372.0 ],
+						"bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
+						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -153,6 +154,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 492.0, 483.0, 32.0, 22.0 ],
+									"style" : "",
 									"text" : "init()"
 								}
 
@@ -165,7 +167,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 270.0, 492.0, 95.0, 49.0 ],
+									"patching_rect" : [ 270.0, 492.0, 98.0, 49.0 ],
+									"style" : "",
 									"text" : "\"function hello() \n  print('squawk') \nend\""
 								}
 
@@ -178,6 +181,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 147.5, 266.0, 53.0, 22.0 ],
+									"style" : "",
 									"text" : "connect"
 								}
 
@@ -188,7 +192,8 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 24.166748046875, 785.0, 125.0, 22.0 ],
+									"patching_rect" : [ 24.166748, 785.0, 125.0, 22.0 ],
+									"style" : "",
 									"text" : "s commands_to_crow"
 								}
 
@@ -201,6 +206,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 24.0, 752.0, 103.0, 22.0 ],
+									"style" : "",
 									"text" : "prepend tell_crow"
 								}
 
@@ -212,7 +218,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 243.0, 218.666686999999996, 74.0, 22.0 ],
+									"patching_rect" : [ 243.0, 218.666687, 74.0, 22.0 ],
+									"style" : "",
 									"text" : "^^clearscript"
 								}
 
@@ -224,7 +231,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 219.5, 186.166626000000008, 80.0, 22.0 ],
+									"patching_rect" : [ 219.5, 186.166626, 80.0, 22.0 ],
+									"style" : "",
 									"text" : "^^print_script"
 								}
 
@@ -235,7 +243,8 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 219.666748000000013, 299.0, 125.0, 22.0 ],
+									"patching_rect" : [ 219.666748, 299.0, 125.0, 22.0 ],
+									"style" : "",
 									"text" : "s commands_to_crow"
 								}
 
@@ -248,6 +257,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 219.5, 266.0, 103.0, 22.0 ],
+									"style" : "",
 									"text" : "prepend tell_crow"
 								}
 
@@ -260,7 +270,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 42.0, 392.66668701171875, 180.0, 290.0 ],
+									"patching_rect" : [ 42.0, 392.666687, 183.0, 290.0 ],
+									"style" : "",
 									"text" : "\"\nlocal position = 0\n\ncountdown = function(c)\n  position = position + 1\n  position = 1000-position\n  print(position)\nend\n\nfunction init()\n\n    printversion()\n\n    counter = Metro.alloc()\n    counter.time = 2.0\n    counter.count = 1000\n    counter.callback = countdown\n    counter:start()\n\nend\n\""
 								}
 
@@ -271,7 +282,8 @@
 									"maxclass" : "newobj",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 24.166747999999998, 299.0, 125.0, 22.0 ],
+									"patching_rect" : [ 24.166748, 299.0, 125.0, 22.0 ],
+									"style" : "",
 									"text" : "s commands_to_crow"
 								}
 
@@ -284,6 +296,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 24.0, 266.0, 103.0, 22.0 ],
+									"style" : "",
 									"text" : "prepend tell_crow"
 								}
 
@@ -295,7 +308,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 47.5, 218.666686999999996, 56.0, 22.0 ],
+									"patching_rect" : [ 47.5, 218.666687, 56.0, 22.0 ],
+									"style" : "",
 									"text" : "^^restart"
 								}
 
@@ -307,7 +321,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 24.0, 186.166626000000008, 78.0, 22.0 ],
+									"patching_rect" : [ 24.0, 186.166626, 78.0, 22.0 ],
+									"style" : "",
 									"text" : "^^bootloader"
 								}
 
@@ -319,7 +334,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 72.166748046875, 705.66668701171875, 77.0, 22.0 ],
+									"patching_rect" : [ 72.166748, 705.666687, 77.0, 22.0 ],
+									"style" : "",
 									"text" : "^^end_script"
 								}
 
@@ -331,7 +347,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 24.0, 354.166626000000008, 80.0, 22.0 ],
+									"patching_rect" : [ 24.0, 354.166626, 80.0, 22.0 ],
+									"style" : "",
 									"text" : "^^start_script"
 								}
 
@@ -356,6 +373,8 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-10", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-11", 0 ]
 								}
 
@@ -363,6 +382,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-11", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-12", 0 ]
 								}
 
@@ -370,6 +391,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-11", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-13", 0 ]
 								}
 
@@ -377,6 +400,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-14", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-15", 0 ]
 								}
 
@@ -384,6 +409,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -391,6 +418,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -398,6 +427,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-56", 0 ]
 								}
 
@@ -405,6 +436,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-15", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-57", 0 ]
 								}
 
@@ -412,6 +445,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-15", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-58", 0 ]
 								}
 
@@ -419,6 +454,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-15", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-6", 0 ]
 								}
 
@@ -426,6 +463,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-15", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -433,6 +472,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-80", 0 ]
 								}
 
@@ -440,25 +481,25 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-15", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-9", 0 ]
 								}
 
 							}
- ],
-						"bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
-						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ]
+ ]
 					}
 ,
 					"patching_rect" : [ 74.5, 262.0, 32.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
-						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
 						"globalpatchername" : "",
-						"locked_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
+						"style" : "",
 						"tags" : ""
 					}
 ,
+					"style" : "",
 					"text" : "p ^^",
 					"varname" : "basic_tab[6]"
 				}
@@ -473,15 +514,16 @@
 					"patcher" : 					{
 						"fileversion" : 1,
 						"appversion" : 						{
-							"major" : 8,
+							"major" : 7,
 							"minor" : 0,
-							"revision" : 3,
+							"revision" : 6,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
-						"classnamespace" : "box",
-						"rect" : [ 0.0, 68.0, 2158.0, 1372.0 ],
+						"rect" : [ 0.0, 26.0, 2158.0, 1372.0 ],
+						"bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
+						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -516,8 +558,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 114.0, 673.0, 24.0, 24.0 ]
+									"patching_rect" : [ 114.0, 673.0, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -529,6 +571,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1358.0, 527.0, 87.0, 22.0 ],
+									"style" : "",
 									"text" : "metro[1]:stop()"
 								}
 
@@ -541,6 +584,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1216.0, 511.0, 87.0, 22.0 ],
+									"style" : "",
 									"text" : "metro[2]:start()"
 								}
 
@@ -553,6 +597,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1067.0, 545.0, 87.0, 22.0 ],
+									"style" : "",
 									"text" : "metro[1]:stop()"
 								}
 
@@ -565,7 +610,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 1301.0, 286.0, 357.0, 76.0 ],
+									"patching_rect" : [ 1301.0, 286.0, 361.0, 76.0 ],
+									"style" : "",
 									"text" : "\"for i=1, 8 do \n  metro[i].time = 4.0 / i\n  metro[i].event = function(count) print('metro ' .. i .. ' ' .. count) end\n  metro[i]:start()\nend\""
 								}
 
@@ -578,6 +624,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 168.0, 178.0, 239.0, 22.0 ],
+									"style" : "",
 									"text" : "myMetro.event = function() print(count) end"
 								}
 
@@ -589,7 +636,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 168.0, 593.66668701171875, 71.0, 22.0 ],
+									"patching_rect" : [ 168.0, 593.666687, 71.0, 22.0 ],
+									"style" : "",
 									"text" : "fromsymbol"
 								}
 
@@ -602,6 +650,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1283.0, 450.0, 367.0, 22.0 ],
+									"style" : "",
 									"text" : "\"metro[1].event = function(count) print('metro ' .. 1 ..' ' .. count ) end\""
 								}
 
@@ -614,6 +663,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1283.0, 412.0, 117.0, 22.0 ],
+									"style" : "",
 									"text" : "print(metro[0].count)"
 								}
 
@@ -626,6 +676,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 985.0, 545.0, 87.0, 22.0 ],
+									"style" : "",
 									"text" : "metro[1]:start()"
 								}
 
@@ -638,6 +689,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1283.0, 381.0, 110.0, 22.0 ],
+									"style" : "",
 									"text" : "print(metro[3].time)"
 								}
 
@@ -650,7 +702,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 1100.0, 355.0, 110.0, 49.0 ],
+									"patching_rect" : [ 1100.0, 355.0, 114.0, 49.0 ],
+									"style" : "",
 									"text" : "\"for i=1, #metro do \n  metro[i]:stop() \nend\""
 								}
 
@@ -663,7 +716,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 1100.0, 291.333343505859375, 110.0, 49.0 ],
+									"patching_rect" : [ 1100.0, 291.333344, 114.0, 49.0 ],
+									"style" : "",
 									"text" : "\"for i=1, #metro do \n  metro[i]:start() \nend\""
 								}
 
@@ -675,8 +729,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 249.666671752929688, 768.0, 24.0, 24.0 ]
+									"patching_rect" : [ 249.666672, 768.0, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -687,8 +741,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 360.333343505859375, 768.0, 24.0, 24.0 ]
+									"patching_rect" : [ 360.333344, 768.0, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -699,8 +753,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 471.0, 768.0, 24.0, 24.0 ]
+									"patching_rect" : [ 471.0, 768.0, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -711,8 +765,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 581.66668701171875, 768.0, 24.0, 24.0 ]
+									"patching_rect" : [ 581.666687, 768.0, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -723,8 +777,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 692.33331298828125, 768.0, 24.0, 24.0 ]
+									"patching_rect" : [ 692.333313, 768.0, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -735,8 +789,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 803.0, 768.0, 24.0, 24.0 ]
+									"patching_rect" : [ 803.0, 768.0, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -747,8 +801,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 913.66668701171875, 768.0, 24.0, 24.0 ]
+									"patching_rect" : [ 913.666687, 768.0, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -759,8 +813,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 1024.3333740234375, 768.0, 24.0, 24.0 ]
+									"patching_rect" : [ 1024.333374, 768.0, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -771,8 +825,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 1135.0, 768.0, 24.0, 24.0 ]
+									"patching_rect" : [ 1135.0, 768.0, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -783,8 +837,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 139.0, 768.0, 24.0, 24.0 ]
+									"patching_rect" : [ 139.0, 768.0, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -796,7 +850,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 1100.0, 214.666671752929688, 195.0, 62.0 ],
+									"patching_rect" : [ 1100.0, 214.666672, 199.0, 62.0 ],
+									"style" : "",
 									"text" : "\"metro = {}\nfor i=1,8 do \n  metro[i] = Metro.init{ time = 2.0 / i}\nend\""
 								}
 
@@ -809,7 +864,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 1165.199951171875, 768.0, 50.0, 22.0 ]
+									"patching_rect" : [ 1165.199951, 768.0, 50.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -821,7 +877,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 832.79998779296875, 768.0, 50.0, 22.0 ]
+									"patching_rect" : [ 832.799988, 768.0, 50.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -833,7 +890,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 611.20001220703125, 768.0, 50.0, 22.0 ]
+									"patching_rect" : [ 611.200012, 768.0, 50.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -845,7 +903,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 389.600006103515625, 768.0, 50.0, 22.0 ]
+									"patching_rect" : [ 389.600006, 768.0, 50.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -857,7 +916,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 1054.4000244140625, 768.0, 50.0, 22.0 ]
+									"patching_rect" : [ 1054.400024, 768.0, 50.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -869,7 +929,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 943.5999755859375, 768.0, 50.0, 22.0 ]
+									"patching_rect" : [ 943.599976, 768.0, 50.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -881,7 +942,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 722.0, 768.0, 50.0, 22.0 ]
+									"patching_rect" : [ 722.0, 768.0, 50.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -893,7 +955,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 500.399993896484375, 768.0, 50.0, 22.0 ]
+									"patching_rect" : [ 500.399994, 768.0, 50.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -905,7 +968,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 278.79998779296875, 768.0, 50.0, 22.0 ]
+									"patching_rect" : [ 278.799988, 768.0, 50.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -917,7 +981,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 168.0, 768.0, 50.0, 22.0 ]
+									"patching_rect" : [ 168.0, 768.0, 50.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -929,6 +994,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1100.0, 178.0, 90.0, 22.0 ],
+									"style" : "",
 									"text" : "Metro.free_all()"
 								}
 
@@ -941,6 +1007,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 168.0, 407.0, 89.0, 22.0 ],
+									"style" : "",
 									"text" : "myMetro:stop()"
 								}
 
@@ -952,7 +1019,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 168.0, 373.142852783203125, 90.0, 22.0 ],
+									"patching_rect" : [ 168.0, 373.142853, 90.0, 22.0 ],
+									"style" : "",
 									"text" : "myMetro:start()"
 								}
 
@@ -964,7 +1032,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 168.0, 339.28570556640625, 385.0, 22.0 ],
+									"patching_rect" : [ 168.0, 339.285706, 385.0, 22.0 ],
+									"style" : "",
 									"text" : "\"myMetro.event = function(count) _c.tell('metro', 'myMetro', count) end\""
 								}
 
@@ -977,6 +1046,7 @@
 									"numoutlets" : 11,
 									"outlettype" : [ "", "", "", "", "", "", "", "", "", "", "" ],
 									"patching_rect" : [ 168.0, 673.0, 1127.0, 22.0 ],
+									"style" : "",
 									"text" : "route 1 2 3 4 5 6 7 8 myMetro anotherMetro"
 								}
 
@@ -988,7 +1058,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 168.0, 633.33331298828125, 70.0, 22.0 ],
+									"patching_rect" : [ 168.0, 633.333313, 70.0, 22.0 ],
+									"style" : "",
 									"text" : "route metro"
 								}
 
@@ -1001,6 +1072,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 168.0, 565.0, 88.0, 22.0 ],
+									"style" : "",
 									"text" : "r crow_printout"
 								}
 
@@ -1013,6 +1085,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 587.0, 382.0, 417.0, 22.0 ],
+									"style" : "",
 									"text" : "\"anotherMetro.event =  function(count) _c.tell('metro',  'anotherMetro', count)\""
 								}
 
@@ -1025,7 +1098,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 587.0, 300.0, 236.0, 62.0 ],
+									"patching_rect" : [ 587.0, 300.0, 239.0, 62.0 ],
+									"style" : "",
 									"text" : "\"anotherMetro.start{\n   event = function(count) print('Chirp') end,\n   count = -1\n}\""
 								}
 
@@ -1038,6 +1112,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 587.0, 265.0, 115.0, 22.0 ],
+									"style" : "",
 									"text" : "anotherMetro:start()"
 								}
 
@@ -1049,7 +1124,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 168.0, 271.571441650390625, 117.0, 22.0 ],
+									"patching_rect" : [ 168.0, 271.571442, 117.0, 22.0 ],
+									"style" : "",
 									"text" : "\"myMetro.count = 8\""
 								}
 
@@ -1062,7 +1138,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 587.0, 178.0, 385.0, 76.0 ],
+									"patching_rect" : [ 587.0, 178.0, 388.0, 76.0 ],
+									"style" : "",
 									"text" : "\"anotherMetro = Metro.init{\n  time = 1.2,\n  count = 4,\n  event = function(count) for counter = 1, count do print('Caw ') end end\n}\""
 								}
 
@@ -1074,7 +1151,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 168.0, 203.857147216796875, 90.0, 22.0 ],
+									"patching_rect" : [ 168.0, 203.857147, 90.0, 22.0 ],
+									"style" : "",
 									"text" : "myMetro:start()"
 								}
 
@@ -1086,7 +1164,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 168.0, 237.714279174804688, 120.0, 22.0 ],
+									"patching_rect" : [ 168.0, 237.714279, 120.0, 22.0 ],
+									"style" : "",
 									"text" : "\"myMetro.time = 0.5\""
 								}
 
@@ -1098,7 +1177,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 168.0, 305.428558349609375, 121.0, 22.0 ],
+									"patching_rect" : [ 168.0, 305.428558, 121.0, 22.0 ],
+									"style" : "",
 									"text" : "\"myMetro.count = -1\""
 								}
 
@@ -1111,6 +1191,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 168.0, 149.0, 135.0, 22.0 ],
+									"style" : "",
 									"text" : "\"myMetro = Metro.init()\""
 								}
 
@@ -1123,6 +1204,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 168.0, 460.0, 103.0, 22.0 ],
+									"style" : "",
 									"text" : "prepend tell_crow"
 								}
 
@@ -1134,6 +1216,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 168.0, 491.0, 125.0, 22.0 ],
+									"style" : "",
 									"text" : "s commands_to_crow"
 								}
 
@@ -1158,6 +1241,8 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-101", 0 ]
 								}
 
@@ -1165,6 +1250,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-104", 0 ]
 								}
 
@@ -1172,6 +1259,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-105", 0 ]
 								}
 
@@ -1179,6 +1268,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-27", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-109", 0 ]
 								}
 
@@ -1186,6 +1277,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 177.5, 261.0, 153.0, 261.0, 153.0, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-11", 0 ]
 								}
@@ -1194,6 +1287,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-111", 0 ]
 								}
 
@@ -1201,6 +1296,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-112", 0 ]
 								}
 
@@ -1208,6 +1305,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-113", 0 ]
 								}
 
@@ -1215,6 +1314,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-115", 0 ]
 								}
 
@@ -1222,6 +1323,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-117", 0 ]
 								}
 
@@ -1229,6 +1332,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 177.5, 228.0, 153.0, 228.0, 153.0, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-13", 0 ]
 								}
@@ -1237,6 +1342,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 596.5, 255.0, 564.0, 255.0, 564.0, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-15", 0 ]
 								}
@@ -1245,6 +1352,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 177.5, 294.0, 153.0, 294.0, 153.0, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-19", 0 ]
 								}
@@ -1253,6 +1362,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 596.5, 288.0, 564.0, 288.0, 564.0, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-21", 0 ]
 								}
@@ -1261,6 +1372,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 596.5, 363.0, 564.0, 363.0, 564.0, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-23", 0 ]
 								}
@@ -1269,6 +1382,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 596.5, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-25", 0 ]
 								}
@@ -1277,6 +1392,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-109", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-26", 0 ]
 								}
 
@@ -1284,7 +1401,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-30", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-27", 0 ]
 								}
 
@@ -1292,7 +1410,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-27", 0 ]
 								}
 
@@ -1300,7 +1419,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-46", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 0 ]
 								}
 
@@ -1308,7 +1428,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-48", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 1 ]
 								}
 
@@ -1316,7 +1437,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-50", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 3 ]
 								}
 
@@ -1324,7 +1446,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-52", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 5 ]
 								}
 
@@ -1332,7 +1455,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-54", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 7 ]
 								}
 
@@ -1340,7 +1464,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-56", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 8 ]
 								}
 
@@ -1348,7 +1473,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-58", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 2 ]
 								}
 
@@ -1356,7 +1482,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-60", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 4 ]
 								}
 
@@ -1364,7 +1491,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-62", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 6 ]
 								}
 
@@ -1372,7 +1500,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-64", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 9 ]
 								}
 
@@ -1380,7 +1509,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-72", 0 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 0 ]
 								}
 
@@ -1388,7 +1518,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-74", 0 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 9 ]
 								}
 
@@ -1396,7 +1527,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-76", 0 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 8 ]
 								}
 
@@ -1404,7 +1536,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-78", 0 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 7 ]
 								}
 
@@ -1412,7 +1545,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-80", 0 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 6 ]
 								}
 
@@ -1420,7 +1554,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-82", 0 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 5 ]
 								}
 
@@ -1428,7 +1563,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-84", 0 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 4 ]
 								}
 
@@ -1436,7 +1572,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-86", 0 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 3 ]
 								}
 
@@ -1444,7 +1581,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-88", 0 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 2 ]
 								}
 
@@ -1452,7 +1590,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-94", 0 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-30", 1 ]
 								}
 
@@ -1460,6 +1599,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 177.5, 363.0, 153.0, 363.0, 153.0, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-32", 0 ]
 								}
@@ -1468,6 +1609,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 177.5, 396.0, 153.0, 396.0, 153.0, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-38", 0 ]
 								}
@@ -1476,6 +1619,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -1483,6 +1628,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 177.5, 432.0, 177.5, 432.0 ],
 									"source" : [ "obj-40", 0 ]
 								}
@@ -1491,6 +1638,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 1109.5, 201.0, 1014.0, 201.0, 1014.0, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-42", 0 ]
 								}
@@ -1499,6 +1648,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 177.5, 195.0, 153.0, 195.0, 153.0, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-7", 0 ]
 								}
@@ -1507,6 +1658,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 1109.5, 279.0, 1014.0, 279.0, 1014.0, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-70", 0 ]
 								}
@@ -1515,6 +1668,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 177.5, 330.0, 153.0, 330.0, 153.0, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-9", 0 ]
 								}
@@ -1523,6 +1678,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 1109.5, 342.0, 1014.0, 342.0, 1014.0, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-96", 0 ]
 								}
@@ -1531,6 +1688,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 1109.5, 447.0, 177.5, 447.0 ],
 									"source" : [ "obj-97", 0 ]
 								}
@@ -1539,25 +1698,25 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-99", 0 ]
 								}
 
 							}
- ],
-						"bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
-						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ]
+ ]
 					}
 ,
 					"patching_rect" : [ 46.0, 193.0, 57.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
-						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
 						"globalpatchername" : "",
-						"locked_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
+						"style" : "",
 						"tags" : ""
 					}
 ,
+					"style" : "",
 					"text" : "p metros",
 					"varname" : "basic_tab[4]"
 				}
@@ -1572,15 +1731,16 @@
 					"patcher" : 					{
 						"fileversion" : 1,
 						"appversion" : 						{
-							"major" : 8,
+							"major" : 7,
 							"minor" : 0,
-							"revision" : 3,
+							"revision" : 6,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
-						"classnamespace" : "box",
 						"rect" : [ 0.0, 26.0, 2158.0, 1372.0 ],
+						"bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
+						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -1616,6 +1776,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "signal" ],
 									"patching_rect" : [ 1979.0, 777.0, 70.0, 22.0 ],
+									"style" : "",
 									"text" : "cycle~ 0.25"
 								}
 
@@ -1628,6 +1789,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "signal" ],
 									"patching_rect" : [ 1903.0, 856.0, 92.0, 22.0 ],
+									"style" : "",
 									"text" : "scale~ -1 1 -5 5"
 								}
 
@@ -1640,6 +1802,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1730.0, 940.0, 105.0, 22.0 ],
+									"style" : "",
 									"text" : "\"remoteVal[1] = 2\""
 								}
 
@@ -1652,6 +1815,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1682.0, 1012.0, 105.0, 22.0 ],
+									"style" : "",
 									"text" : "\"remoteVal[1] = 0\""
 								}
 
@@ -1663,6 +1827,7 @@
 									"numinlets" : 2,
 									"numoutlets" : 0,
 									"patching_rect" : [ 1789.0, 833.0, 35.0, 22.0 ],
+									"style" : "",
 									"text" : "dac~"
 								}
 
@@ -1675,6 +1840,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1816.0, 798.0, 72.0, 22.0 ],
+									"style" : "",
 									"text" : "startwindow"
 								}
 
@@ -1687,6 +1853,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1839.0, 953.0, 192.0, 22.0 ],
+									"style" : "",
 									"text" : "sprintf symout remoteVal[1] = %.2f"
 								}
 
@@ -1699,6 +1866,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "float" ],
 									"patching_rect" : [ 1839.0, 918.0, 81.0, 22.0 ],
+									"style" : "",
 									"text" : "snapshot~ 20"
 								}
 
@@ -1711,6 +1879,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "signal" ],
 									"patching_rect" : [ 1916.0, 798.0, 53.0, 22.0 ],
+									"style" : "",
 									"text" : "cycle~ 1"
 								}
 
@@ -1723,6 +1892,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1816.0, 997.0, 97.0, 22.0 ],
+									"style" : "",
 									"text" : "\"remoteVal  = {}\""
 								}
 
@@ -1730,13 +1900,14 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-52",
-									"linecount" : 7,
+									"linecount" : 6,
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 1772.0, 1091.0, 208.0, 102.0 ],
-									"text" : "\"out[1].asl.action = loop{ \n  toward( \n    function() return remoteVal[1] end, \n    .02, \n    'linear'\n  ) \n}\""
+									"patching_rect" : [ 1772.0, 1091.0, 216.0, 89.0 ],
+									"style" : "",
+									"text" : "\"out[1].asl.action = loop{ \n  to( function() return remoteVal[1] end\n     , 0.02\n     , 'linear'\n     )\n}\""
 								}
 
 							}
@@ -1748,6 +1919,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1627.0, 953.0, 57.0, 22.0 ],
+									"style" : "",
 									"text" : "tosymbol"
 								}
 
@@ -1761,7 +1933,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 1462.0, 867.0, 50.0, 22.0 ]
+									"patching_rect" : [ 1462.0, 867.0, 50.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -1773,6 +1946,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1447.0, 931.0, 105.0, 22.0 ],
+									"style" : "",
 									"text" : "rampLevel[1] = $1"
 								}
 
@@ -1785,6 +1959,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1350.0, 940.0, 57.0, 22.0 ],
+									"style" : "",
 									"text" : "tosymbol"
 								}
 
@@ -1798,7 +1973,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 1185.0, 854.0, 50.0, 22.0 ]
+									"patching_rect" : [ 1185.0, 854.0, 50.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -1810,6 +1986,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1170.0, 918.0, 107.0, 22.0 ],
+									"style" : "",
 									"text" : "rampWidth[1] = $1"
 								}
 
@@ -1822,7 +1999,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 1101.0, 1044.5, 310.0, 183.0 ],
+									"patching_rect" : [ 1101.0, 1044.5, 313.0, 183.0 ],
+									"style" : "",
 									"text" : "\"out[1].asl.action = loop{\n  toward(0.0, 0, 'linear'), \n  toward(\n    function() return rampLevel[1] end, \n    function() return period[1]*rampWidth[1] end, \n    'linear'\n  ), \n  toward( \n    0.0, \n    function() return period[1]-period[1]*rampWidth[1] end,\n    'linear'\n  ) \n}\""
 								}
 
@@ -1835,6 +2013,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 973.0, 893.0, 87.0, 22.0 ],
+									"style" : "",
 									"text" : "print(period[1])"
 								}
 
@@ -1847,7 +2026,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 927.0, 1072.5, 120.0, 102.0 ],
+									"patching_rect" : [ 927.0, 1072.5, 124.0, 102.0 ],
+									"style" : "",
 									"text" : "\"rampLevel = {} \nrampWidth = {} \nperiod = {} \nrampLevel[1] = 5.0 \nrampWidth[1] = 0.33 \nperiod[1] = 2.0\n\""
 								}
 
@@ -1860,6 +2040,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 652.0, 1001.0, 670.0, 24.0 ],
+									"style" : "",
 									"text" : "Use a function to dynamically get input[2], and use that as an input to our mapper to dynamically adjust the level of our lfo"
 								}
 
@@ -1872,6 +2053,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 527.0, 913.5, 440.0, 24.0 ],
+									"style" : "",
 									"text" : "Give Crow a function to scale a value from an input domain to an output range"
 								}
 
@@ -1884,6 +2066,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 97.5, 986.0, 525.0, 22.0 ],
+									"style" : "",
 									"text" : "\"output[1].asl.action = lfo(function() return mapping(io_get_input(1), 0, 25, .01, 2) end , 'linear', 5)\""
 								}
 
@@ -1896,7 +2079,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 62.0, 893.0, 454.0, 89.0 ],
+									"patching_rect" : [ 62.0, 893.0, 457.0, 89.0 ],
+									"style" : "",
 									"text" : "\"function mapping(x,domain_low,domain_hi,range_low,range_hi)\n  x = x*x\n  x = ((x-domain_low) / (domain_hi-domain_low) * (range_hi-range_low)+range_low)\n  return x\nend\n\""
 								}
 
@@ -1912,7 +2096,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 261.0, 830.0, 50.0, 22.0 ]
+									"patching_rect" : [ 261.0, 830.0, 50.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -1924,6 +2109,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 261.0, 859.0, 191.0, 22.0 ],
+									"style" : "",
 									"text" : "sprintf symout \"out[1].level = %.1f\""
 								}
 
@@ -1937,7 +2123,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 62.0, 830.0, 50.0, 22.0 ]
+									"patching_rect" : [ 62.0, 830.0, 50.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -1949,6 +2136,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 62.0, 859.0, 203.0, 22.0 ],
+									"style" : "",
 									"text" : "sprintf symout \"output[1].rate = %.1f\""
 								}
 
@@ -1961,6 +2149,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 62.0, 798.0, 568.0, 22.0 ],
+									"style" : "",
 									"text" : "\"output[1].asl.action = lfo(function() return output[1].rate end, 'linear', function() return output[1].level end)\""
 								}
 
@@ -1972,7 +2161,8 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 159.0, 720.5, 391.0, 24.0 ],
+									"patching_rect" : [ 191.0, 720.5, 391.0, 24.0 ],
+									"style" : "",
 									"text" : "Changing the level and rate no longer works!"
 								}
 
@@ -1985,7 +2175,8 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 361.0, 661.0, 391.0, 37.0 ],
+									"patching_rect" : [ 423.0, 661.0, 391.0, 37.0 ],
+									"style" : "",
 									"text" : "If you assign the lfo like this, we will use our old values for rate and level"
 								}
 
@@ -1998,6 +2189,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 62.0, 760.5, 108.0, 22.0 ],
+									"style" : "",
 									"text" : "\"output[1].rate = 2\""
 								}
 
@@ -2010,6 +2202,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 62.0, 720.5, 112.0, 22.0 ],
+									"style" : "",
 									"text" : "\"output[1].level = 5\""
 								}
 
@@ -2022,6 +2215,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 59.0, 692.0, 117.0, 22.0 ],
+									"style" : "",
 									"text" : "output[1].asl:action()"
 								}
 
@@ -2030,12 +2224,12 @@
 								"box" : 								{
 									"bubble" : 1,
 									"id" : "obj-69",
-									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 277.0, 592.0, 675.0, 37.0 ],
-									"text" : "Step 4: There are some helper functions to create slope forms for you, like lfo(<period in secs>, <shape>, <amplitude in volts>)"
+									"patching_rect" : [ 277.0, 592.0, 675.0, 24.0 ],
+									"style" : "",
+									"text" : "Step 4: There are some helper functions to create actions for you, like lfo(<period in secs>, <shape>, <amplitude in volts>)"
 								}
 
 							}
@@ -2047,6 +2241,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 59.0, 627.0, 117.0, 22.0 ],
+									"style" : "",
 									"text" : "output[1].asl:action()"
 								}
 
@@ -2059,6 +2254,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 59.0, 661.0, 345.0, 22.0 ],
+									"style" : "",
 									"text" : "\"output[1].asl.action = lfo(output[1].rate, 'linear', output[1].level)\""
 								}
 
@@ -2067,12 +2263,12 @@
 								"box" : 								{
 									"bubble" : 1,
 									"id" : "obj-64",
-									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 466.0, 516.0, 760.0, 37.0 ],
-									"text" : "Step 4: We can use \"constructors\" like \"loop\" to generate more complex actions.  See ASL documentation for more info on other constructors."
+									"patching_rect" : [ 466.0, 516.0, 760.0, 24.0 ],
+									"style" : "",
+									"text" : "Step 4: We can use \"constructs\" like \"loop\" to generate more complex actions.  See ASL documentation for more info on other constructs."
 								}
 
 							}
@@ -2084,6 +2280,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 59.0, 556.0, 117.0, 22.0 ],
+									"style" : "",
 									"text" : "output[1].asl:action()"
 								}
 
@@ -2095,8 +2292,9 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 59.0, 516.0, 415.0, 22.0 ],
-									"text" : "\"output[1].asl.action = loop{ toward(5.0,3.0,'linear'), toward(-2.0, .5, 'linear') }\""
+									"patching_rect" : [ 59.0, 516.0, 365.0, 22.0 ],
+									"style" : "",
+									"text" : "\"output[1].asl.action = loop{ to(5.0,3.0,'linear'), to(-2.0, .5, 'linear') }\""
 								}
 
 							}
@@ -2104,12 +2302,12 @@
 								"box" : 								{
 									"bubble" : 1,
 									"id" : "obj-61",
-									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 442.0, 433.0, 507.0, 37.0 ],
-									"text" : "Step 4: We can create a compound coroutine by putting multiple coroutines together in a table"
+									"patching_rect" : [ 442.0, 433.0, 507.0, 24.0 ],
+									"style" : "",
+									"text" : "Step 4: We can create a compound ASL by putting multiple to calls together in a table"
 								}
 
 							}
@@ -2121,6 +2319,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 59.0, 475.0, 117.0, 22.0 ],
+									"style" : "",
 									"text" : "output[1].asl:action()"
 								}
 
@@ -2132,8 +2331,9 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 59.0, 435.0, 393.0, 22.0 ],
-									"text" : "\"output[1].asl.action = { toward(5.0,3.0,'linear'), toward(-2.0, .5, 'linear') }\""
+									"patching_rect" : [ 59.0, 435.0, 343.0, 22.0 ],
+									"style" : "",
+									"text" : "\"output[1].asl.action = { to(5.0,3.0,'linear'), to(-2.0, .5, 'linear') }\""
 								}
 
 							}
@@ -2145,6 +2345,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 59.0, 395.0, 117.0, 22.0 ],
+									"style" : "",
 									"text" : "output[1].asl:action()"
 								}
 
@@ -2156,6 +2357,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 166.0, 433.0, 206.0, 20.0 ],
+									"style" : "",
 									"text" : "Step 4: Now let's execute that action!"
 								}
 
@@ -2167,8 +2369,9 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 59.0, 355.0, 256.0, 22.0 ],
-									"text" : "\"output[1].asl.action = toward(0.0, 4.0, 'linear')\""
+									"patching_rect" : [ 59.0, 355.0, 232.0, 22.0 ],
+									"style" : "",
+									"text" : "\"output[1].asl.action = to(0.0, 4.0, 'linear')\""
 								}
 
 							}
@@ -2176,12 +2379,12 @@
 								"box" : 								{
 									"bubble" : 1,
 									"id" : "obj-55",
-									"linecount" : 2,
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 308.0, 355.0, 674.0, 37.0 ],
-									"text" : "Step 4: Now let's assign a new action using toward(<destination in volts>, <time in secs>, shape) to create a new \"co-routine\""
+									"patching_rect" : [ 308.0, 355.0, 674.0, 24.0 ],
+									"style" : "",
+									"text" : "Step 4: Now let's assign a new action using to(<destination in volts>, <time in secs>, shape)"
 								}
 
 							}
@@ -2193,8 +2396,9 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 197.0, 309.5, 927.0, 37.0 ],
-									"text" : "Step 3: We've been running an ASL action - let's get rid of that action, or \"coroutine\" by assigning the action for output 1's asl to be empty.  output 1 will finish its current segment, then stop."
+									"patching_rect" : [ 197.0, 309.5, 932.0, 37.0 ],
+									"style" : "",
+									"text" : "Step 3: We've been running an ASL action - let's get rid of that action by assigning the action for output 1's asl to be empty.  output 1 will finish its current segment, then stop."
 								}
 
 							}
@@ -2206,6 +2410,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 59.0, 315.0, 139.0, 22.0 ],
+									"style" : "",
 									"text" : "\"output[1].asl.action = {}\""
 								}
 
@@ -2218,6 +2423,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 59.0, 275.0, 108.0, 22.0 ],
+									"style" : "",
 									"text" : "\"output[1].rate = 5\""
 								}
 
@@ -2230,6 +2436,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 167.0, 283.0, 183.0, 24.0 ],
+									"style" : "",
 									"text" : "Step 3: Change the LFO rate"
 								}
 
@@ -2242,6 +2449,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 59.0, 235.0, 112.0, 22.0 ],
+									"style" : "",
 									"text" : "\"output[1].level = 2\""
 								}
 
@@ -2255,6 +2463,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 179.0, 238.0, 183.0, 37.0 ],
+									"style" : "",
 									"text" : "Step 3: Change the LFO level"
 								}
 
@@ -2268,6 +2477,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1462.0, 566.0, 72.0, 22.0 ],
+									"style" : "",
 									"text" : "append 100"
 								}
 
@@ -2279,8 +2489,9 @@
 									"maxclass" : "newobj",
 									"numinlets" : 3,
 									"numoutlets" : 2,
-									"outlettype" : [ "", "bang" ],
+									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 1462.0, 598.0, 57.0, 22.0 ],
+									"style" : "",
 									"text" : "line 0. 10"
 								}
 
@@ -2292,6 +2503,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 1864.0, 720.5, 21.0, 20.0 ],
+									"style" : "",
 									"text" : "0v"
 								}
 
@@ -2303,6 +2515,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 1862.0, 637.0, 35.0, 20.0 ],
+									"style" : "",
 									"text" : "+10v"
 								}
 
@@ -2314,6 +2527,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 1862.0, 757.0, 25.0, 20.0 ],
+									"style" : "",
 									"text" : "-5v"
 								}
 
@@ -2321,7 +2535,7 @@
 , 							{
 								"box" : 								{
 									"id" : "obj-35",
-									"linecolor" : [ 0.996078431372549, 0.996078431372549, 0.996078431372549, 1.0 ],
+									"linecolor" : [ 0.996078, 0.996078, 0.996078, 1.0 ],
 									"maxclass" : "live.line",
 									"numinlets" : 1,
 									"numoutlets" : 0,
@@ -2337,6 +2551,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 59.0, 195.0, 162.0, 22.0 ],
+									"style" : "",
 									"text" : "\"input[1].mode('stream', 0.1)\""
 								}
 
@@ -2350,6 +2565,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 240.0, 195.0, 183.0, 37.0 ],
+									"style" : "",
 									"text" : "Step 2: Activating input[1] polling"
 								}
 
@@ -2364,7 +2580,8 @@
 									"parameter_enable" : 0,
 									"patching_rect" : [ 1443.0, 647.0, 398.0, 126.0 ],
 									"setminmax" : [ -5.0, 10.0 ],
-									"setstyle" : 4
+									"setstyle" : 4,
+									"style" : ""
 								}
 
 							}
@@ -2377,6 +2594,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 1462.0, 538.0, 46.0, 22.0 ],
+									"style" : "",
 									"text" : "route 1"
 								}
 
@@ -2390,6 +2608,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 1462.0, 511.0, 72.0, 22.0 ],
+									"style" : "",
 									"text" : "route ret_cv"
 								}
 
@@ -2403,6 +2622,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 1462.0, 479.0, 137.0, 22.0 ],
+									"style" : "",
 									"text" : "r commands_from_crow"
 								}
 
@@ -2416,6 +2636,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 17.0, 156.0, 629.0, 37.0 ],
+									"style" : "",
 									"text" : "Step 1: Send crow output[1] to a parameter on your synth (and mult it to crow input[1] for visualization in this window)"
 								}
 
@@ -2427,6 +2648,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 620.0, 1140.0, 150.0, 20.0 ],
+									"style" : "",
 									"text" : "Not working!"
 								}
 
@@ -2438,8 +2660,9 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 432.5, 1139.0, 177.0, 22.0 ],
-									"text" : "\"action2 = toward( [ 'now' ] = 3)\""
+									"patching_rect" : [ 432.5, 1139.0, 153.0, 22.0 ],
+									"style" : "",
+									"text" : "\"action2 = to( [ 'now' ] = 3)\""
 								}
 
 							}
@@ -2451,6 +2674,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 417.0, 1181.0, 153.0, 22.0 ],
+									"style" : "",
 									"text" : "\"out[1].asl.action = action1\""
 								}
 
@@ -2462,8 +2686,9 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 383.0, 1107.0, 471.0, 22.0 ],
-									"text" : "\"action1 = loop {toward(0.0,0.0,'linear'), toward(5.0,3.0,'linear'), toward(0.0,3.0,'linear')}\""
+									"patching_rect" : [ 383.0, 1107.0, 395.0, 22.0 ],
+									"style" : "",
+									"text" : "\"action1 = loop {to(0.0,0.0,'linear'), to(5.0,3.0,'linear'), to(0.0,3.0,'linear')}\""
 								}
 
 							}
@@ -2475,6 +2700,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 59.0, 592.0, 223.0, 22.0 ],
+									"style" : "",
 									"text" : "\"output[1].asl.action = lfo(4, 'linear', 5.0)\""
 								}
 
@@ -2486,6 +2712,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 10.0, 1135.0, 125.0, 22.0 ],
+									"style" : "",
 									"text" : "s commands_to_crow"
 								}
 
@@ -2498,6 +2725,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 10.0, 1095.0, 103.0, 22.0 ],
+									"style" : "",
 									"text" : "prepend tell_crow"
 								}
 
@@ -2522,6 +2750,8 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-1", 0 ]
 								}
 
@@ -2529,6 +2759,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-13", 0 ]
 								}
 
@@ -2536,6 +2768,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-27", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-14", 0 ]
 								}
 
@@ -2543,6 +2777,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-20", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-15", 0 ]
 								}
 
@@ -2550,6 +2786,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-16", 0 ]
 								}
 
@@ -2557,6 +2795,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-14", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-17", 0 ]
 								}
 
@@ -2564,6 +2804,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-18", 0 ]
 								}
 
@@ -2571,6 +2813,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-19", 0 ]
 								}
 
@@ -2578,6 +2822,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-5", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-20", 0 ]
 								}
 
@@ -2585,6 +2831,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-43", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-24", 0 ]
 								}
@@ -2593,6 +2840,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-24", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-25", 0 ]
 								}
@@ -2601,6 +2849,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-25", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-26", 0 ]
 								}
@@ -2609,6 +2858,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-27", 0 ]
 								}
 
@@ -2616,6 +2867,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-29", 0 ]
 								}
 
@@ -2623,6 +2876,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-12", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -2630,6 +2885,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-36", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-31", 0 ]
 								}
 
@@ -2637,6 +2894,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-32", 0 ]
 								}
@@ -2645,6 +2903,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-33", 0 ]
 								}
 
@@ -2652,6 +2912,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-39", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-34", 0 ]
 								}
 
@@ -2659,6 +2921,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-34", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-36", 0 ]
 								}
 
@@ -2666,6 +2930,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-39", 0 ]
 								}
 
@@ -2673,6 +2939,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -2680,6 +2948,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-28", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-42", 0 ]
 								}
@@ -2688,6 +2957,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-42", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-43", 0 ]
 								}
@@ -2696,6 +2966,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-49", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-45", 0 ]
 								}
 
@@ -2703,6 +2975,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-46", 0 ]
 								}
@@ -2711,6 +2984,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-48", 0 ]
 								}
@@ -2719,6 +2993,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-5", 0 ]
 								}
 
@@ -2726,6 +3002,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-50", 0 ]
 								}
@@ -2734,6 +3011,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-52", 0 ]
 								}
 
@@ -2741,6 +3020,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-53", 0 ]
 								}
 
@@ -2748,6 +3029,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-56", 0 ]
 								}
@@ -2756,6 +3038,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-58", 0 ]
 								}
@@ -2764,6 +3047,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-59", 0 ]
 								}
@@ -2772,6 +3056,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-6", 0 ]
 								}
 
@@ -2779,6 +3065,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-60", 0 ]
 								}
@@ -2787,6 +3074,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-62", 0 ]
 								}
@@ -2795,6 +3083,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-63", 0 ]
 								}
@@ -2803,6 +3092,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-67", 0 ]
 								}
@@ -2811,6 +3101,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-68", 0 ]
 								}
@@ -2819,6 +3110,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-7", 0 ]
 								}
 
@@ -2826,6 +3119,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-70", 0 ]
 								}
@@ -2834,6 +3128,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-71", 0 ]
 								}
@@ -2842,6 +3137,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-72", 0 ]
 								}
@@ -2850,6 +3146,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-73", 0 ]
 								}
 
@@ -2857,6 +3155,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-76", 0 ]
 								}
@@ -2865,6 +3164,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -2872,6 +3173,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-83", 0 ]
 								}
@@ -2880,6 +3182,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-83", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-89", 0 ]
 								}
 
@@ -2887,6 +3191,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"source" : [ "obj-9", 0 ]
 								}
@@ -2914,9 +3219,10 @@
 , 							{
 								"name" : "Luca",
 								"default" : 								{
-									"fontname" : [ "Open Sans Semibold" ],
-									"selectioncolor" : [ 0.720698, 0.16723, 0.080014, 1.0 ],
 									"textcolor_inverse" : [ 0.239216, 0.254902, 0.278431, 1.0 ],
+									"accentcolor" : [ 0.32549, 0.345098, 0.372549, 1.0 ],
+									"elementcolor" : [ 0.786675, 0.801885, 0.845022, 1.0 ],
+									"fontname" : [ "Open Sans Semibold" ],
 									"bgfillcolor" : 									{
 										"type" : "gradient",
 										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
@@ -2927,10 +3233,9 @@
 										"autogradient" : 0
 									}
 ,
-									"accentcolor" : [ 0.32549, 0.345098, 0.372549, 1.0 ],
 									"color" : [ 0.475135, 0.293895, 0.251069, 1.0 ],
-									"bgcolor" : [ 0.904179, 0.895477, 0.842975, 0.56 ],
-									"elementcolor" : [ 0.786675, 0.801885, 0.845022, 1.0 ]
+									"selectioncolor" : [ 0.720698, 0.16723, 0.080014, 1.0 ],
+									"bgcolor" : [ 0.904179, 0.895477, 0.842975, 0.56 ]
 								}
 ,
 								"parentstyle" : "",
@@ -2949,8 +3254,11 @@
 , 							{
 								"name" : "WTF",
 								"default" : 								{
-									"fontname" : [ "HydrogenType" ],
 									"patchlinecolor" : [ 0.231373, 0.121569, 0.305882, 0.9 ],
+									"accentcolor" : [ 0.50764, 0.065317, 0.112129, 1.0 ],
+									"elementcolor" : [ 0.461105, 0.492646, 0.591878, 1.0 ],
+									"fontsize" : [ 18.0 ],
+									"fontname" : [ "HydrogenType" ],
 									"bgfillcolor" : 									{
 										"type" : "gradient",
 										"color" : [ 0.290196, 0.309804, 0.301961, 1.0 ],
@@ -2961,11 +3269,8 @@
 										"autogradient" : 0
 									}
 ,
-									"accentcolor" : [ 0.50764, 0.065317, 0.112129, 1.0 ],
-									"fontsize" : [ 18.0 ],
 									"color" : [ 0.113725, 0.580392, 0.737255, 1.0 ],
-									"bgcolor" : [ 0.163647, 0.174699, 0.17409, 1.0 ],
-									"elementcolor" : [ 0.461105, 0.492646, 0.591878, 1.0 ]
+									"bgcolor" : [ 0.163647, 0.174699, 0.17409, 1.0 ]
 								}
 ,
 								"parentstyle" : "",
@@ -2974,9 +3279,11 @@
 , 							{
 								"name" : "classic",
 								"default" : 								{
-									"fontname" : [ "Geneva" ],
 									"textcolor_inverse" : [ 0.0, 0.0, 0.0, 1.0 ],
 									"patchlinecolor" : [ 0.0, 0.0, 0.0, 1.0 ],
+									"accentcolor" : [ 0.498039, 0.498039, 0.498039, 1.0 ],
+									"fontsize" : [ 9.0 ],
+									"fontname" : [ "Geneva" ],
 									"bgfillcolor" : 									{
 										"type" : "color",
 										"color1" : [ 0.83978, 0.839941, 0.839753, 1.0 ],
@@ -2986,8 +3293,6 @@
 										"proportion" : 0.39
 									}
 ,
-									"accentcolor" : [ 0.498039, 0.498039, 0.498039, 1.0 ],
-									"fontsize" : [ 9.0 ],
 									"color" : [ 0.498039, 0.498039, 0.498039, 1.0 ],
 									"bgcolor" : [ 0.83978, 0.839941, 0.839753, 1.0 ]
 								}
@@ -3043,10 +3348,10 @@
 , 							{
 								"name" : "classicKslider",
 								"default" : 								{
-									"selectioncolor" : [ 0.498039, 0.498039, 0.498039, 1.0 ],
+									"elementcolor" : [ 0.498039, 0.498039, 0.498039, 1.0 ],
 									"color" : [ 1.0, 1.0, 1.0, 1.0 ],
-									"bgcolor" : [ 0.0, 0.0, 0.0, 1.0 ],
-									"elementcolor" : [ 0.498039, 0.498039, 0.498039, 1.0 ]
+									"selectioncolor" : [ 0.498039, 0.498039, 0.498039, 1.0 ],
+									"bgcolor" : [ 0.0, 0.0, 0.0, 1.0 ]
 								}
 ,
 								"parentstyle" : "",
@@ -3055,8 +3360,8 @@
 , 							{
 								"name" : "classicLed",
 								"default" : 								{
-									"color" : [ 1.0, 0.0, 0.0, 1.0 ],
-									"elementcolor" : [ 0.6, 0.0, 0.0, 1.0 ]
+									"elementcolor" : [ 0.6, 0.0, 0.0, 1.0 ],
+									"color" : [ 1.0, 0.0, 0.0, 1.0 ]
 								}
 ,
 								"parentstyle" : "",
@@ -3074,8 +3379,8 @@
 , 							{
 								"name" : "classicMeter~",
 								"default" : 								{
-									"bgcolor" : [ 0.380392, 0.380392, 0.380392, 1.0 ],
-									"elementcolor" : [ 0.498039, 0.498039, 0.498039, 1.0 ]
+									"elementcolor" : [ 0.498039, 0.498039, 0.498039, 1.0 ],
+									"bgcolor" : [ 0.380392, 0.380392, 0.380392, 1.0 ]
 								}
 ,
 								"parentstyle" : "",
@@ -3084,9 +3389,9 @@
 , 							{
 								"name" : "classicNodes",
 								"default" : 								{
+									"elementcolor" : [ 0.498039, 0.498039, 0.498039, 1.0 ],
 									"fontsize" : [ 9.0 ],
-									"color" : [ 0.839216, 0.839216, 0.839216, 1.0 ],
-									"elementcolor" : [ 0.498039, 0.498039, 0.498039, 1.0 ]
+									"color" : [ 0.839216, 0.839216, 0.839216, 1.0 ]
 								}
 ,
 								"parentstyle" : "",
@@ -3141,8 +3446,8 @@
 , 							{
 								"name" : "classicTab",
 								"default" : 								{
-									"color" : [ 0.498039, 0.498039, 0.498039, 1.0 ],
-									"elementcolor" : [ 0.839216, 0.839216, 0.839216, 1.0 ]
+									"elementcolor" : [ 0.839216, 0.839216, 0.839216, 1.0 ],
+									"color" : [ 0.498039, 0.498039, 0.498039, 1.0 ]
 								}
 ,
 								"parentstyle" : "",
@@ -3161,8 +3466,8 @@
 , 							{
 								"name" : "classicToggle",
 								"default" : 								{
-									"color" : [ 0.380392, 0.380392, 0.380392, 1.0 ],
-									"elementcolor" : [ 0.376471, 0.384314, 0.4, 0.0 ]
+									"elementcolor" : [ 0.376471, 0.384314, 0.4, 0.0 ],
+									"color" : [ 0.380392, 0.380392, 0.380392, 1.0 ]
 								}
 ,
 								"parentstyle" : "",
@@ -3180,8 +3485,8 @@
 , 							{
 								"name" : "classicWaveform~",
 								"default" : 								{
-									"selectioncolor" : [ 0.498039, 0.498039, 0.498039, 0.5 ],
-									"color" : [ 0.380392, 0.380392, 0.380392, 1.0 ]
+									"color" : [ 0.380392, 0.380392, 0.380392, 1.0 ],
+									"selectioncolor" : [ 0.498039, 0.498039, 0.498039, 0.5 ]
 								}
 ,
 								"parentstyle" : "",
@@ -3190,7 +3495,9 @@
 , 							{
 								"name" : "dark-night-patch",
 								"default" : 								{
+									"textcolor" : [ 0.862745, 0.870588, 0.878431, 1.0 ],
 									"patchlinecolor" : [ 0.439216, 0.74902, 0.254902, 0.898039 ],
+									"accentcolor" : [ 0.952941, 0.564706, 0.098039, 1.0 ],
 									"bgfillcolor" : 									{
 										"type" : "gradient",
 										"color1" : [ 0.376471, 0.384314, 0.4, 1.0 ],
@@ -3199,9 +3506,7 @@
 										"angle" : 270.0,
 										"proportion" : 0.39
 									}
-,
-									"textcolor" : [ 0.862745, 0.870588, 0.878431, 1.0 ],
-									"accentcolor" : [ 0.952941, 0.564706, 0.098039, 1.0 ]
+
 								}
 ,
 								"parentstyle" : "",
@@ -3215,9 +3520,10 @@
 , 							{
 								"name" : "jpatcher002",
 								"default" : 								{
-									"fontname" : [ "Ableton Sans Book" ],
-									"clearcolor" : [ 0.32549, 0.345098, 0.372549, 0.0 ],
 									"patchlinecolor" : [ 0.65098, 0.65098, 0.65098, 0.0 ],
+									"clearcolor" : [ 0.32549, 0.345098, 0.372549, 0.0 ],
+									"fontsize" : [ 9.5 ],
+									"fontname" : [ "Ableton Sans Book" ],
 									"bgfillcolor" : 									{
 										"type" : "color",
 										"color1" : [ 0.32549, 0.345098, 0.372549, 0.0 ],
@@ -3226,8 +3532,7 @@
 										"angle" : 270.0,
 										"proportion" : 0.39
 									}
-,
-									"fontsize" : [ 9.5 ]
+
 								}
 ,
 								"parentstyle" : "",
@@ -3236,9 +3541,11 @@
 , 							{
 								"name" : "jpink",
 								"default" : 								{
-									"clearcolor" : [ 0.113725, 0.607843, 0.607843, 1.0 ],
-									"selectioncolor" : [ 0.619608, 0.0, 0.360784, 1.0 ],
+									"textcolor" : [ 0.619608, 0.0, 0.360784, 1.0 ],
 									"patchlinecolor" : [ 0.65, 0.65, 0.65, 1.0 ],
+									"clearcolor" : [ 0.113725, 0.607843, 0.607843, 1.0 ],
+									"accentcolor" : [ 0.619608, 0.0, 0.360784, 1.0 ],
+									"elementcolor" : [ 0.619608, 0.0, 0.360784, 1.0 ],
 									"bgfillcolor" : 									{
 										"type" : "color",
 										"color" : [ 0.619608, 0.0, 0.360784, 1.0 ],
@@ -3249,11 +3556,9 @@
 										"autogradient" : 0
 									}
 ,
-									"textcolor" : [ 0.619608, 0.0, 0.360784, 1.0 ],
-									"accentcolor" : [ 0.619608, 0.0, 0.360784, 1.0 ],
 									"color" : [ 0.619608, 0.0, 0.360784, 1.0 ],
-									"bgcolor" : [ 0.862745, 0.870588, 0.878431, 1.0 ],
-									"elementcolor" : [ 0.619608, 0.0, 0.360784, 1.0 ]
+									"selectioncolor" : [ 0.619608, 0.0, 0.360784, 1.0 ],
+									"bgcolor" : [ 0.862745, 0.870588, 0.878431, 1.0 ]
 								}
 ,
 								"parentstyle" : "",
@@ -3271,8 +3576,8 @@
 , 							{
 								"name" : "lightbutton",
 								"default" : 								{
-									"bgcolor" : [ 0.309495, 0.299387, 0.299789, 1.0 ],
-									"elementcolor" : [ 0.654902, 0.572549, 0.376471, 1.0 ]
+									"elementcolor" : [ 0.654902, 0.572549, 0.376471, 1.0 ],
+									"bgcolor" : [ 0.309495, 0.299387, 0.299789, 1.0 ]
 								}
 ,
 								"parentstyle" : "",
@@ -3412,9 +3717,9 @@
 , 							{
 								"name" : "tastefultoggle",
 								"default" : 								{
+									"elementcolor" : [ 0.654902, 0.572549, 0.376471, 1.0 ],
 									"color" : [ 0.941176, 0.690196, 0.196078, 1.0 ],
-									"bgcolor" : [ 0.287863, 0.333333, 0.329398, 1.0 ],
-									"elementcolor" : [ 0.654902, 0.572549, 0.376471, 1.0 ]
+									"bgcolor" : [ 0.287863, 0.333333, 0.329398, 1.0 ]
 								}
 ,
 								"parentstyle" : "",
@@ -3433,31 +3738,29 @@
 , 							{
 								"name" : "whitey",
 								"default" : 								{
-									"fontname" : [ "Dirty Ego" ],
-									"selectioncolor" : [ 0.011765, 0.396078, 0.752941, 1.0 ],
 									"textcolor_inverse" : [ 0.65098, 0.666667, 0.662745, 1.0 ],
 									"patchlinecolor" : [ 0.199068, 0.062496, 0.060031, 0.9 ],
-									"fontsize" : [ 36.0 ]
+									"fontsize" : [ 36.0 ],
+									"fontname" : [ "Dirty Ego" ],
+									"selectioncolor" : [ 0.011765, 0.396078, 0.752941, 1.0 ]
 								}
 ,
 								"parentstyle" : "",
 								"multi" : 0
 							}
- ],
-						"bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
-						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ]
+ ]
 					}
 ,
 					"patching_rect" : [ 33.0, 163.0, 60.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
-						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
 						"globalpatchername" : "",
-						"locked_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
+						"style" : "",
 						"tags" : ""
 					}
 ,
+					"style" : "",
 					"text" : "p outputs",
 					"varname" : "basic_tab[3]"
 				}
@@ -3472,15 +3775,16 @@
 					"patcher" : 					{
 						"fileversion" : 1,
 						"appversion" : 						{
-							"major" : 8,
+							"major" : 7,
 							"minor" : 0,
-							"revision" : 3,
+							"revision" : 6,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
-						"classnamespace" : "box",
 						"rect" : [ 0.0, 26.0, 2158.0, 1372.0 ],
+						"bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
+						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -3510,26 +3814,14 @@
 						"showontab" : 1,
 						"boxes" : [ 							{
 								"box" : 								{
-									"id" : "obj-20",
-									"linecount" : 2,
-									"maxclass" : "message",
-									"numinlets" : 2,
-									"numoutlets" : 1,
-									"outlettype" : [ "" ],
-									"patching_rect" : [ 401.0, 436.0, 105.0, 35.0 ],
-									"text" : "ret_cv 1 -0.081575"
-								}
-
-							}
-, 							{
-								"box" : 								{
 									"id" : "obj-17",
 									"maxclass" : "message",
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 30.000008000000001, 323.0, 54.0, 22.0 ],
-									"text" : "get_cv 1"
+									"patching_rect" : [ 30.000008, 323.0, 70.0, 22.0 ],
+									"style" : "",
+									"text" : "get_input 1"
 								}
 
 							}
@@ -3540,7 +3832,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 75.5, 659.50006103515625, 84.0, 22.0 ],
+									"patching_rect" : [ 75.5, 659.500061, 84.0, 22.0 ],
+									"style" : "",
 									"text" : "-25481.96"
 								}
 
@@ -3552,6 +3845,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 38.0, 593.5, 93.0, 20.0 ],
+									"style" : "",
 									"text" : "'none' / 'stream'"
 								}
 
@@ -3565,8 +3859,9 @@
 									"orientation" : 0,
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 162.0, 658.50006099999996, 86.0, 23.5 ],
-									"setminmax" : [ -5.0, 10.0 ]
+									"patching_rect" : [ 162.0, 658.500061, 86.0, 23.5 ],
+									"setminmax" : [ -5.0, 10.0 ],
+									"style" : ""
 								}
 
 							}
@@ -3579,8 +3874,9 @@
 									"orientation" : 0,
 									"outlettype" : [ "", "" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 140.0, 626.00006099999996, 86.0, 23.5 ],
-									"setminmax" : [ -5.0, 10.0 ]
+									"patching_rect" : [ 140.0, 626.000061, 86.0, 23.5 ],
+									"setminmax" : [ -5.0, 10.0 ],
+									"style" : ""
 								}
 
 							}
@@ -3591,7 +3887,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 54.0, 625.50006103515625, 84.0, 22.0 ],
+									"patching_rect" : [ 54.0, 625.500061, 84.0, 22.0 ],
+									"style" : "",
 									"text" : "-0.081575"
 								}
 
@@ -3602,7 +3899,8 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 414.0, 614.5, 54.0, 20.0 ],
+									"patching_rect" : [ 287.0, 588.5, 54.0, 20.0 ],
+									"style" : "",
 									"text" : "'change'"
 								}
 
@@ -3613,7 +3911,8 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 49.0, 658.50006099999996, 19.0, 20.0 ],
+									"patching_rect" : [ 49.0, 658.500061, 19.0, 20.0 ],
+									"style" : "",
 									"text" : "2"
 								}
 
@@ -3624,7 +3923,8 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 30.000008000000001, 625.50006099999996, 19.0, 20.0 ],
+									"patching_rect" : [ 30.000008, 625.500061, 19.0, 20.0 ],
+									"style" : "",
 									"text" : "1"
 								}
 
@@ -3636,8 +3936,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 389.0, 654.50006099999996, 24.0, 24.0 ]
+									"patching_rect" : [ 339.0, 654.500061, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -3648,8 +3948,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "bang" ],
-									"parameter_enable" : 0,
-									"patching_rect" : [ 363.0, 621.50006099999996, 24.0, 24.0 ]
+									"patching_rect" : [ 313.0, 621.500061, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -3661,7 +3961,8 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 363.0, 654.50006099999996, 24.0, 24.0 ]
+									"patching_rect" : [ 313.0, 654.500061, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -3673,7 +3974,8 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 337.0, 621.50006099999996, 24.0, 24.0 ]
+									"patching_rect" : [ 287.0, 621.500061, 24.0, 24.0 ],
+									"style" : ""
 								}
 
 							}
@@ -3684,7 +3986,8 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 352.0, 511.0, 56.0, 22.0 ],
+									"patching_rect" : [ 302.0, 511.0, 56.0, 22.0 ],
+									"style" : "",
 									"text" : "route 1 2"
 								}
 
@@ -3697,6 +4000,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "" ],
 									"patching_rect" : [ 140.0, 511.0, 56.0, 22.0 ],
+									"style" : "",
 									"text" : "route 1 2"
 								}
 
@@ -3708,8 +4012,9 @@
 									"numinlets" : 3,
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "" ],
-									"patching_rect" : [ 140.0, 465.0, 443.0, 22.0 ],
-									"text" : "route ret_cv change_cv"
+									"patching_rect" : [ 140.0, 465.0, 343.0, 22.0 ],
+									"style" : "",
+									"text" : "route stream change"
 								}
 
 							}
@@ -3721,6 +4026,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 140.0, 421.0, 137.0, 22.0 ],
+									"style" : "",
 									"text" : "r commands_from_crow"
 								}
 
@@ -3732,6 +4038,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 140.0, 363.0, 125.0, 22.0 ],
+									"style" : "",
 									"text" : "s commands_to_crow"
 								}
 
@@ -3744,6 +4051,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 744.0, 257.0, 182.0, 22.0 ],
+									"style" : "",
 									"text" : "\"input[1].mode('change',  1, 0.1)\""
 								}
 
@@ -3757,6 +4065,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 422.0, 188.0, 128.0, 89.0 ],
+									"style" : "",
 									"text" : "\"input[2]{\n    mode = 'change' ,\n    threshold = 1.5 ,\n    hysteresis = 0.1 ,\n    direction = 'falling'\n}\""
 								}
 
@@ -3770,6 +4079,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 278.0, 188.0, 128.0, 89.0 ],
+									"style" : "",
 									"text" : "\"input[2]{\n    mode = 'change' ,\n    threshold = 1.5 ,\n    hysteresis = 0.1 ,\n    direction = 'rising'\n}\""
 								}
 
@@ -3782,7 +4092,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 140.0, 215.0, 110.0, 62.0 ],
+									"patching_rect" : [ 140.0, 215.0, 113.0, 62.0 ],
+									"style" : "",
 									"text" : "\"input[1]{ \n   mode = 'stream' ,\n   time = 0.05\n}\""
 								}
 
@@ -3795,6 +4106,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 566.0, 257.0, 162.0, 22.0 ],
+									"style" : "",
 									"text" : "\"input[1].mode('stream', 0.1)\""
 								}
 
@@ -3808,6 +4120,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 988.0, 243.0, 136.0, 35.0 ],
+									"style" : "",
 									"text" : "\"input[1].mode('none')\n input[2].mode('none')\""
 								}
 
@@ -3820,6 +4133,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 140.0, 323.0, 103.0, 22.0 ],
+									"style" : "",
 									"text" : "prepend tell_crow"
 								}
 
@@ -3843,16 +4157,9 @@
  ],
 						"lines" : [ 							{
 								"patchline" : 								{
-									"destination" : [ "obj-20", 1 ],
-									"order" : 0,
-									"source" : [ "obj-1", 0 ]
-								}
-
-							}
-, 							{
-								"patchline" : 								{
 									"destination" : [ "obj-4", 0 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-1", 0 ]
 								}
 
@@ -3860,6 +4167,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-10", 0 ]
 								}
 
@@ -3867,7 +4176,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-14", 1 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-11", 0 ]
 								}
 
@@ -3875,7 +4185,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-15", 1 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-11", 1 ]
 								}
 
@@ -3883,7 +4194,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-62", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-11", 0 ]
 								}
 
@@ -3891,7 +4203,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-63", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-11", 1 ]
 								}
 
@@ -3899,7 +4212,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-52", 0 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-13", 0 ]
 								}
 
@@ -3907,7 +4221,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-53", 0 ],
-									"order" : 1,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-13", 1 ]
 								}
 
@@ -3915,7 +4230,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-55", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-13", 0 ]
 								}
 
@@ -3923,7 +4239,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-61", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-13", 1 ]
 								}
 
@@ -3931,6 +4248,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-12", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-17", 0 ]
 								}
 
@@ -3938,6 +4257,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-12", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-3", 0 ]
 								}
 
@@ -3945,6 +4266,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-11", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -3952,6 +4275,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-13", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-4", 1 ]
 								}
 
@@ -3959,6 +4284,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-5", 0 ]
 								}
 
@@ -3966,6 +4293,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-6", 0 ]
 								}
 
@@ -3973,6 +4302,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-7", 0 ]
 								}
 
@@ -3980,6 +4311,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-8", 0 ]
 								}
 
@@ -3987,25 +4320,25 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-3", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-9", 0 ]
 								}
 
 							}
- ],
-						"bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
-						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ]
+ ]
 					}
 ,
 					"patching_rect" : [ 26.0, 134.0, 53.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
-						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
 						"globalpatchername" : "",
-						"locked_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
+						"style" : "",
 						"tags" : ""
 					}
 ,
+					"style" : "",
 					"text" : "p inputs",
 					"varname" : "basic_tab[2]"
 				}
@@ -4026,6 +4359,7 @@
 						"parameter_enable" : 0
 					}
 ,
+					"style" : "",
 					"text" : "js helpstarter crow"
 				}
 
@@ -4039,15 +4373,16 @@
 					"patcher" : 					{
 						"fileversion" : 1,
 						"appversion" : 						{
-							"major" : 8,
+							"major" : 7,
 							"minor" : 0,
-							"revision" : 3,
+							"revision" : 6,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
-						"classnamespace" : "box",
 						"rect" : [ 0.0, 26.0, 2158.0, 1372.0 ],
+						"bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
+						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
 						"default_fontsize" : 12.0,
@@ -4083,6 +4418,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 390.0, 569.0, 90.0, 22.0 ],
+									"style" : "",
 									"text" : "s crow_printout"
 								}
 
@@ -4096,9 +4432,10 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 794.0, 353.5, 286.0, 25.0 ],
+									"patching_rect" : [ 822.0, 353.5, 286.0, 25.0 ],
+									"style" : "",
 									"text" : "send Lua chunk to be immediately executed",
-									"textcolor" : [ 0.50196099281311, 0.50196099281311, 0.50196099281311, 1.0 ]
+									"textcolor" : [ 0.501961, 0.501961, 0.501961, 1.0 ]
 								}
 
 							}
@@ -4112,8 +4449,9 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 165.0, 508.0, 294.0, 25.0 ],
+									"style" : "",
 									"text" : "doubleclick to open port selection if necessary ",
-									"textcolor" : [ 0.50196099281311, 0.50196099281311, 0.50196099281311, 1.0 ]
+									"textcolor" : [ 0.501961, 0.501961, 0.501961, 1.0 ]
 								}
 
 							}
@@ -4125,6 +4463,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 109.0, 735.0, 139.0, 22.0 ],
+									"style" : "",
 									"text" : "s commands_from_crow"
 								}
 
@@ -4138,9 +4477,10 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 385.0, 569.0, 257.0, 25.0 ],
+									"patching_rect" : [ 488.5, 569.0, 257.0, 25.0 ],
+									"style" : "",
 									"text" : "Printout results of Lua print() commands",
-									"textcolor" : [ 0.50196099281311, 0.50196099281311, 0.50196099281311, 1.0 ]
+									"textcolor" : [ 0.501961, 0.501961, 0.501961, 1.0 ]
 								}
 
 							}
@@ -4152,8 +4492,9 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 8.0, 676.0, 107.0, 35.0 ],
-									"text" : "ret_cv 1 -0.081575"
+									"patching_rect" : [ 8.0, 676.0, 79.0, 35.0 ],
+									"style" : "",
+									"text" : "stream 1 -0.081575"
 								}
 
 							}
@@ -4166,9 +4507,10 @@
 									"maxclass" : "comment",
 									"numinlets" : 1,
 									"numoutlets" : 0,
-									"patching_rect" : [ 842.0, 292.0, 286.0, 25.0 ],
+									"patching_rect" : [ 870.0, 292.0, 286.0, 25.0 ],
+									"style" : "",
 									"text" : "send Lua chunk to be immediately executed",
-									"textcolor" : [ 0.50196099281311, 0.50196099281311, 0.50196099281311, 1.0 ]
+									"textcolor" : [ 0.501961, 0.501961, 0.501961, 1.0 ]
 								}
 
 							}
@@ -4182,8 +4524,9 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 128.0, 676.0, 254.0, 25.0 ],
+									"style" : "",
 									"text" : "receive formatted commands from crow",
-									"textcolor" : [ 0.50196099281311, 0.50196099281311, 0.50196099281311, 1.0 ]
+									"textcolor" : [ 0.501961, 0.501961, 0.501961, 1.0 ]
 								}
 
 							}
@@ -4196,6 +4539,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 8.0, 438.0, 123.0, 22.0 ],
+									"style" : "",
 									"text" : "r commands_to_crow"
 								}
 
@@ -4209,7 +4553,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 227.0, 645.0, 88.0, 22.0 ]
+									"patching_rect" : [ 227.0, 645.0, 88.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -4222,7 +4567,8 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "bang" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 128.0, 645.0, 88.0, 22.0 ]
+									"patching_rect" : [ 128.0, 645.0, 88.0, 22.0 ],
+									"style" : ""
 								}
 
 							}
@@ -4233,8 +4579,9 @@
 									"numinlets" : 2,
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
-									"patching_rect" : [ 128.0, 569.0, 72.0, 22.0 ],
-									"text" : "route ret_cv"
+									"patching_rect" : [ 128.0, 569.0, 78.0, 22.0 ],
+									"style" : "",
+									"text" : "route stream"
 								}
 
 							}
@@ -4245,6 +4592,7 @@
 									"numinlets" : 1,
 									"numoutlets" : 0,
 									"patching_rect" : [ 212.0, 569.0, 168.0, 22.0 ],
+									"style" : "",
 									"text" : "print crow_printout @popup 1"
 								}
 
@@ -4256,8 +4604,9 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 547.0, 299.0, 79.0, 22.0 ],
-									"text" : "printversion()"
+									"patching_rect" : [ 575.0, 299.0, 84.0, 22.0 ],
+									"style" : "",
+									"text" : "^^printversion"
 								}
 
 							}
@@ -4268,7 +4617,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 714.0, 355.0, 73.0, 22.0 ],
+									"patching_rect" : [ 742.0, 355.0, 73.0, 22.0 ],
+									"style" : "",
 									"text" : "helloWorld()"
 								}
 
@@ -4281,7 +4631,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 714.0, 280.0, 134.0, 49.0 ],
+									"patching_rect" : [ 742.0, 280.0, 134.0, 49.0 ],
+									"style" : "",
 									"text" : "\"function helloWorld()\n  print('squawk')\nend\""
 								}
 
@@ -4294,6 +4645,7 @@
 									"numoutlets" : 2,
 									"outlettype" : [ "", "" ],
 									"patching_rect" : [ 128.0, 508.0, 34.0, 22.0 ],
+									"style" : "",
 									"text" : "crow"
 								}
 
@@ -4305,7 +4657,8 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 339.0, 299.0, 162.0, 22.0 ],
+									"patching_rect" : [ 367.0, 299.0, 162.0, 22.0 ],
+									"style" : "",
 									"text" : "tell_crow \"print('Caw! Caw!')\""
 								}
 
@@ -4317,7 +4670,8 @@
 									"numinlets" : 1,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 547.0, 414.0, 103.0, 22.0 ],
+									"patching_rect" : [ 575.0, 414.0, 103.0, 22.0 ],
+									"style" : "",
 									"text" : "prepend tell_crow"
 								}
 
@@ -4330,6 +4684,7 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "" ],
 									"patching_rect" : [ 128.0, 608.0, 217.0, 22.0 ],
+									"style" : "",
 									"text" : "route 1 2"
 								}
 
@@ -4342,6 +4697,7 @@
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
 									"patching_rect" : [ 128.0, 299.0, 51.0, 22.0 ],
+									"style" : "",
 									"text" : "connect"
 								}
 
@@ -4353,8 +4709,9 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 261.0, 299.0, 54.0, 22.0 ],
-									"text" : "get_cv 2"
+									"patching_rect" : [ 280.0, 299.0, 70.0, 22.0 ],
+									"style" : "",
+									"text" : "get_input 2"
 								}
 
 							}
@@ -4365,8 +4722,9 @@
 									"numinlets" : 2,
 									"numoutlets" : 1,
 									"outlettype" : [ "" ],
-									"patching_rect" : [ 194.0, 299.0, 54.0, 22.0 ],
-									"text" : "get_cv 1"
+									"patching_rect" : [ 194.0, 299.0, 70.0, 22.0 ],
+									"style" : "",
+									"text" : "get_input 1"
 								}
 
 							}
@@ -4400,8 +4758,9 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 689.0, 355.0, 20.0, 20.0 ],
+									"patching_rect" : [ 717.0, 355.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
+									"style" : "",
 									"text" : "6",
 									"textcolor" : [ 0.2, 0.2, 0.2, 1.0 ]
 								}
@@ -4421,8 +4780,9 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 689.0, 280.0, 20.0, 20.0 ],
+									"patching_rect" : [ 717.0, 280.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
+									"style" : "",
 									"text" : "5",
 									"textcolor" : [ 0.2, 0.2, 0.2, 1.0 ]
 								}
@@ -4442,8 +4802,9 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 525.0, 299.0, 20.0, 20.0 ],
+									"patching_rect" : [ 553.0, 299.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
+									"style" : "",
 									"text" : "4",
 									"textcolor" : [ 0.2, 0.2, 0.2, 1.0 ]
 								}
@@ -4463,8 +4824,9 @@
 									"numoutlets" : 3,
 									"outlettype" : [ "", "", "int" ],
 									"parameter_enable" : 0,
-									"patching_rect" : [ 339.0, 271.0, 20.0, 20.0 ],
+									"patching_rect" : [ 367.0, 271.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
+									"style" : "",
 									"text" : "3",
 									"textcolor" : [ 0.2, 0.2, 0.2, 1.0 ]
 								}
@@ -4486,6 +4848,7 @@
 									"parameter_enable" : 0,
 									"patching_rect" : [ 194.0, 271.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
+									"style" : "",
 									"text" : "2",
 									"textcolor" : [ 0.2, 0.2, 0.2, 1.0 ]
 								}
@@ -4507,6 +4870,7 @@
 									"parameter_enable" : 0,
 									"patching_rect" : [ 128.0, 271.0, 20.0, 20.0 ],
 									"rounded" : 60.0,
+									"style" : "",
 									"text" : "1",
 									"textcolor" : [ 0.2, 0.2, 0.2, 1.0 ]
 								}
@@ -4516,7 +4880,9 @@
 						"lines" : [ 							{
 								"patchline" : 								{
 									"destination" : [ "obj-14", 0 ],
-									"midpoints" : [ 556.5, 495.0, 137.5, 495.0 ],
+									"disabled" : 0,
+									"hidden" : 0,
+									"midpoints" : [ 584.5, 495.0, 137.5, 495.0 ],
 									"source" : [ "obj-1", 0 ]
 								}
 
@@ -4524,6 +4890,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-20", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-10", 0 ]
 								}
 
@@ -4531,6 +4899,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-23", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-10", 1 ]
 								}
 
@@ -4538,7 +4908,9 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 723.5, 330.0, 637.0, 330.0, 637.0, 399.0, 556.5, 399.0 ],
+									"disabled" : 0,
+									"hidden" : 0,
+									"midpoints" : [ 751.5, 330.0, 665.0, 330.0, 665.0, 399.0, 584.5, 399.0 ],
 									"source" : [ "obj-12", 0 ]
 								}
 
@@ -4546,7 +4918,9 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 723.5, 399.0, 556.5, 399.0 ],
+									"disabled" : 0,
+									"hidden" : 0,
+									"midpoints" : [ 751.5, 399.0, 584.5, 399.0 ],
 									"source" : [ "obj-13", 0 ]
 								}
 
@@ -4554,7 +4928,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-18", 0 ],
-									"order" : 0,
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-14", 0 ]
 								}
 
@@ -4562,8 +4937,9 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-22", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 152.5, 555.0, 221.5, 555.0 ],
-									"order" : 1,
 									"source" : [ "obj-14", 1 ]
 								}
 
@@ -4571,8 +4947,9 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-24", 1 ],
-									"midpoints" : [ 137.5, 554.0, 105.5, 554.0 ],
-									"order" : 2,
+									"disabled" : 0,
+									"hidden" : 0,
+									"midpoints" : [ 137.5, 554.0, 77.5, 554.0 ],
 									"source" : [ "obj-14", 0 ]
 								}
 
@@ -4580,9 +4957,9 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-26", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"midpoints" : [ 137.5, 555.0, 118.5, 555.0 ],
-									"order" : 1,
 									"source" : [ "obj-14", 0 ]
 								}
 
@@ -4590,9 +4967,9 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-29", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"midpoints" : [ 152.5, 555.0, 399.5, 555.0 ],
-									"order" : 0,
 									"source" : [ "obj-14", 1 ]
 								}
 
@@ -4600,7 +4977,9 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-1", 0 ],
-									"midpoints" : [ 556.5, 324.0, 556.5, 324.0 ],
+									"disabled" : 0,
+									"hidden" : 0,
+									"midpoints" : [ 584.5, 324.0, 584.5, 324.0 ],
 									"source" : [ "obj-17", 0 ]
 								}
 
@@ -4608,6 +4987,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-10", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"source" : [ "obj-18", 0 ]
 								}
 
@@ -4615,6 +4996,8 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-14", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 203.5, 495.0, 137.5, 495.0 ],
 									"source" : [ "obj-3", 0 ]
 								}
@@ -4623,7 +5006,9 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-14", 0 ],
-									"midpoints" : [ 348.5, 495.0, 137.5, 495.0 ],
+									"disabled" : 0,
+									"hidden" : 0,
+									"midpoints" : [ 376.5, 495.0, 137.5, 495.0 ],
 									"source" : [ "obj-4", 0 ]
 								}
 
@@ -4631,6 +5016,7 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-14", 0 ],
+									"disabled" : 0,
 									"hidden" : 1,
 									"midpoints" : [ 17.5, 495.0, 137.5, 495.0 ],
 									"source" : [ "obj-5", 0 ]
@@ -4640,7 +5026,9 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-14", 0 ],
-									"midpoints" : [ 270.5, 495.0, 137.5, 495.0 ],
+									"disabled" : 0,
+									"hidden" : 0,
+									"midpoints" : [ 289.5, 495.0, 137.5, 495.0 ],
 									"source" : [ "obj-6", 0 ]
 								}
 
@@ -4648,26 +5036,26 @@
 , 							{
 								"patchline" : 								{
 									"destination" : [ "obj-14", 0 ],
+									"disabled" : 0,
+									"hidden" : 0,
 									"midpoints" : [ 137.5, 324.0, 137.5, 324.0 ],
 									"source" : [ "obj-8", 0 ]
 								}
 
 							}
- ],
-						"bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
-						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ]
+ ]
 					}
 ,
 					"patching_rect" : [ 4.0, 80.0, 50.0, 22.0 ],
 					"saved_object_attributes" : 					{
 						"description" : "",
 						"digest" : "",
-						"editing_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
 						"globalpatchername" : "",
-						"locked_bgcolor" : [ 1.0, 1.0, 1.0, 1.0 ],
+						"style" : "",
 						"tags" : ""
 					}
 ,
+					"style" : "",
 					"text" : "p basic",
 					"varname" : "basic_tab"
 				}
@@ -4685,7 +5073,7 @@
 					"numoutlets" : 1,
 					"outlettype" : [ "" ],
 					"parameter_enable" : 0,
-					"patching_rect" : [ 10.0, 10.0, 108.968002319335938, 57.600002288818359 ]
+					"patching_rect" : [ 10.0, 10.0, 108.968002, 57.600002 ]
 				}
 
 			}
@@ -4698,14 +5086,13 @@
 					"patcher" : 					{
 						"fileversion" : 1,
 						"appversion" : 						{
-							"major" : 8,
+							"major" : 7,
 							"minor" : 0,
-							"revision" : 3,
+							"revision" : 6,
 							"architecture" : "x64",
 							"modernui" : 1
 						}
 ,
-						"classnamespace" : "box",
 						"rect" : [ 0.0, 26.0, 2158.0, 1372.0 ],
 						"bglocked" : 0,
 						"openinpresentation" : 0,
@@ -4743,9 +5130,11 @@
 						"description" : "",
 						"digest" : "",
 						"globalpatchername" : "",
+						"style" : "",
 						"tags" : ""
 					}
 ,
+					"style" : "",
 					"text" : "p ?",
 					"varname" : "q_tab"
 				}
@@ -4767,22 +5156,19 @@
 			}
 , 			{
 				"name" : "crow.maxpat",
-				"bootpath" : "~/Dropbox/2019_crow/crow/max",
-				"patcherrelativepath" : "..",
+				"bootpath" : "~/dev/stm32f7/crow/max",
 				"type" : "JSON",
 				"implicit" : 1
 			}
 , 			{
 				"name" : "crowmax.lua",
-				"bootpath" : "~/Dropbox/2019_crow/crow/max",
-				"patcherrelativepath" : "..",
+				"bootpath" : "~/dev/stm32f7/crow/max",
 				"type" : "Jlua",
 				"implicit" : 1
 			}
 , 			{
 				"name" : "crowmax-test.lua",
-				"bootpath" : "~/Dropbox/2019_crow/crow/max",
-				"patcherrelativepath" : "..",
+				"bootpath" : "~/dev/stm32f7/crow/max",
 				"type" : "Jlua",
 				"implicit" : 1
 			}
@@ -4793,7 +5179,7 @@
 				"implicit" : 1
 			}
  ],
-		"autosave" : 0
+		"embedsnapshot" : 0
 	}
 
 }


### PR DESCRIPTION
updates the naming of 'ret_cv' to 'stream' etc
adds max messages in the test-harness for the new ^^version and ^^identity queries
cleans up a lot of testing junk from the test-harness
adds captured display of output queries

almost finishes #135 (m4l remaining).

these changes are currently untested.