### PR TITLE
change_handler now passes state as a bool

### DIFF
--- a/lua/input.lua
+++ b/lua/input.lua
@@ -107,7 +107,7 @@ setmetatable(Input, Input) -- capture the metamethods
 
 -- callback
 function stream_handler( chan, val ) Input.inputs[chan].stream( val ) end
-function change_handler( chan, val ) Input.inputs[chan].change( val ) end
+function change_handler( chan, val ) Input.inputs[chan].change( val ~= 0 ) end
 function midi_handler( ... ) d = {...}; Input.inputs[1].midi(d) end
 
 print 'input loaded'


### PR DESCRIPTION
fixes #143 

likely causes some new bugs in both monome/norns but also the max object