### PR TITLE
Fix bug caused by #149 in input[n].change default function

### DIFF
--- a/lua/input.lua
+++ b/lua/input.lua
@@ -20,7 +20,7 @@ function Input.new( chan )
               , ratios     = {}
         -- user-customizable events
               , stream     = function(value) _c.tell('stream',chan,value) end
-              , change     = function(state) _c.tell('change',chan,state) end
+              , change     = function(state) _c.tell('change',chan,state and 1 or 0) end
               , midi       = function(data) _c.tell('midi',table.unpack(data)) end
               , window     = function(ix, direction) get_cv(chan) end
               , scale      = function(octave, ix) get_cv(chan) end

--- a/lua/input.lua
+++ b/lua/input.lua
@@ -107,7 +107,7 @@ setmetatable(Input, Input) -- capture the metamethods
 
 -- callback
 function stream_handler( chan, val ) Input.inputs[chan].stream( val ) end
-function change_handler( chan, val ) Input.inputs[chan].change( val ) end
+function change_handler( chan, val ) Input.inputs[chan].change( val ~= 0 ) end
 function midi_handler( ... ) d = {...}; Input.inputs[1].midi(d) end
 
 print 'input loaded'


### PR DESCRIPTION
_c.tell lua function is not able to handle booleans directly. using the and/or lua idiom to convert a bool to a 1/0.

bonus is it means for crow standalone applications you get the nice boolean usage (eg. if _ then, or if not _ then) but norns & max remote application is unchanged.