### PR TITLE
lua's math.random now correctly follows the integer argument ranges

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -402,9 +402,18 @@ static int _metro_set_time( lua_State* L )
     return 0;
 }
 
-static int _random_get( lua_State* L )
+static int _random_float( lua_State* L )
 {
-    lua_pushnumber( L, Random_Get() );
+    lua_pushnumber( L, Random_Float() );
+    return 1;
+}
+
+static int _random_int( lua_State* L )
+{
+    int r = Random_Int( luaL_checknumber(L, 1)
+                      , luaL_checknumber(L, 2) );
+    lua_pop(L, 2);
+    lua_pushinteger( L, r);
     return 1;
 }
 
@@ -452,7 +461,8 @@ static const struct luaL_Reg libCrow[]=
     , { "metro_stop"       , _metro_stop       }
     , { "metro_set_time"   , _metro_set_time   }
         // random
-    , { "random_get"       , _random_get       }
+    , { "random_float"     , _random_float     }
+    , { "random_int"       , _random_int       }
         // calibration
     , { "calibrate_now"    , _calibrate_now    }
     , { "calibrate_print"  , _calibrate_print  }

--- a/ll/random.c
+++ b/ll/random.c
@@ -63,7 +63,7 @@ void HAL_RNG_ReadyDataCallback( RNG_HandleTypeDef* hr, uint32_t rand32 )
     }
 }
 
-float Random_Get(void)
+float Random_Float(void)
 {
     if( rrrCount <= 0 ){ printf("rng: underrun\n"); }
     float retval = rrrFm[rrrNext++];
@@ -72,6 +72,11 @@ float Random_Get(void)
         Random_Update();
     }
     return retval;
+}
+
+int Random_Int(int lower, int upper)
+{
+    return ((int)(Random_Float() * (float)(1 + upper - lower)) + lower);
 }
 
 void Random_Update(void)

--- a/ll/random.h
+++ b/ll/random.h
@@ -7,5 +7,6 @@
 void Random_Init(void);
 void Random_DeInit(void);
 
-float Random_Get(void);
+float Random_Float(void);
+int Random_Int(int lower, int upper);
 void Random_Update(void);

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -123,9 +123,9 @@ end
 --- True Random Number Generator
 -- redefine library function to use stm native rng
 math.random = function(a,b)
-    if a == nil then return random_get()
-    elseif b == nil then return random_get() * a
-    else return (b-a)*random_get() + a
+    if a == nil then return random_float()
+    elseif b == nil then return random_int(1,a)
+    else return random_int(a,b)
     end
 end
 


### PR DESCRIPTION
adds a C function to return a random int between 2 values inclusive.

fixes #142 