### PR TITLE
Bootloader quiet

### DIFF
--- a/main.c
+++ b/main.c
@@ -26,6 +26,7 @@ int main(void)
 
     // Drivers
     IO_Init();
+    IO_Start(); // must start IO before running lua init() script
     events_init();
     Metro_Init();
     Caw_Init();
@@ -35,7 +36,6 @@ int main(void)
 
     REPL_init( Lua_Init() );
 
-    IO_Start(); // must start IO before running lua init() script
     Lua_crowbegin();
 
 


### PR DESCRIPTION
This PR is about minimizing the behaviour where the outputs are stuck at 10V on bootup.

In crow itself, this runs `IO_Start()` as soon as `IO_Init()` is complete. This means the data will be zeroes for a couple hundred milliseconds, rather than staying at the 10V limit then jumping to the real data. Gets the 10V time down to <100ms.

Secondarily, the bootloader has been updated with the SPI driver for the DAC so it can set the outputs to 0V while doing the bootload process.

*nb: this requires `git submodule update` if you want to burn the current bootloader.*

fixes #150 