### PR TITLE
update dfu-util upload command to avoid error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ debug:
 	stlink-trace -c 216
 
 dfu: $(BIN)
-	sudo dfu-util -a 0 -s 0x08020000:leave -D $(BIN) -d ,0483:df11
+	sudo dfu-util -a 0 -s 0x08020000 -R -D $(BIN) -d ,0483:df11
 
 boot:
 	cd $(BOOTLOADER) && \

--- a/flash.sh
+++ b/flash.sh
@@ -1,1 +1,1 @@
-sudo dfu-util -a 0 -s 0x08020000:leave -D crow.bin -d 0483:df11
+sudo dfu-util -a 0 -s 0x08020000 -R -D crow.bin -d ,0483:df11


### PR DESCRIPTION
Needed to use a non DeFuSe command for the 'reset after upload'.

Annoyingly, the dfu command is now less "oh no it didn't work" but still not fantastic. reads like:
```
Download        [=========================] 100%       299692 bytes
Download done.
File downloaded successfully
dfu-util: can't detach
Resetting USB to switch back to runtime mode
```

Importantly, dfu-util no longer exits with an errorcode, so we could extend `flash.sh` to handle the errorcode & conditionally print a more user-friendly error/success message. Is that overkill?

For now I'm calling this one done.

fixes #128 