### PR TITLE
Refine calibration engine

### DIFF
--- a/ll/adda.c
+++ b/ll/adda.c
@@ -168,7 +168,7 @@ int CAL_ValidateData( void )
 uint8_t CAL_StepB( IO_block_t* b, float* value )
 {
     const float input_resistor = 100.0; // 100k
-    const float mux_resistor   = 0.33; // 330r
+    const float mux_resistor   = 0.33 + 0.135; // 330r + MUX508 internal r
     float resistor_scale = (input_resistor + mux_resistor)
                                     / input_resistor;
     if( cal.avg_count == AVERAGE_COUNT ){
@@ -189,7 +189,7 @@ uint8_t CAL_StepB( IO_block_t* b, float* value )
 uint8_t CAL_Step( IO_block_t* b, float* value )
 {
     const float input_resistor = 100.0; // 100k
-    const float mux_resistor   = 0.33; // 330r
+    const float mux_resistor   = 0.33 + 0.135; // 330r + MUX508 internal r
     float resistor_scale = (input_resistor + mux_resistor)
                                     / input_resistor;
     if( cal.avg_count == AVERAGE_COUNT ){

--- a/ll/adda.c
+++ b/ll/adda.c
@@ -228,7 +228,8 @@ IO_block_t* CAL_BlockProcess( IO_block_t* b )
             cal.adc[0].scale -= cal.adc[0].shift;
             cal.adc[0].scale  = vref / cal.adc[0].scale;
             ADC_CalibrateScalar( 0, cal.adc[0].scale );
-            ADC_CalibrateScalar( 1, cal.adc[0].scale ); // copy ch0 to ch1
+            cal.adc[1].scale  = cal.adc[0].scale; // copy ch0 to ch1
+            ADC_CalibrateScalar( 1, cal.adc[1].scale );
             cal.adc[0].shift = 0.0; // reset before scaled calibration
             cal.stage++;
             break;
@@ -362,13 +363,13 @@ void CAL_Recalibrate( uint8_t use_defaults )
     for( int j=0; j<2; j++ ){
         cal.adc[j].shift = 0.0;
         ADC_CalibrateShift( j, 0.0 );
-        cal.adc[j].scale = 1.0;
+        cal.adc[j].scale = 0.0; // use zero! otherwise will affect average.
         ADC_CalibrateScalar( j, 1.0 );
     }
     for( int j=0; j<4; j++ ){
         cal.dac[j].shift = 0.0;
         DAC_CalibrateOffset( j, 0.0 );
-        cal.dac[j].scale = 1.0;
+        cal.dac[j].scale = 0.0; // use zero! otherwise will affect average.
         DAC_CalibrateScalar( j, 1.0 );
     }
     if( !use_defaults ){ // causes recalibration to run


### PR DESCRIPTION
- Fixed sequencing so offsets are calculated after scaling determined.
- Input 2 now has it's offset measured (but still copies scaling from input 1).
- Doubled sampling times for better average values.
- Add validation check after Cal.test() to make sure values are in acceptable range. If not, revert to defaults & print a message telling the user to make sure all patch cables are removed & try again.
- Reset measurement data to defaults before testing (previously, any prior measurement would affect the following average).
- Accounting for multiplexer ON resistance.

This system is still not perfect. I can't figure out why the process isn't at least making the test cases exact after testing. 

moves #39 to 2.0 (i'm adding test data to that issue)