### PR TITLE
output[n]() table call corrected

### DIFF
--- a/lua/output.lua
+++ b/lua/output.lua
@@ -42,20 +42,7 @@ Output.__index = function(self, ix)
 end
 
 Output.__call = function(self, ...)
-    local args = {...}
-    if #args == 0 then
-        self.asl:action()
-    else -- table call
-        self.asl.action = args[1]
-        self.asl:action()
-        --local m = 0
-        ----if #args[1] == 0 then _ end -- implies empty table call
-        --for k,v in pairs( args[1] ) do
-        --    if k == 'mode' then m = v end -- defer mode change after setting params
-        --    self[k] = v
-        --end
-        --if m ~= 0 then self.mode = m end -- apply mode change
-    end
+    self.asl:action(...)
 end
 
 setmetatable(Output, Output) -- capture the metamethods


### PR DESCRIPTION
interacting with the asl virtual machine is now done exclusively by calling the output table as a function. the behaviour is documented in the README.

basically just forwards whatever the arguments are into the asl lib.

notably this nice adsr() example works correctly:
```
output[1].action = adsr()
input[1].change = function(s) output[1](s) end
input[1].mode = 'change'
```