### PR TITLE
asllib updates

### DIFF
--- a/lua/asl.lua
+++ b/lua/asl.lua
@@ -201,9 +201,6 @@ function to( dest, time, shape )
     local d,t,s
     if type(dest) == 'table' then -- accept table syntax
         local tt = dest
-        -- provide 'delay' and 'now' methods
-        if tt.delay then d,t,s = 'here', tt.delay, 'linear'
-        elseif tt.now then d,t,s = tt.now, 0, 'linear' end
         d,t,s = tt.dest or 'here', tt.time or 0, tt.shape or 'linear'
     else
         d,t,s = dest or 'here', time or 0, shape or 'linear'

--- a/lua/asllib.lua
+++ b/lua/asllib.lua
@@ -55,11 +55,11 @@ function ramp( time, skew, level )
                     , level or 5
 
     -- note skew expects 0-1 range
-	local rise = 0.5/(0.998 * skew + 0.001)
-	local fall = 1.0/(2.0 - 1.0/rise)
+    local rise = 0.5/(0.998 * skew + 0.001)
+    local fall = 1.0/(2.0 - 1.0/rise)
 
-    return{ loop{ to(  level, time*rise, curve )
-                , to( -level, time*fall, curve )
+    return{ loop{ to(  level, time/rise )
+                , to( -level, time/fall )
                 }
           }
 end

--- a/lua/asllib.lua
+++ b/lua/asllib.lua
@@ -90,10 +90,3 @@ end
 print 'asllib loaded'
 
 return Asllib
-
--- continue for the following shapes
--- ASR
--- HADSR
--- DADSR
--- trapezoidal
--- whatever other classic shapes there are???

--- a/lua/asllib.lua
+++ b/lua/asllib.lua
@@ -34,7 +34,7 @@ function lfo( speed, level )
 end
 
 function trig( polarity, time, level )
-    polarity, time, level = polarity or 1, time or 0.1, level or 5
+    polarity, time, level = polarity or 1, time or 0.01, level or 5
 
     local rest = 0
     if polarity == 0 then
@@ -75,10 +75,10 @@ function ar( attack, release, level )
 end
 
 function adsr( attack, decay, sustain, release )
-    attack,decay,sustain,release = attack  or 0.1
-                                 , decay   or 0.5
+    attack,decay,sustain,release = attack  or 0.05
+                                 , decay   or 0.3
                                  , sustain or 2
-                                 , release or 4
+                                 , release or 2
 
     return{ held{ to( 5.0, attack )
                 , to( sustain, decay )

--- a/lua/asllib.lua
+++ b/lua/asllib.lua
@@ -23,12 +23,12 @@ function note( noteNum, duration )
           }
 end
 
-function lfo( speed, curve, level )
+function lfo( speed, level )
     -- allow these defaults to be attributes of the out channel
-    speed, curve, level = speed or 1, curve or 'linear', level or 5
+    speed, level = speed or 1, level or 5
 
-    return loop{ to(        level , speed, curve )
-               , to( negate(level), speed, curve )
+    return loop{ to(        level , speed )
+               , to( negate(level), speed )
                }
 
 end
@@ -49,11 +49,10 @@ function trig( polarity, time, level )
 end
 
 
-function ramp( time, skew, curve, level )
-    time,skew,curve,level = time  or 1
-                          , skew  or 0.5
-                          , curve or 'linear'
-                          , level or 5
+function ramp( time, skew, level )
+    time,skew,level = time  or 1
+                    , skew  or 0.5
+                    , level or 5
 
     -- note skew expects 0-1 range
 	local rise = 0.5/(0.998 * skew + 0.001)
@@ -65,14 +64,13 @@ function ramp( time, skew, curve, level )
           }
 end
 
-function ar( attack, release, curve, level )
-    attack,release,level = attack  or 1
-                         , release or 1
-                         , curve   or 'linear'
-                         , level   or 5
+function ar( attack, release, level )
+    attack,release,level = attack  or 0.05
+                         , release or 0.5
+                         , level   or 7
 
-    return{ to( level, attack,  curve )
-          , to( 0,     release, curve )
+    return{ to( level, attack )
+          , to( 0,     release )
           }
 end
 

--- a/lua/asllib.lua
+++ b/lua/asllib.lua
@@ -51,7 +51,7 @@ end
 
 function ramp( time, skew, level )
     time,skew,level = time  or 1
-                    , skew  or 0.5
+                    , skew  or 0.25
                     , level or 5
 
     -- note skew expects 0-1 range

--- a/lua/asllib.lua
+++ b/lua/asllib.lua
@@ -37,14 +37,14 @@ function trig( polarity, time, level )
     polarity, time, level = polarity or 1, time or 0.1, level or 5
 
     local rest = 0
-    if not polarity then
+    if polarity == 0 then
         rest  = level
         level = 0
     end
 
-    return{ to{ ['now'   ] = level }
-          , to{ ['delay' ] = time  }
-          , to{ ['now'   ] = rest  }
+    return{ to( level, 0 )
+          , to( level, time )
+          , to( rest , 0 )
           }
 end
 

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -82,7 +82,6 @@ if Asl then
         output[id].asl:step()
     end
 end
--- TODO should 'go_toward' be called 'slew'???
 -- special wrapper should really be in the ASL lib itself?
 function LL_toward( id, d, t, s )
     if type(d) == 'function' then d = d() end

--- a/tests/asl.lua
+++ b/tests/asl.lua
@@ -366,6 +366,25 @@ function run_tests()
           , {{false,'nil'}          , {1,3,3,'linear'}}
           )
 
+    _t.run( 'loop{{to,to},to}'
+          , function(count)
+                local sl = Asl.new(1)
+                sl.action = loop{ { to( 1,1 )
+                                  , to( 2,2 )
+                                  }
+                                , to( 3,3 )
+                                }
+                sl:action()
+                for i=1,count do sl:step() end
+                return get_last_to()
+            end
+          , {0, {1,1,1,'linear'}}
+          , {1, {1,2,2,'linear'}}
+          , {2, {1,3,3,'linear'}}
+          , {3, {1,1,1,'linear'}}
+          )
+
+
 
 --    _t.run( 'weave'
 --          , function(count)


### PR DESCRIPTION
large selection of fixes for the asllib.

all included functions are well tested & have had default arguments calibrated for generic musical contexts. a number of fixes to functionality too.

all 'curve' (aka 'shape') arguments have been removed as they are unsupported by the C low-level driver at this stage.
the special table syntax params 'now' and 'delay' have been removed as their presence muddied the waters of how the function worked, and they only saved a single argument. table-syntax is still provided, though the `to` function can be considered as a simply (destination, time) pair which makes it feel pretty unnecessary.
