### PR TITLE
increase USB transfer polling rate to 2ms

### DIFF
--- a/usbd/usbd_cdc_interface.h
+++ b/usbd/usbd_cdc_interface.h
@@ -67,7 +67,7 @@
 
 /* Periodically, the state of the buffer "UserTxBuffer" is checked.
    The period depends on CDC_POLLING_INTERVAL */
-#define CDC_POLLING_INTERVAL             5 /* in ms. The max is 65 and the min is 1 */
+#define CDC_POLLING_INTERVAL             2 /* in ms. The max is 65 and the min is 1 */
 
 extern USBD_CDC_ItfTypeDef  USBD_CDC_fops;
 


### PR DESCRIPTION
when sending large amounts of data from crow to a host, this change reduces the likelihood of dropped messages.

this does not improve very large chunks that are built up into a single string (these are limited to 2kB), but rather allows for greater throughput of numerous small messages called on rapid timers (eg. very fast input streams).