### PR TITLE
Slope generator DSP is more accurate

### DIFF
--- a/lib/slopes.c
+++ b/lib/slopes.c
@@ -58,8 +58,17 @@ void S_toward( int        index
         // FIXME. delay is broken without calling the next action directly
         //if( self->action != NULL ){ (*self->action)(index); } // call next step
     } else {
+        float overflow = 0.0;
+        if( self->countdown < 0.0 && self->countdown > -1023.0 ){
+            overflow = self->countdown;
+        }
         self->countdown = ms * self->scalar; // samples until callback
         self->delta = (self->dest - self->here) / self->countdown;
+        if( overflow < 0.0 ){
+            self->here -= overflow * self->delta;
+            self->countdown += overflow;
+            // TODO add protection against overshoot for very <1block slopes
+        }
     }
 }
 
@@ -83,6 +92,9 @@ float* S_step_v( int     index
     if( self->countdown <= 0.0 ){ // at destination
         for( int i=0; i<size; i++ ){
             *out2++ = self->here;
+        }
+        if( self->countdown > -1024.0 ){ // count overflow samples
+            self->countdown -= (float)size;
         }
     } else if( self->countdown > (float)size ){ // no edge case
         if( self->delta == 0.0 ){ // delay only
@@ -125,6 +137,7 @@ float* S_step_v( int     index
             //      settings, so the vals are ready to be used locally
             self->here  = self->dest;
             self->delta = 0.0;
+            self->countdown -= (float)after_break; // compensate!
             for(; after_break>0; after_break-- ){
                 *out2++ = self->here;
             }
@@ -135,6 +148,7 @@ float* S_step_v( int     index
         if( self->countdown <= 0.0 ){ // treat as 'arrived'
             self->here  = self->dest;
             self->delta = 0.0;
+            self->countdown -= (float)after_break; // compensate!
             for(; after_break>0; after_break-- ){
                 *out2++ = self->here;
             }
@@ -149,7 +163,7 @@ float* S_step_v( int     index
             //*out2++ = *out3++ + self->delta; // <- broken by event system
             *out2++ = self->here; // FIXME just clamping bc action hasn't applied yet
         }
-        self->countdown -= (float)after_break + after_breakRem;
+        self->countdown -= (float)after_break;
     }
     self->here = out[size-1]; // TODO overwrites delay() breakpoint
     return out;


### PR DESCRIPTION
Fixed an issue where the last sample before the destination would overshoot.
Fixed an issue where there could be a 'missing' sample at very fast rates (causing a glitch in the output waveform).

Added timing compensation for the event queue delay. This adds a small discontinuity in the waveform as it jumps from the previous destination into the new destination, but is only noticeable at very fast rates (>100Hz). Also I note that the state goes bad above ~600Hz due to the compensation not being recursive. See #112 for future improvement possibilities.