### PR TITLE
Cal and Midi become cal and midi

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ input[1].change = function(state)
 end
 ```
 
-## Midi Library
+## MIDI Library
 
 crow's first Input doubles as MIDI input with the somewhat new TRS cable standard.
 
@@ -355,7 +355,7 @@ function init()
 end
 
 input[1].midi = function(data)
-  local m = Midi.to_msg(data)
+  local m = midi.to_msg(data)
   if m.type == 'note_on' then
     print('on ' .. m.note)
   elseif m.type == 'note_off' then
@@ -704,16 +704,16 @@ of other purposes!
 All modules come pre-calibrated from the factory, so you'll likely never need to
 think about this, but just in case, recalibration and data inspection is allowed.
 
-### Cal.test()
+### cal.test()
 
-The `Cal.test()` function causes crow to re-run the calibration process.
+The `cal.test()` function causes crow to re-run the calibration process.
 
 **You must remove all patch cables from the jacks for this process to work correctly!**
 Calling `test` without any arguments runs the calibration as per normal, while
 runing `test('default')` will not run the calibration process, but instead return
 to default values, in case you're having problems with the calibration process.
 
-### Cal.print()
+### cal.print()
 
 This helper function is just for debugging purposes. Calling it will simply dump
 a list of values showing the scaling & translation of voltages that were measured

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -13,11 +13,10 @@ local function closelibs()
     Output = nil
     Asl    = nil
     Asllib = nil
-    Metro  = nil
-    metro  = nil --alias
+    metro  = nil
     ii     = nil
-    Cal    = nil
-    Midi   = nil
+    cal    = nil
+    midi   = nil
 end
 
 function _crow.libs( lib )
@@ -27,11 +26,10 @@ function _crow.libs( lib )
         Output = dofile('lua/output.lua')
         Asl    = dofile('lua/asl.lua')
         Asllib = dofile('lua/asllib.lua')
-        Metro  = dofile('lua/metro.lua')
-        metro  = Metro --alias
+        metro  = dofile('lua/metro.lua')
         ii     = dofile('lua/ii.lua')
-        Cal    = dofile('lua/calibrate.lua')
-        Midi   = dofile('lua/midi.lua')
+        cal    = dofile('lua/calibrate.lua')
+        midi   = dofile('lua/midi.lua')
     elseif type(lib) == 'table' then
         -- load the list 
     else
@@ -109,9 +107,8 @@ ii._c.inputF = function(chan)
     else return 0 end
 end
 
---TODO int16 conversion should be rolled into i2c generation tool
 ii._c.output = function(chan,val)
-    output[chan].level = val/1638.4
+    output[chan].level = val
     --TODO step ASL
 end
 


### PR DESCRIPTION
lowercased both `cal` and `midi` so that all user calls to the libraries are through lowercase names.

also removed the `metro = Metro` alias because we only ever use `metro` and that seems correct.

tested now & looks good. also updated README entries.