### PR TITLE
kill command added to C layer parser

### DIFF
--- a/lib/caw.c
+++ b/lib/caw.c
@@ -67,6 +67,7 @@ static C_cmd_t _find_cmd( char* str, uint32_t len )
                 else if( *pStr == 'p' ){ return C_print; }
                 else if( *pStr == 'v' ){ return C_version; }
                 else if( *pStr == 'i' ){ return C_identity; }
+                else if( *pStr == 'k' ){ return C_killlua; }
             }
         }
     }
@@ -116,6 +117,7 @@ C_cmd_t Caw_try_receive( void )
             case C_print:      retcmd = C_print; goto exit;
             case C_version:    retcmd = C_version; goto exit;
             case C_identity:   retcmd = C_identity; goto exit;
+            case C_killlua:    retcmd = C_killlua; goto exit;
             default: break;
         }
         if( *buf == '\e' ){ // escape key

--- a/lib/caw.h
+++ b/lib/caw.h
@@ -12,6 +12,7 @@ typedef enum{ C_none
             , C_print
             , C_version
             , C_identity
+            , C_killlua
 } C_cmd_t;
 
 uint8_t Caw_Init( void );

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -76,6 +76,13 @@ lua_State* Lua_Init(void)
     return L;
 }
 
+void Lua_Reset( void )
+{
+    Lua_DeInit();
+    Lua_Init();
+    Lua_crowbegin();
+}
+
 void Lua_load_default_script( void )
 {
     Lua_eval(L, lua_default

--- a/lib/lualink.h
+++ b/lib/lualink.h
@@ -9,6 +9,7 @@ typedef void (*ErrorHandler_t)(char* error_message);
 struct lua_lib_locator{ const char* name; const char* addr_of_luacode; };
 
 lua_State* Lua_Init(void);
+void Lua_Reset(void);
 void Lua_DeInit(void);
 
 void Lua_crowbegin(void);

--- a/main.c
+++ b/main.c
@@ -54,6 +54,7 @@ int main(void)
             case C_print:      REPL_print_script(); break;
             case C_version:    system_print_version(); break;
             case C_identity:   system_print_identity(); break;
+            case C_killlua:    Lua_Reset(); break;
             default: break; // 'C_none' does nothing
         }
         Random_Update();

--- a/readme-development.md
+++ b/readme-development.md
@@ -203,6 +203,7 @@ mnemonic assistance:
 - `^^printscript`: the current user script is sent over usb to the host
 - `^^version`: prints crow's semantic version to the usb host
 - `^^identity`: print's this crow's unique ID to the usb host
+- `^^kill`: resets the lua vm and re-runs the userscript (or default)
 
 #### Bootloader
 


### PR DESCRIPTION
can now use `^^k` to hard-reset the lua environment. particularly useful for developing a standalone application for use with crow when you trash the lua env, but don't want to reset the device (because you haven't implemented auto-reconnect).