### PR TITLE
MIDI error handling

### DIFF
--- a/lib/midi.c
+++ b/lib/midi.c
@@ -33,6 +33,7 @@ typedef enum{ MIDI_SYSEX         = 0xF0
 static uint8_t MIDI_rx_cmd( void );
 static uint8_t MIDI_rx_data( uint8_t count );
 static void event_complete( uint8_t* d );
+void MIDI_Handle_Error( void );
 
 
 // public defns
@@ -40,7 +41,9 @@ void MIDI_Active( int state )
 {
     static int is_active = 0;
     if( state && !is_active ){
-        MIDI_ll_Init( &MIDI_Handle_LL );
+        MIDI_ll_Init( &MIDI_Handle_LL
+                    , &MIDI_Handle_Error
+                    );
         if( MIDI_rx_cmd() ){ printf("midi0\n"); }
         is_active = 1;
     } else if( !state && is_active ){
@@ -92,6 +95,10 @@ void MIDI_Handle_LL( uint8_t* buf )
             event_complete(buf);
         }
     }
+}
+void MIDI_Handle_Error( void )
+{
+    MIDI_rx_cmd();
 }
 
 int MIDI_byte_count( uint8_t cmd_byte )

--- a/ll/midi_ll.c
+++ b/ll/midi_ll.c
@@ -3,11 +3,14 @@
 UART_HandleTypeDef midiuart;
 
 void rx_callback_null( uint8_t* buf );
+void error_callback_null( void );
 void (*rx_callback)(uint8_t*) = rx_callback_null;
 uint8_t rx_buf[8]; // TODO not big enough for sysex!
+void (*error_callback)(void) = error_callback_null;
 
 // public defns
-void MIDI_ll_Init( void(*rx_handler)(uint8_t*) )
+void MIDI_ll_Init( void(*rx_handler)(uint8_t*)
+                 , void(*error_handler)(void) )
 {
     midiuart.Instance = MIDIx;
 
@@ -22,6 +25,7 @@ void MIDI_ll_Init( void(*rx_handler)(uint8_t*) )
     while( HAL_UART_GetState( &midiuart ) != HAL_UART_STATE_READY ){}
 
     rx_callback = rx_handler;
+    error_callback = error_handler;
 }
 
 void MIDI_ll_DeInit(void)
@@ -93,6 +97,11 @@ void HAL_UART_RxCpltCallback( UART_HandleTypeDef *huart )
 {
     (*rx_callback)(rx_buf);
 }
+void HAL_UART_ErrorCallback( UART_HandleTypeDef *huart )
+{
+    printf("uart_error: %i\n", huart->ErrorCode);
+    (*error_callback)();
+}
 
 void MIDI_ll_IRQHandler( void )
 {
@@ -100,3 +109,4 @@ void MIDI_ll_IRQHandler( void )
 }
 
 void rx_callback_null( uint8_t* buf ){}
+void error_callback_null( void ){}

--- a/ll/midi_ll.c
+++ b/ll/midi_ll.c
@@ -19,7 +19,7 @@ void MIDI_ll_Init( void(*rx_handler)(uint8_t*)
     midiuart.Init.StopBits     = UART_STOPBITS_1;
     midiuart.Init.Parity       = UART_PARITY_NONE;
     midiuart.Init.Mode         = UART_MODE_RX;
-    midiuart.Init.OverSampling = UART_OVERSAMPLING_16; // 16 or 8. d=16
+    midiuart.Init.OverSampling = UART_OVERSAMPLING_8; // 16 or 8. d=16
     if( HAL_UART_Init( &midiuart ) ){ printf("!midi_uart_init\n"); }
 
     while( HAL_UART_GetState( &midiuart ) != HAL_UART_STATE_READY ){}
@@ -46,9 +46,9 @@ void HAL_UART_MspInit(UART_HandleTypeDef *hu )
 
     GPIO_InitTypeDef gpio;
     gpio.Pin       = MIDI_RXPIN;
-    gpio.Mode      = GPIO_MODE_AF_PP;
+    gpio.Mode      = GPIO_MODE_AF_OD;
     gpio.Pull      = GPIO_PULLUP;
-    gpio.Speed     = GPIO_SPEED_FREQ_HIGH;
+    gpio.Speed     = GPIO_SPEED_FREQ_LOW;
     gpio.Alternate = MIDI_AF;
     HAL_GPIO_Init( MIDI_GPIO, &gpio );
 

--- a/ll/midi_ll.h
+++ b/ll/midi_ll.h
@@ -32,10 +32,12 @@
 
 #define DBG_UART_TIMEOUT    0x4000 /* a long time */
 
-void MIDI_ll_Init( void(*rx_handler)(uint8_t*) );
+void MIDI_ll_Init( void(*rx_handler)(uint8_t*)
+                 , void(*error_handler)(void) );
 void MIDI_ll_DeInit(void);
 
 int MIDI_ll_Rx( int ix, int count );
 
-void HAL_UART_RxCpltCallback(UART_HandleTypeDef *huart);
+void HAL_UART_RxCpltCallback( UART_HandleTypeDef *huart );
+void HAL_UART_ErrorCallback( UART_HandleTypeDef *huart );
 void MIDI_ll_IRQHandler( void );


### PR DESCRIPTION
Now if there is an error in receiving a MIDI packet over the UART crow will print a console error (debugger only) and attempt to receive the next packet. Previously the UART would simply stop running after any error occurred.

These errors should be avoided by the flying resistor mod we discussed, however they can still occur when hot-plugging the cable while in MIDI mode.