### PR TITLE
Allow 8kB long userscripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For a developer focused intro, see [readme-development.md](readme-development.md
 crow is many things, but here's some starters:
 - Eurorack module. 2hp. +60mA, -15mA (TODO confirm).
 - Hardware i/o: 2inputs, 4outputs, 16bit, [-5v,+10v] range
-- Full lua environment, 64kB of local script storage
+- Full lua environment, 8kB of local script storage
 - USB device, for communicating text(!)
 - i2c leader & follower, multiple crows can share responsibilities
 - MIDI input on TRS cable (top-most input only)

--- a/lib/caw.c
+++ b/lib/caw.c
@@ -141,6 +141,7 @@ C_cmd_t Caw_try_receive( void )
         if( pReader + len > USB_RX_BUFFER ){ // overflow protection
             pReader = 0;
             Caw_send_luachunk("!chunk too long!");
+            printf("!chunk too long!\n");
             //multiline = 0; // FIXME can we know whether this is high / low?
             retcmd = C_none;
             goto exit;

--- a/lib/flash.h
+++ b/lib/flash.h
@@ -11,7 +11,7 @@
 #define USER_SCRIPT_LOCATION 0x08010000
 #define USER_SCRIPT_SECTOR   FLASH_SECTOR_4
 //#define USER_SCRIPT_SIZE     (0x10000 - 4)
-#define USER_SCRIPT_SIZE     (0x1000 - 4)
+#define USER_SCRIPT_SIZE     (0x2000 - 4)
 
 typedef enum { FLASH_Status_Init  = 0
              , FLASH_Status_Saved = 1

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -535,6 +535,7 @@ void L_handle_toward( int id )
     lua_pushinteger(L, id+1); // 1-ix'd
     if( lua_pcall(L, 1, 0, 0) != LUA_OK ){
         Caw_send_luachunk("error running toward_handler");
+        Caw_send_luachunk( (char*)lua_tostring(L, -1) );
         printf( "%s\n", (char*)lua_tostring(L, -1) );
         lua_pop( L, 1 );
     }

--- a/usbd/usbd_cdc_interface.c
+++ b/usbd/usbd_cdc_interface.c
@@ -147,7 +147,7 @@ static int8_t CDC_Itf_Control (uint8_t cmd, uint8_t* pbuf, uint16_t length)
             LineCoding.paritytype = pbuf[5];
             LineCoding.datatype   = pbuf[6];
             break;
-        case CDC_GET_LINE_CODING: printf("itf:g_line_coding\n");
+        case CDC_GET_LINE_CODING:
             pbuf[0] = (uint8_t)(LineCoding.bitrate);
             pbuf[1] = (uint8_t)(LineCoding.bitrate >> 8);
             pbuf[2] = (uint8_t)(LineCoding.bitrate >> 16);
@@ -156,9 +156,9 @@ static int8_t CDC_Itf_Control (uint8_t cmd, uint8_t* pbuf, uint16_t length)
             pbuf[5] = LineCoding.paritytype;
             pbuf[6] = LineCoding.datatype;
             break;
-        case CDC_SET_CONTROL_LINE_STATE: break;//printf("itf:s_ctrl_state\n"); break;
+        case CDC_SET_CONTROL_LINE_STATE: break;
         case CDC_SEND_BREAK:             printf("itf:send_brk\n");     break;
-        default: printf("default\n"); break;
+        default: printf("itf: default\n"); break;
     }
     return (USBD_OK);
 }
@@ -171,7 +171,7 @@ void USB_tx_enqueue( uint8_t* buf, uint32_t len )
     }
     if( len == 0 ){
         // FIXME? Likely means we're trying to TX when no usb device connected
-        printf("TxBuf full\n"); // TODO memcpy will still run (can rm this warning)
+        //printf("TxBuf full\n"); // TODO memcpy will still run (can rm this warning)
     }
     memcpy( &UserTxBuffer[UserTxDataLen]
           , buf
@@ -200,7 +200,8 @@ uint8_t USB_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 //__disable_irq();
             int error = USBD_OK;
             if( (error = USBD_CDC_TransmitPacket(&USBD_Device)) ){
-                printf("CDC_tx failed %i\n", error);
+                // This means the buffer is full & hasn't been read
+                //printf("CDC_tx failed %i\n", error);
             } else {
                 UserTxDataLen = 0; // only clear data if no error
             }


### PR DESCRIPTION
Some updates to the layer that accepts text from USB. Allows for scripts up to 8k characters.
Also turns off some unneeded debugging messages that would flood the USB & debugger streams in some cases.

This still needs more stress testing!