### PR TITLE
new default.lua script

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -17,6 +17,7 @@
 #include "lib/io.h"         // IO_GetADC()
 #include "../ll/random.h"   // Random_Get()
 #include "../ll/adda.h"     // CAL_Recalibrate() CAL_PrintCalibration()
+#include "../ll/system.h"   // getUID_Word()
 #include "lib/events.h"     // event_t event_post()
 #include "lib/midi.h"       // MIDI_Active()
 
@@ -200,6 +201,13 @@ static int _bootloader( lua_State *L )
 {
     bootloader_enter();
     return 0;
+}
+static int _unique_id( lua_State *L )
+{
+    lua_pushinteger(L, getUID_Word(0));
+    lua_pushinteger(L, getUID_Word(4));
+    lua_pushinteger(L, getUID_Word(8));
+    return 3;
 }
 static int _go_toward( lua_State *L )
 {
@@ -445,6 +453,7 @@ static const struct luaL_Reg libCrow[]=
     , { "tell"             , _print_tell       }
         // system
     , { "sys_bootloader"   , _bootloader       }
+    , { "unique_id"        , _unique_id        }
     //, { "sys_cpu_load"     , _sys_cpu          }
         // io
     , { "go_toward"        , _go_toward        }

--- a/ll/system.c
+++ b/ll/system.c
@@ -11,7 +11,6 @@ static void Sys_Clk_Config(void);
 static void Error_Handler(void);
 static void MPU_Config(void);
 static void CPU_CACHE_Enable(void);
-static inline uint32_t getUID_Word( uint32_t offset );
 
 // public definitions
 void system_init(void)
@@ -33,9 +32,9 @@ void system_print_identity(void)
 {
     char s[64];
     sprintf( s, "^^identity('0x%08x%08x%08x')"
-              , (unsigned int)getUID_Word(0)
-              , (unsigned int)getUID_Word(4)
-              , (unsigned int)getUID_Word(8)
+              , getUID_Word(0)
+              , getUID_Word(4)
+              , getUID_Word(8)
               );
     Caw_send_luachunk( s );
 }
@@ -111,12 +110,12 @@ static void Error_Handler(void)
     while(1){;;}
 }
 
-static inline uint32_t getUID_Word( uint32_t offset )
+unsigned int getUID_Word( unsigned int offset )
 {
     const uint32_t base = 0x1FF07A10;
     //return (uint32_t)(READ_REG(*((uint32_t*)(UID_BASE + offset))));
     //return (uint32_t)(READ_REG(UID_BASE + offset));
     uint32_t* x = (uint32_t*)(base + offset);
-    return (uint32_t)(READ_REG(*x));
+    return (unsigned int)(READ_REG(*x));
     //return (uint32_t)x;
 }

--- a/ll/system.h
+++ b/ll/system.h
@@ -3,3 +3,4 @@
 void system_init(void);
 void system_print_version(void);
 void system_print_identity(void);
+unsigned int getUID_Word( unsigned int offset );

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -29,7 +29,7 @@ function _crow.libs( lib )
         metro  = dofile('lua/metro.lua')
         ii     = dofile('lua/ii.lua')
         cal    = dofile('lua/calibrate.lua')
-        midi   = dofile('lua/midi.lua')
+        --midi   = dofile('lua/midi.lua')
     elseif type(lib) == 'table' then
         -- load the list 
     else

--- a/lua/default.lua
+++ b/lua/default.lua
@@ -1,25 +1,97 @@
-function init()
-    -- start all the lfos
-    for c=1, 4 do
-        output[c].asl:action()
-    end
+--- unique melody box
+-- each crow sings it's own song
 
-    ii.txi.get( 'value', 1 )
-    --input[1].mode('change', 0.5, 0.1, 'both')
+length = {}
+rhythm = {}
+notes  = {}
+step   = {}
+bits   = {}
+scale  = { {0,2,4,7,9}, {0,2,4,5,7,9,11} }
+decay  = 0.4
+attack = 0.04
+
+function set_d(t) decay = (t-1)/8 + 0.05 end
+function set_a(t) attack = (t-1)/64 + 0.003 end
+
+function play(out,ix)
+  -- play rhythm
+  if rhythm[ix][ step[ix] ] & 8 == 8 then
+    if ix == 1 then set_d(t[ix]) else set_a(t[ix]) end
+    t[ix] = 0
+    output[out+1]()
+  end
+  -- set note
+  if rhythm[ix+2][ step[ix+2] ] & 8 == 8 then
+    n1 = notes[ix][ step[ix+2] ]
+    n2 = notes[ix][ step[ix] ]
+    abs = math.abs(input[2].volts)/5
+    note = n1 + abs*(n2-n1)
+    note = math.floor(note * (abs*3 + 0.1))
+    s = scale[input[2].volts > -0.04 and 1 or 2]
+    nn = s[ note%(#s) + 1 ]
+    oct = math.floor(note/12)
+    output[out].volts = nn/12 + oct
+  end
+  step[ix] = (step[ix] % length[ix]) + 1
+  step[ix+2] = (step[ix+2] % length[ix+2]) + 1
 end
 
--- FIXME need to access 'ii.<mod>' before defining event bc it gets trampled
--- by the setup otherwise? i don't understand why the table access doesn't cause
--- the library to be loaded, have default event, then apply the .event here to
--- overwrite it?
---local ignore = ii.txi.get
---ii.txi.event = function( e, data )
---    if e == 'value' then debug_usart('value='..data)
---    end
---end
+input[1].change = function(s)
+  play(1,1)
+  play(3,2)
+end
 
---local position = 0
---function count(c)
---    position = position + 1
---    print(position)
---end
+sd = 0
+function lcg(seed)
+  local s = seed or sd
+  sd = (1103515245*s + 12345) % (1<<31)
+  return sd
+end
+
+function get_d() return decay end
+function get_a() return attack end
+
+t = {0,0}
+function env(count)
+  for i=1,2 do t[i] = t[i] + 1 end
+end
+
+function init()
+  -- generate unique tables
+  lcg(unique_id())
+  lcg()
+  lcg()
+  lcg()
+
+  for i=1,4 do
+    length[i] = lcg()%19 + 6
+    rhythm[i] = {}
+    for n=1,32 do
+      rhythm[i][n] = lcg()
+    end
+    step[i] = 1
+  end
+
+  -- notes
+  for i=1,4 do
+    notes[i] = {0}
+    for n=1,31 do
+      notes[i][n+1] = notes[i][n] + (lcg() % 7) -3
+    end
+  end
+
+  -- out params
+  output[1].slew   = 0
+  output[1].volts  = 0
+  output[2].action = ar(get_a,get_d)
+  output[3].slew   = 0.01
+  output[3].volts  = 0
+  output[4].action = ar(get_a,get_d)
+
+  -- start sequence!
+  input[1]{ mode = 'change', direction = 'rising' }
+  dec = metro.init{ event = env, time = 0.1 }
+  dec:start()
+end
+
+init()


### PR DESCRIPTION
plays a dualing / phasing melody. the sequence (rhythm & pitch) are determined by each crow's unique id number, so should be subtly different across all modules.

input[1]: attach trigger to advance sequence
input[2]: near 0V is least movement, +ve & -ve stretch the melodies out. counter-clockwise is ionian, clockwise is pentatonic. there are 2 sequences being crossfaded as the voltage increases
output[1+2]: cv/env for voice1
output[3+4]: cv/env for voice2

note: added extra hooks to get the unique-id into lua.