### PR TITLE
Unified upload and run logic

### DIFF
--- a/lib/caw.c
+++ b/lib/caw.c
@@ -60,8 +60,9 @@ static C_cmd_t _find_cmd( char* str, uint32_t len )
         if( *pStr++ == '^' ){
             if( *pStr++ == '^' ){
                 if(      *pStr == 'b' ){ return C_boot; }
-                else if( *pStr == 's' ){ return C_flashstart; }
-                else if( *pStr == 'e' ){ return C_flashend; }
+                else if( *pStr == 's' ){ return C_startupload; }
+                else if( *pStr == 'e' ){ return C_endupload; }
+                else if( *pStr == 'f' ){ return C_flashupload; }
                 else if( *pStr == 'c' ){ return C_flashclear; }
                 else if( *pStr == 'r' ){ return C_restart; }
                 else if( *pStr == 'p' ){ return C_print; }
@@ -109,15 +110,16 @@ C_cmd_t Caw_try_receive( void )
 
     if( USB_rx_dequeue( &buf, &len ) ){
         switch( _find_cmd( (char*)buf, len ) ){ // check for a system command
-            case C_boot:       retcmd = C_boot; goto exit;
-            case C_flashstart: retcmd = C_flashstart; goto exit;
-            case C_flashend:   retcmd = C_flashend; goto exit;
-            case C_flashclear: retcmd = C_flashclear; goto exit;
-            case C_restart:    retcmd = C_restart; goto exit;
-            case C_print:      retcmd = C_print; goto exit;
-            case C_version:    retcmd = C_version; goto exit;
-            case C_identity:   retcmd = C_identity; goto exit;
-            case C_killlua:    retcmd = C_killlua; goto exit;
+            case C_boot:        retcmd = C_boot; goto exit;
+            case C_startupload: retcmd = C_startupload; goto exit;
+            case C_endupload:   retcmd = C_endupload; goto exit;
+            case C_flashupload: retcmd = C_flashupload; goto exit;
+            case C_flashclear:  retcmd = C_flashclear; goto exit;
+            case C_restart:     retcmd = C_restart; goto exit;
+            case C_print:       retcmd = C_print; goto exit;
+            case C_version:     retcmd = C_version; goto exit;
+            case C_identity:    retcmd = C_identity; goto exit;
+            case C_killlua:     retcmd = C_killlua; goto exit;
             default: break;
         }
         if( *buf == '\e' ){ // escape key

--- a/lib/caw.h
+++ b/lib/caw.h
@@ -5,8 +5,9 @@
 typedef enum{ C_none
             , C_repl
             , C_boot
-            , C_flashstart
-            , C_flashend
+            , C_startupload
+            , C_endupload
+            , C_flashupload
             , C_flashclear
             , C_restart
             , C_print

--- a/lib/repl.c
+++ b/lib/repl.c
@@ -2,6 +2,7 @@
 
 #include <stdlib.h> // malloc(), free()
 #include <string.h> // memcpy()
+#include <stdbool.h>
 
 #include <stm32f7xx_hal.h> // HAL_Delay()
 #include "lib/flash.h"     // Flash_write_(), Flash_is_userscript(), Flash_read()
@@ -10,6 +11,7 @@
 // types
 typedef enum{ REPL_normal
             , REPL_reception
+            , REPL_discard
 } L_repl_mode;
 
 // global variables
@@ -19,7 +21,7 @@ char*       new_script;
 uint16_t    new_script_len;
 
 // prototypes
-static void REPL_new_script_buffer( uint32_t len );
+static bool REPL_new_script_buffer( uint32_t len );
 static void REPL_receive_script( char* buf, uint32_t len, ErrorHandler_t errfn );
 
 // public interface
@@ -44,42 +46,54 @@ void REPL_init( lua_State* lua )
 
 void REPL_begin_upload( void )
 {
-    repl_mode = REPL_reception;
-    REPL_new_script_buffer( USER_SCRIPT_SIZE );
+    Lua_Reset(); // free up memory
+    if( REPL_new_script_buffer( USER_SCRIPT_SIZE ) ){
+      repl_mode = REPL_reception;
+    } else {
+      repl_mode = REPL_discard;
+    }
 }
 
 void REPL_run_upload( void )
 {
-    repl_mode = REPL_normal;
-    Lua_Reset();
-    if( !Lua_eval( Lua, new_script
-                      , new_script_len
-                      , Caw_send_luaerror
-                      ) ){ // successful load
-        Caw_send_luachunk("running...");
+    if( repl_mode == REPL_discard ){
+        Caw_send_luachunk("upload failed, returning to normal mode");
+    } else {
+        if( !Lua_eval( Lua, new_script
+                          , new_script_len
+                          , Caw_send_luaerror
+                          ) ){ // successful load
+            Caw_send_luachunk("running...");
+        } else {
+          Caw_send_luachunk("evaluation failed");
+        }
+        free(new_script);
     }
-    free(new_script);
+    repl_mode = REPL_normal;
 }
 
 void REPL_flash_upload( void )
 {
-    repl_mode = REPL_normal;
-    // FIME: should this Lua_Reset() like run?
-    if( !Lua_eval( Lua, new_script
-                      , new_script_len
-                      , Caw_send_luaerror
-                      ) ){ // successful load
+    if( repl_mode == REPL_discard ){
+        Caw_send_luachunk("upload failed, returning to normal mode");
+    } else {
+        if( !Lua_eval( Lua, new_script
+                          , new_script_len
+                          , Caw_send_luaerror
+                          ) ){ // successful load
 
-        // TODO if we're setting init() should check it doesn't crash
-        if( Flash_write_user_script( new_script
-                                    , new_script_len
-                                    ) ){
-            printf("flash write failed\n");
-            Caw_send_luachunk("flash write failed");
-        }
-        printf("script saved, len: %i\n", new_script_len);
-    } else { printf("new user script failed test\n"); }
-    free(new_script); // cleanup memory
+            // TODO if we're setting init() should check it doesn't crash
+            if( Flash_write_user_script( new_script
+                                        , new_script_len
+                                        ) ){
+                printf("flash write failed\n");
+                Caw_send_luachunk("flash write failed");
+            }
+            printf("script saved, len: %i\n", new_script_len);
+        } else { printf("new user script failed test\n"); }
+        free(new_script); // cleanup memory
+    }
+    repl_mode = REPL_normal;
 }
 
 void REPL_eval( char* buf, uint32_t len, ErrorHandler_t errfn )
@@ -117,24 +131,26 @@ void REPL_print_script( void )
 // private funcs
 static void REPL_receive_script( char* buf, uint32_t len, ErrorHandler_t errfn )
 {
-    // FIXME: must do bounds checking to not overrun 8kB buffer
-    memcpy( &new_script[new_script_len], buf, len );
-    new_script_len += len;
+    if( new_script_len + len >= USER_SCRIPT_SIZE ){
+        Caw_send_luachunk("!script: upload is too big");
+        repl_mode = REPL_discard;
+        free(new_script);
+    } else {
+        memcpy( &new_script[new_script_len], buf, len );
+        new_script_len += len;
+    }
 }
 
-static void REPL_new_script_buffer( uint32_t len )
+static bool REPL_new_script_buffer( uint32_t len )
 {
     // TODO call to Lua to free resources from current script
     new_script = malloc(len);
     if(new_script == NULL){
         printf("out of mem\n");
         Caw_send_luachunk("!script: out of memory");
-        //(*errfn)("!script: out of memory");
-        return; // how to deal with this situation?
-        // FIXME: should respond over usb stating out of memory?
-        //        try allocating a smaller amount and hope it fits?
-        //        retry?
+        return false;
     }
-    for( int i=0; i<len; i++ ){ new_script[i] = 0; }
+    memset(new_script, 0, len);
     new_script_len = 0;
+    return true;
 }

--- a/lib/repl.h
+++ b/lib/repl.h
@@ -9,12 +9,10 @@
 
 #include "lualink.h" // ErrorHandler_t, Lua_eval(), Lua_load_default_script()
 
-// types
-typedef enum{ REPL_normal
-            , REPL_reception
-} L_repl_mode;
-
 void REPL_init( lua_State* lua );
-void REPL_mode( L_repl_mode mode );
+void REPL_begin_upload( void );
+void REPL_run_upload( void );
+void REPL_flash_upload( void );
+
 void REPL_eval( char* buf, uint32_t len, ErrorHandler_t errfn );
 void REPL_print_script( void );

--- a/main.c
+++ b/main.c
@@ -46,15 +46,16 @@ int main(void)
                                         , Caw_get_read_len()
                                         , Caw_send_luaerror
                                         ); break;
-            case C_boot:       bootloader_enter(); break;
-            case C_flashstart: REPL_mode( REPL_reception ); break;
-            case C_flashend:   REPL_mode( REPL_normal ); break;
-            case C_flashclear: Flash_clear_user_script(); break;
-            case C_restart:    bootloader_restart(); break;
-            case C_print:      REPL_print_script(); break;
-            case C_version:    system_print_version(); break;
-            case C_identity:   system_print_identity(); break;
-            case C_killlua:    Lua_Reset(); break;
+            case C_boot:        bootloader_enter(); break;
+            case C_startupload: REPL_begin_upload(); break;
+            case C_endupload:   REPL_run_upload(); break;
+            case C_flashupload: REPL_flash_upload(); break;
+            case C_flashclear:  Flash_clear_user_script(); break;
+            case C_restart:     bootloader_restart(); break;
+            case C_print:       REPL_print_script(); break;
+            case C_version:     system_print_version(); break;
+            case C_identity:    system_print_identity(); break;
+            case C_killlua:     Lua_Reset(); break;
             default: break; // 'C_none' does nothing
         }
         Random_Update();

--- a/readme-development.md
+++ b/readme-development.md
@@ -217,8 +217,9 @@ based on the first character following the symbol. Full names are listed here fo
 mnemonic assistance:
 - `^^bootloader`: jump to the bootloader.
 - `^^reset` / `^^restart`: reboots crow including the USB connection.
-- `^^startscript`: sets crow to reception mode. following code will be saved
-- `^^endscript`: saved code above will be written to flash. crow returns to repl mode
+- `^^startscript`: sets crow to reception mode. following code will be saved to a buffer
+- `^^endscript`: saved code buffer will be run immediately. crow returns to repl mode
+- `^^flashscript`: saved code buffer will be written to flash. crow returns to repl mode
 - `^^clearscript`: clears onboard user script. use if your script is crashing crow
 - `^^printscript`: the current user script is sent over usb to the host
 - `^^version`: prints crow's semantic version to the usb host


### PR DESCRIPTION
This is a *work in progress* intended for discussion as to approach. If this is a reasonable direction to go I will do further testing and cleanup. 

The goal is to have consistent upload limitations, parse/eval, and vm reset behavior across the druid `upload` (aka flash) and `run` operations.

The approach is to have both `upload` and `run` perform bulk uploads by issuing a `^^s` (start) command, sending the script, and then signaling completion with either a new command; `^^f` (flash), in the upload case or the existing command; `^^e` (end) in the run case. 

A cursory amount of testing (with a modified druid) appears to confirm the basic approach works. Items worth noting:
- The notion of the `repl_mode` is now entirely internal to the repl code.
- `Lua_Reset()` is called to free resources ahead of upload buffer allocation because repeated attempts to run code seemed to fail (likely in allocation) and leave the device in an inconsistent state (previously druid would issue a `^^k` to reset ahead of an upload)
- Previously upload buffer allocation failures weren't really being handled. Now when allocation fails the repl is put into `REPL_discard` mode which simply throws away everything received until such time as either of the `^^f` or `^^e` stop commands are received.
- Previously upload was not checking to see if the 8kB upload buffer size was exceeded. Now if the upload exceeds 8kB (`USER_SCRIPT_SIZE`) the buffer is freed and the repl is put into `REPL_discard` mode. 
