### PR TITLE
Correct initialization of lua env for different upload / boot processes

### DIFF
--- a/lib/caw.c
+++ b/lib/caw.c
@@ -62,7 +62,7 @@ static C_cmd_t _find_cmd( char* str, uint32_t len )
                 if(      *pStr == 'b' ){ return C_boot; }
                 else if( *pStr == 's' ){ return C_startupload; }
                 else if( *pStr == 'e' ){ return C_endupload; }
-                else if( *pStr == 'f' ){ return C_flashupload; }
+                else if( *pStr == 'w' ){ return C_flashupload; }
                 else if( *pStr == 'c' ){ return C_flashclear; }
                 else if( *pStr == 'r' ){ return C_restart; }
                 else if( *pStr == 'p' ){ return C_print; }

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -81,7 +81,6 @@ void Lua_Reset( void )
 {
     Lua_DeInit();
     Lua_Init();
-    Lua_crowbegin();
 }
 
 void Lua_load_default_script( void )

--- a/lib/repl.h
+++ b/lib/repl.h
@@ -11,8 +11,7 @@
 
 void REPL_init( lua_State* lua );
 void REPL_begin_upload( void );
-void REPL_run_upload( void );
-void REPL_flash_upload( void );
+void REPL_upload( int flash );
 
 void REPL_eval( char* buf, uint32_t len, ErrorHandler_t errfn );
 void REPL_print_script( void );

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -150,6 +150,9 @@ for _,fn in ipairs( wrapped_fns ) do
     -- fn = closure_if_table( fn ) -- this *doesn't* redirect the identifier
 end
 
+-- empty init function in case userscript doesn't define it
+function init() end
+
 print'crowlib loaded'
 
 -- cleanup all unused lua objects before releasing to the userscript

--- a/lua/default.lua
+++ b/lua/default.lua
@@ -93,5 +93,3 @@ function init()
   dec = metro.init{ event = env, time = 0.1 }
   dec:start()
 end
-
-init()

--- a/main.c
+++ b/main.c
@@ -48,8 +48,8 @@ int main(void)
                                         ); break;
             case C_boot:        bootloader_enter(); break;
             case C_startupload: REPL_begin_upload(); break;
-            case C_endupload:   REPL_run_upload(); break;
-            case C_flashupload: REPL_flash_upload(); break;
+            case C_endupload:   REPL_upload(0); break;
+            case C_flashupload: REPL_upload(1); break;
             case C_flashclear:  Flash_clear_user_script(); break;
             case C_restart:     bootloader_restart(); break;
             case C_print:       REPL_print_script(); break;

--- a/readme-development.md
+++ b/readme-development.md
@@ -219,7 +219,7 @@ mnemonic assistance:
 - `^^reset` / `^^restart`: reboots crow including the USB connection.
 - `^^startscript`: sets crow to reception mode. following code will be saved to a buffer
 - `^^endscript`: saved code buffer will be run immediately. crow returns to repl mode
-- `^^flashscript`: saved code buffer will be written to flash. crow returns to repl mode
+- `^^writescript`: saved code buffer will be written to flash. crow returns to repl mode
 - `^^clearscript`: clears onboard user script. use if your script is crashing crow
 - `^^printscript`: the current user script is sent over usb to the host
 - `^^version`: prints crow's semantic version to the usb host


### PR DESCRIPTION
- default.lua no longer calls init() at the end of the file (crow itself should do this)
- if a userscript doesn't include an init() fn, lua doesn't have an eval error
- using `^^w` to end an upload & 'write' to flash (leaves `^^f/F` free for First)
- any upload (regardless of write-to-flash or run) calls init() after a successful upload.

fixes #201 
fixes #33 
