### PR TITLE
crow.reset() for zeroing everything out

### DIFF
--- a/lib/caw.c
+++ b/lib/caw.c
@@ -62,7 +62,7 @@ static C_cmd_t _find_cmd( char* str, uint32_t len )
                 if(      *pStr == 'b' ){ return C_boot; }
                 else if( *pStr == 's' ){ return C_startupload; }
                 else if( *pStr == 'e' ){ return C_endupload; }
-                else if( *pStr == 'f' ){ return C_flashupload; }
+                else if( *pStr == 'w' ){ return C_flashupload; }
                 else if( *pStr == 'c' ){ return C_flashclear; }
                 else if( *pStr == 'r' ){ return C_restart; }
                 else if( *pStr == 'p' ){ return C_print; }

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -81,7 +81,6 @@ void Lua_Reset( void )
 {
     Lua_DeInit();
     Lua_Init();
-    Lua_crowbegin();
 }
 
 void Lua_load_default_script( void )

--- a/lib/repl.h
+++ b/lib/repl.h
@@ -11,8 +11,7 @@
 
 void REPL_init( lua_State* lua );
 void REPL_begin_upload( void );
-void REPL_run_upload( void );
-void REPL_flash_upload( void );
+void REPL_upload( int flash );
 
 void REPL_eval( char* buf, uint32_t len, ErrorHandler_t errfn );
 void REPL_print_script( void );

--- a/lua/bootstrap.lua
+++ b/lua/bootstrap.lua
@@ -46,5 +46,6 @@ end
 print'lua bootstrapped'
 
 _c = dofile('lua/crowlib.lua')
+crow = _c
 
 --collectgarbage('collect')

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -41,6 +41,15 @@ end
 -- open all libs by default
 _crow.libs()
 
+function _crow.reset()
+    for n=1,2 do input[n].mode = 'none' end
+    for n=1,4 do
+        output[n].slew = 0
+        output[n].volts = 0
+    end
+    metro.free_all()
+end
+
 --- Communication functions
 -- these will be called from norns (or the REPL)
 -- they return values wrapped in strings that can be used in Lua directly

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -150,6 +150,9 @@ for _,fn in ipairs( wrapped_fns ) do
     -- fn = closure_if_table( fn ) -- this *doesn't* redirect the identifier
 end
 
+-- empty init function in case userscript doesn't define it
+function init() end
+
 print'crowlib loaded'
 
 -- cleanup all unused lua objects before releasing to the userscript

--- a/lua/default.lua
+++ b/lua/default.lua
@@ -93,5 +93,3 @@ function init()
   dec = metro.init{ event = env, time = 0.1 }
   dec:start()
 end
-
-init()

--- a/main.c
+++ b/main.c
@@ -48,8 +48,8 @@ int main(void)
                                         ); break;
             case C_boot:        bootloader_enter(); break;
             case C_startupload: REPL_begin_upload(); break;
-            case C_endupload:   REPL_run_upload(); break;
-            case C_flashupload: REPL_flash_upload(); break;
+            case C_endupload:   REPL_upload(0); break;
+            case C_flashupload: REPL_upload(1); break;
             case C_flashclear:  Flash_clear_user_script(); break;
             case C_restart:     bootloader_restart(); break;
             case C_print:       REPL_print_script(); break;

--- a/readme-development.md
+++ b/readme-development.md
@@ -219,7 +219,7 @@ mnemonic assistance:
 - `^^reset` / `^^restart`: reboots crow including the USB connection.
 - `^^startscript`: sets crow to reception mode. following code will be saved to a buffer
 - `^^endscript`: saved code buffer will be run immediately. crow returns to repl mode
-- `^^flashscript`: saved code buffer will be written to flash. crow returns to repl mode
+- `^^writescript`: saved code buffer will be written to flash. crow returns to repl mode
 - `^^clearscript`: clears onboard user script. use if your script is crashing crow
 - `^^printscript`: the current user script is sent over usb to the host
 - `^^version`: prints crow's semantic version to the usb host


### PR DESCRIPTION
- adds a new library function `crow.reset()` which stops inputs, zeros outputs & frees all metros
- adds an alias to the crowlib as `crow` (was previously only `_c`)

follows the naming convention on norns.

fixes #200 