### PR TITLE
add basic time query

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -20,6 +20,7 @@
 #include "../ll/system.h"   // getUID_Word()
 #include "lib/events.h"     // event_t event_post()
 #include "lib/midi.h"       // MIDI_Active()
+#include "stm32f7xx_hal.h"  // HAL_GetTick()
 
 // Lua libs wrapped in C-headers: Note the extra '.h'
 #include "lua/bootstrap.lua.h" // MUST LOAD THIS MANUALLY FIRST
@@ -208,6 +209,11 @@ static int _unique_id( lua_State *L )
     lua_pushinteger(L, getUID_Word(4));
     lua_pushinteger(L, getUID_Word(8));
     return 3;
+}
+static int _time( lua_State *L )
+{
+    lua_pushinteger(L, HAL_GetTick());
+    return 1;
 }
 static int _go_toward( lua_State *L )
 {
@@ -454,6 +460,7 @@ static const struct luaL_Reg libCrow[]=
         // system
     , { "sys_bootloader"   , _bootloader       }
     , { "unique_id"        , _unique_id        }
+    , { "time"             , _time             }
     //, { "sys_cpu_load"     , _sys_cpu          }
         // io
     , { "go_toward"        , _go_toward        }


### PR DESCRIPTION
Beware this makes a global function `time()` which will very likely get trampled by a user's script.

On norns it's wrapped in a table called `util` which i think we should also do on crow. Making a new gh issue.