### PR TITLE
Separate input.stream from metros. call timers directly

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -20,6 +20,7 @@
 #include "../ll/system.h"   // getUID_Word()
 #include "lib/events.h"     // event_t event_post()
 #include "lib/midi.h"       // MIDI_Active()
+#include "../ll/timers.h"   // Timer_*()
 #include "stm32f7xx_hal.h"  // HAL_GetTick()
 
 // Lua libs wrapped in C-headers: Note the extra '.h'
@@ -260,11 +261,8 @@ static int _set_input_stream( lua_State *L )
     Detect_t* d = Detect_ix_to_p( ix ); // Lua is 1-based
     if(d){ // valid index
         Detect_none( d );
-        Metro_start( ix
-                   , luaL_checknumber(L, 2)
-                   , -1
-                   , 0
-                   );
+        Timer_Set_Params( ix, luaL_checknumber(L, 2) );
+        Timer_Start( ix, L_queue_in_stream );
         if( ix == 0 ){ MIDI_Active( 0 ); } // deactivate MIDI if first chan
     }
     lua_pop( L, 2 );
@@ -276,7 +274,7 @@ static int _set_input_change( lua_State *L )
     uint8_t ix = luaL_checkinteger(L, 1)-1;
     Detect_t* d = Detect_ix_to_p( ix ); // Lua is 1-based
     if(d){ // valid index
-        Metro_stop( ix );
+        Timer_Stop( ix );
         Detect_change( d
                      , L_queue_change
                      , luaL_checknumber(L, 2)
@@ -296,7 +294,7 @@ static int _set_input_midi( lua_State *L )
         Detect_t* d = Detect_ix_to_p( ix ); // Lua is 1-based
         if(d){ // valid index
             Detect_none( d );
-            Metro_stop( ix );
+            Timer_Stop( ix );
             MIDI_Active( 1 );
         }
     }

--- a/lib/metro.c
+++ b/lib/metro.c
@@ -26,9 +26,9 @@ static void Metro_bang( int ix );
 
 // public definitions
 int max_num_metros = 0;
-void Metro_Init(void)
+void Metro_Init( int num_metros )
 {
-    max_num_metros = Timer_Init( Metro_bang );
+    max_num_metros = num_metros;
     metros = malloc( sizeof(Metro_t) * max_num_metros );
 
     for( int i=0; i<max_num_metros; i++ ){
@@ -55,7 +55,7 @@ void Metro_start( int   ix
     t->stage  = stage;
 
     Timer_Set_Params( ix, seconds );
-    Timer_Start( ix );
+    Timer_Start( ix, Metro_bang );
 }
 
 // cancel all scheduled iterations
@@ -83,11 +83,7 @@ void Metro_set_time( int ix, float sec )
 static void Metro_bang( int ix )
 {
     // TODO confirm lua(1) makes a single tick
-    if( ix < 2 ){
-        L_queue_in_stream( ix );
-    } else {
-        L_queue_metro( ix, metros[ix].stage );
-    }
+    L_queue_metro( ix, metros[ix].stage );
     metros[ix].stage++;
     //FIXME next line causes system not to load?
     if( metros[ix].stage == 0x7FFFFFFF ){ metros[ix].stage = 0x7FFFFFFE; } // overflow

--- a/lib/metro.c
+++ b/lib/metro.c
@@ -5,7 +5,6 @@
 
 #include "../ll/timers.h"      // _Init() _Start() _Stop() _Set_Params()
 #include "lualink.h"           // L_handle_metro()
-#include "io.h"                // IO_handle_timer
 
 typedef enum { METRO_STATUS_RUNNING
              , METRO_STATUS_STOPPED

--- a/lib/metro.h
+++ b/lib/metro.h
@@ -2,7 +2,7 @@
 
 extern const int MAX_NUM_METROS;
 
-void Metro_Init(void);
+void Metro_Init( int num_metros );
 
 // create a metro at the specified index
 // seconds < 0 == use previous period

--- a/ll/timers.c
+++ b/ll/timers.c
@@ -51,7 +51,7 @@ const Timer_setup_t _timer[]=
     };
 
 TIM_HandleTypeDef TimHandle[MAX_LL_TIMERS];
-Timer_Callback_t callback;
+Timer_Callback_t callback[MAX_LL_TIMERS];
 
 // FIXME have to manually index the following
 //void TIM1_IRQHandler( void ){  HAL_TIM_IRQHandler( &(TimHandle[0]) ); }
@@ -69,9 +69,8 @@ void TIM8_BRK_TIM12_IRQHandler(     void ){ HAL_TIM_IRQHandler( &(TimHandle[7]) 
 void TIM8_UP_TIM13_IRQHandler(      void ){ HAL_TIM_IRQHandler( &(TimHandle[8]) ); }
 void TIM8_TRG_COM_TIM14_IRQHandler( void ){ HAL_TIM_IRQHandler( &(TimHandle[9]) ); }
 
-int Timer_Init( Timer_Callback_t cb )
+int Timer_Init(void)
 {
-    callback = cb;
     for( int i=0; i<MAX_LL_TIMERS; i++ ){
         TimHandle[i].Instance = _timer[i].Instance;
 
@@ -106,7 +105,7 @@ void HAL_TIM_PeriodElapsedCallback( TIM_HandleTypeDef *htim )
     if( !USB_TIM_PeriodElapsedCallback(htim) ){
         for( int i=0; i<MAX_LL_TIMERS; i++ ){
             if( htim == &(TimHandle[i]) ){
-                (*callback)(i); // raise callback
+                (*callback[i])(i); // raise callback
                 return;
             }
         }
@@ -129,9 +128,10 @@ void Timer_Set_Params( int ix, float seconds )
     }
 }
 
-void Timer_Start( int ix )
+void Timer_Start( int ix, Timer_Callback_t cb )
 {
     uint8_t err;
+    callback[ix] = cb;
     BLOCK_IRQS(
         err = HAL_TIM_Base_Start_IT( &(TimHandle[ix]) );
     );

--- a/ll/timers.h
+++ b/ll/timers.h
@@ -40,8 +40,8 @@
 
 typedef void (*Timer_Callback_t)(int);
 
-int Timer_Init( Timer_Callback_t cb );
+int Timer_Init(void);
 
-void Timer_Start( int ix );
+void Timer_Start( int ix, Timer_Callback_t cb );
 void Timer_Stop( int ix );
 void Timer_Set_Params( int ix, float seconds );

--- a/main.c
+++ b/main.c
@@ -29,7 +29,8 @@ int main(void)
     IO_Init();
     IO_Start(); // must start IO before running lua init() script
     events_init();
-    Metro_Init( Timer_Init() );
+    int max_timers = Timer_Init();
+    Metro_Init( max_timers );
     Caw_Init();
     CDC_clear_buffers();
     ii_init( II_CROW );

--- a/main.c
+++ b/main.c
@@ -4,6 +4,7 @@
 #include "syscalls.c" // printf() redirection
 #include "lib/io.h"
 #include "lib/events.h"
+#include "ll/timers.h"
 #include "lib/metro.h"
 #include "lib/caw.h"
 #include "lib/ii.h"
@@ -28,7 +29,7 @@ int main(void)
     IO_Init();
     IO_Start(); // must start IO before running lua init() script
     events_init();
-    Metro_Init();
+    Metro_Init( Timer_Init() );
     Caw_Init();
     CDC_clear_buffers();
     ii_init( II_CROW );


### PR DESCRIPTION
Previously the input[n].stream events were passed via the metro C library. This PR makes stream call directly to ll/timers which means lib/metro no longer includes lib/io. Better separates parts, so the metro lib can be changed without affecting the functionality of input.stream.

Now the timers library accepts a function pointer for each timer which is called when the time has elapsed.

fixes #114 