### PR TITLE
increase First gate threshold to 1V

### DIFF
--- a/lua/First.lua
+++ b/lua/First.lua
@@ -89,7 +89,10 @@ function init()
   output[4].action = ar(get_a,get_d)
 
   -- start sequence!
-  input[1]{ mode = 'change', direction = 'rising' }
+  input[1]{ mode = 'change'
+          , direction = 'rising'
+	  , threshold = 1.0
+	  }
   dec = metro.init{ event = env, time = 0.1 }
   dec:start()
 end

--- a/lua/First.lua
+++ b/lua/First.lua
@@ -91,8 +91,8 @@ function init()
   -- start sequence!
   input[1]{ mode = 'change'
           , direction = 'rising'
-	  , threshold = 1.0
-	  }
+          , threshold = 1.0
+          }
   dec = metro.init{ event = env, time = 0.1 }
   dec:start()
 end

--- a/lua/First.lua
+++ b/lua/First.lua
@@ -89,10 +89,7 @@ function init()
   output[4].action = ar(get_a,get_d)
 
   -- start sequence!
-  input[1]{ mode = 'change'
-          , direction = 'rising'
-          , threshold = 1.0
-          }
+  input[1]{ mode = 'change', direction = 'rising' }
   dec = metro.init{ event = env, time = 0.1 }
   dec:start()
 end

--- a/lua/input.lua
+++ b/lua/input.lua
@@ -10,7 +10,7 @@ function Input.new( chan )
     local i = { channel    = chan
               , _mode      = 'none'
               , time       = 0.1
-              , threshold  = 0.5
+              , threshold  = 1.0
               , hysteresis = 0.1
               , direction  = 'both'
               , windows    = {}


### PR DESCRIPTION
Seems from measurement that Maths EOR/EOC gate outputs, and probably some other common modules, have a sloppy low of about 0.7V, causing First not to trigger. Not sure if maybe the default threshold (0.5V) in input.lua should be changed as well. This was giving at least [one person](https://llllllll.co/t/crow-help-general-connectivity-device-qs-ecosystem/25866/128) trouble, thought I saw another post about this too but am not finding it now.