### PR TITLE
stop input polling timers during upload to avoid crashes

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -98,6 +98,20 @@ void Lua_DeInit(void)
     lua_close(L);
 }
 
+void Lua_pause_inputs( void )
+{
+    for (uint8_t ix = 0; ix < 2; ix++){
+	Timer_Stop(ix);
+    }
+}
+
+void Lua_resume_inputs( void )
+{
+    for (uint8_t ix = 0; ix < 2; ix++){
+	Timer_Start( ix, L_queue_in_stream );
+    }
+}
+
 // C-fns accessible to lua
 
 // NB these static functions are prefixed  with '_'

--- a/lib/lualink.h
+++ b/lib/lualink.h
@@ -19,6 +19,8 @@ uint8_t Lua_eval( lua_State*     L
                 , ErrorHandler_t errfn
                 );
 void Lua_load_default_script( void );
+void Lua_pause_inputs( void );
+void Lua_resume_inputs( void );
 
 // Event enqueue wrappers
 extern void L_queue_toward( int id );

--- a/lib/repl.c
+++ b/lib/repl.c
@@ -53,6 +53,7 @@ void REPL_init( lua_State* lua )
 
 void REPL_begin_upload( void )
 {
+    Lua_pause_inputs();
     Lua_Reset(); // free up memory
     if( REPL_new_script_buffer( USER_SCRIPT_SIZE ) ){
         repl_mode = REPL_reception;
@@ -82,6 +83,7 @@ void REPL_upload( int flash )
             } else {
                 Caw_send_luachunk("running...");
             }
+            Lua_resume_inputs();
             Lua_crowbegin();
         } else {
             Caw_send_luachunk("evaluation failed");

--- a/lib/repl.c
+++ b/lib/repl.c
@@ -83,13 +83,13 @@ void REPL_upload( int flash )
             } else {
                 Caw_send_luachunk("running...");
             }
-            Lua_resume_inputs();
             Lua_crowbegin();
         } else {
             Caw_send_luachunk("evaluation failed");
         }
         free(new_script);
     }
+    Lua_resume_inputs();
     repl_mode = REPL_normal;
 }
 


### PR DESCRIPTION
Disables the timers for input stream polling while a script upload is in progress. This seems to improve the situation for some types of crow crashes during script upload, as reported by users on the forum and discussed [here](https://github.com/monome/druid/issues/44). With the 1.0.0 firmware, I can upload longer scripts a few times, but then start getting Lua evaluation failures followed shortly by complete crow crashes (on windows: crow disconnects, then reconnects a while later but with a "device scan failed" message, and is unusable until a power cycle). With this patch I am able to load the example script in https://github.com/monome/druid/issues/44 repeatedly without crashes.

I am still unable to do reliable uploads of longer scripts from OSX, on either the 1.0.0 firmware or with this patch. This I think is something of a different issue (edit: I suspect now it is [this](https://github.com/monome/druid/pull/48)), because I typically am still able to ask crow to print the user script, but Lua evaluation has stopped working -- if I run `^^r` in this situation I am able to use the REPL again.

I have not tried this patch when uploading from Linux yet, hopefully the behavior there is closer to the Windows behavior than OSX.