### PR TITLE
Stop all interrupt generating routines when calling Lua_Reset()

### DIFF
--- a/lib/events.c
+++ b/lib/events.c
@@ -25,17 +25,8 @@ void (*app_event_handlers[E_COUNT])(event_t *e) = { handler_none };
 // initialize event handler
 void events_init() {
     printf("\ninitializing event handler\n");
-    int k;
 
-    // set queue (circular list) to empty
-    putIdx = 0;
-    getIdx = 0;
-
-    // zero out the event records
-    for ( k = 0; k < MAX_EVENTS; k++ ) {
-        sysEvents[ k ].type   = 0;
-        sysEvents[ k ].data.i = 0;
-    }
+    events_clear();
 
     // assign event handlers
     app_event_handlers[E_none] = &handler_none;
@@ -44,6 +35,19 @@ void events_init() {
     app_event_handlers[E_change] = &handler_change;
     app_event_handlers[E_toward] = &handler_toward;
     app_event_handlers[E_midi] = &handler_midi;
+}
+
+void events_clear(void)
+{
+    // set queue (circular list) to empty
+    putIdx = 0;
+    getIdx = 0;
+
+    // zero out the event records
+    for ( int k = 0; k < MAX_EVENTS; k++ ) {
+        sysEvents[ k ].type   = 0;
+        sysEvents[ k ].data.i = 0;
+    }
 }
 
 // get next event

--- a/lib/events.h
+++ b/lib/events.h
@@ -30,6 +30,7 @@ extern void (*app_event_handlers[])(event_t *e);
 
 
 extern void events_init(void);
+extern void events_clear(void);
 extern uint8_t event_post(event_t *e);
 extern uint8_t event_next(event_t *e);
 

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -81,6 +81,14 @@ lua_State* Lua_Init(void)
 
 void Lua_Reset( void )
 {
+    Metro_stop_all();
+    for( int i=0; i<2; i++ ){
+        Detect_none( Detect_ix_to_p(i) );
+    }
+    for( int i=0; i<4; i++ ){
+        S_toward( i, 0.0, 0.0, SHAPE_Linear, NULL );
+    }
+    events_clear();
     Lua_DeInit();
     Lua_Init();
 }

--- a/lib/metro.c
+++ b/lib/metro.c
@@ -70,6 +70,13 @@ void Metro_stop( int ix )
     }
 }
 
+void Metro_stop_all( void )
+{
+    for( int i=0; i<max_num_metros; i++ ){
+        Metro_stop(i);
+    }
+}
+
 // set period of metro
 void Metro_set_time( int ix, float sec )
 {

--- a/lib/metro.h
+++ b/lib/metro.h
@@ -14,6 +14,7 @@ void Metro_start( int   idx
 
 // cancel all scheduled iterations
 void Metro_stop( int idx );
+void Metro_stop_all( void );
 
 // set period of metro
 // NB: if the metro is running, its hard to say if new value will take effect


### PR DESCRIPTION
This is an alternative PR for @csboling 's #232. Firstly, big thanks for isolating this issue!!

This PR takes the idea of turning off the input streams when uploading, and applies it to all C routines that generate interrupts causing events to be added to the queue. My hypothesis is that the crashes are resulting from events being added to the event queue after the Lua VM has been torn down, then being called again.

This is acheived in the C-function `Lua_Reset` which is called before either a `r` or `u` upload in druid. As we're tearing down the whole Lua VM, the metros should not be restarted manually, instead waiting for the lua script to do it if that's part of the init() function. Now Lua_Reset does the following before calling Lua_DeInit():
- deactivate inputs in either `stream` or `change` mode
- ensure all outputs are set to zero volts & don't raise events when they arrive there
- deactivate all metros
- empty the event queue

Testing here shows I can repeatedly `u` a long script on linux. I'll test on OS X & Windows (unless someone beats me to it).