### PR TITLE
Lua VM reconstruction fixed

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -79,8 +79,9 @@ lua_State* Lua_Init(void)
     return L;
 }
 
-void Lua_Reset( void )
+lua_State* Lua_Reset( void )
 {
+    printf("Lua_Reset\n");
     Metro_stop_all();
     for( int i=0; i<2; i++ ){
         Timer_Stop(i);
@@ -91,7 +92,7 @@ void Lua_Reset( void )
     }
     events_clear();
     Lua_DeInit();
-    Lua_Init();
+    return Lua_Init();
 }
 
 void Lua_load_default_script( void )

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -83,6 +83,7 @@ void Lua_Reset( void )
 {
     Metro_stop_all();
     for( int i=0; i<2; i++ ){
+        Timer_Stop(i);
         Detect_none( Detect_ix_to_p(i) );
     }
     for( int i=0; i<4; i++ ){

--- a/lib/lualink.h
+++ b/lib/lualink.h
@@ -9,7 +9,7 @@ typedef void (*ErrorHandler_t)(char* error_message);
 struct lua_lib_locator{ const char* name; const char* addr_of_luacode; };
 
 lua_State* Lua_Init(void);
-void Lua_Reset(void);
+lua_State* Lua_Reset( void );
 void Lua_DeInit(void);
 
 void Lua_crowbegin( void );

--- a/lib/repl.c
+++ b/lib/repl.c
@@ -54,7 +54,7 @@ void REPL_init( lua_State* lua )
 
 void REPL_begin_upload( void )
 {
-    Lua_Reset(); // free up memory
+    REPL_reset(); // free up memory
     if( REPL_new_script_buffer( USER_SCRIPT_SIZE ) ){
         repl_mode = REPL_reception;
     } else {
@@ -98,7 +98,7 @@ void REPL_upload( int flash )
 
 void REPL_clear_script( void )
 {
-    Lua_Reset();
+    REPL_reset();
     Flash_clear_user_script();
     Caw_send_luachunk("User script cleared.");
     REPL_print_script_name(NULL);
@@ -107,12 +107,17 @@ void REPL_clear_script( void )
 
 void REPL_default_script( void )
 {
-    Lua_Reset();
+    REPL_reset();
     Flash_default_user_script();
     Caw_send_luachunk("Using default script.");
     REPL_print_script_name(NULL);
     Lua_load_default_script();
     Lua_crowbegin();
+}
+
+void REPL_reset( void )
+{
+    Lua = Lua_Reset();
 }
 
 void REPL_eval( char* buf, uint32_t len, ErrorHandler_t errfn )

--- a/lib/repl.h
+++ b/lib/repl.h
@@ -14,6 +14,7 @@ void REPL_begin_upload( void );
 void REPL_upload( int flash );
 void REPL_clear_script( void );
 void REPL_default_script( void );
+void REPL_reset( void );
 
 void REPL_eval( char* buf, uint32_t len, ErrorHandler_t errfn );
 void REPL_print_script( void );

--- a/main.c
+++ b/main.c
@@ -56,7 +56,7 @@ int main(void)
             case C_print:       REPL_print_script(); break;
             case C_version:     system_print_version(); break;
             case C_identity:    system_print_identity(); break;
-            case C_killlua:     Lua_Reset(); break;
+            case C_killlua:     REPL_reset(); break;
             case C_flashclear:  REPL_clear_script(); break;
             case C_loadFirst:   REPL_default_script(); break;
             default: break; // 'C_none' does nothing


### PR DESCRIPTION
When running Lua_Reset, the stream timers were not deactivated causing events to continue to pile up until the new script ran.

More importantly (and the reason for only-one flash per reboot), when the Lua env was being torn down and re-initialized, the pointer to that `lua_State` was not being updated in lib/repl.c, meaning that subsequent uploads would try and free the old lua_State that likely no longer lived at the same address.

Now all calls to `Lua_Reset` are done via `REPL_reset` which updates the reference in lib/repl.c

From my testing, previously crashing scripts with active streams are no longer crashing.

cc @csboling 