### PR TITLE
handle packets greater than 64bytes

### DIFF
--- a/usbd/usbd_cdc_interface.h
+++ b/usbd/usbd_cdc_interface.h
@@ -74,7 +74,9 @@ extern USBD_CDC_ItfTypeDef  USBD_CDC_fops;
 void CDC_clear_buffers();
 
 void USB_tx_enqueue( uint8_t* buf, uint32_t len );
-uint8_t USB_rx_dequeue( uint8_t** buf, uint32_t* len );
+uint8_t USB_rx_dequeue_LOCK( uint8_t** buf, uint32_t* len );
+void USB_rx_dequeue_UNLOCK( void );
+
 
 // called from timer library
 uint8_t USB_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim);


### PR DESCRIPTION
Previously single USB packets of more than 64bytes could overwrite the rx buffer on crow causing the line to be corrupted. These are now correctly sequenced, so longer commands are accepted (both from the REPL and in an uploaded file).