### PR TITLE
Repl discard double free

### DIFF
--- a/lib/repl.c
+++ b/lib/repl.c
@@ -124,9 +124,9 @@ void REPL_eval( char* buf, uint32_t len, ErrorHandler_t errfn )
                    )){
             printf("!eval\n");
         }
-    } else { // REPL_reception
+    } else if( repl_mode == REPL_reception ){ // REPL_reception
         REPL_receive_script( buf, len, errfn );
-    }
+    } // else REPL_discard
 }
 
 void REPL_print_script( void )
@@ -174,8 +174,6 @@ void REPL_print_script_name( char* buffer )
 // private funcs
 static void REPL_receive_script( char* buf, uint32_t len, ErrorHandler_t errfn )
 {
-    if( repl_mode == REPL_discard ){ return; } // EARLY RETURN
-
     if( new_script_len + len >= USER_SCRIPT_SIZE ){
         Caw_send_luachunk("!ERROR! Script is too long.");
         repl_mode = REPL_discard;

--- a/lib/repl.c
+++ b/lib/repl.c
@@ -174,6 +174,8 @@ void REPL_print_script_name( char* buffer )
 // private funcs
 static void REPL_receive_script( char* buf, uint32_t len, ErrorHandler_t errfn )
 {
+    if( repl_mode == REPL_discard ){ return; } // EARLY RETURN
+
     if( new_script_len + len >= USER_SCRIPT_SIZE ){
         Caw_send_luachunk("!ERROR! Script is too long.");
         repl_mode = REPL_discard;


### PR DESCRIPTION
If a mass upload had begun and failed due to the script being too long, the reception buffer will be `free`d on every received packet, leading to a memory fault & crash.

This PR simply ignores any received bytes when in REPL_discard state until an end-upload command is received.