### PR TITLE
Fix bug where the slopes library could crash crow

### DIFF
--- a/lib/slopes.c
+++ b/lib/slopes.c
@@ -116,9 +116,10 @@ float* S_step_v( int     index
         int after_break = size - i - 1; // 1 is the iRem + after_breakRem
 
         *out2++ = self->here + self->delta;
-        i--;
-        while(i--){
-            *out2++ = *out3++ + self->delta;
+        if(i--){ // account for above, and skip if zero
+            while(i--){
+                *out2++ = *out3++ + self->delta;
+            }
         }
         *out2++ = self->dest;
         // TODO compesnate for this amount of overshoot with the new trajectory

--- a/stm32f7xx_it.c
+++ b/stm32f7xx_it.c
@@ -41,15 +41,19 @@
 #include "stm32f7xx_hal.h"
 #include "stm32f7xx_it.h"
 
+#include "ll/debug_usart.h" // U_PrintNow()
+
 /******************************************************************************/
 /*            Cortex-M7 Processor Exceptions Handlers                         */
 /******************************************************************************/
 
+void wait(void){ U_PrintNow(); while(1); }
+
 void NMI_Handler(void){ printf("!!NMI\n"); }
-void HardFault_Handler(void){ printf("!!HardFault\n"); while(1){} }
-void MemManage_Handler(void){ printf("!!MemManage\n"); while(1){} }
-void BusFault_Handler(void){ printf("!!BusFault\n"); while(1){} }
-void UsageFault_Handler(void){ printf("!!UsageFault\n"); while(1){} }
+void HardFault_Handler(void){ printf("!!HardFault\n"); wait(); }
+void MemManage_Handler(void){ printf("!!MemManage\n"); wait(); }
+void BusFault_Handler(void){ printf("!!BusFault\n"); wait(); }
+void UsageFault_Handler(void){ printf("!!UsageFault\n"); wait(); }
 void SVC_Handler(void){ printf("!!SVC\n"); }
 void DebugMon_Handler(void){ printf("!!DebugMon\n"); }
 void PendSV_Handler(void){ printf("!!PendSV\n"); }


### PR DESCRIPTION
If there was less than 1 sample of an existing slope to run before triggering the next breakpoint, crow could segfault & crash.

This was hard to catch because the system level failures weren't making it over the uart, so this PR also ensures they are sent (by banging the uart send function before hanging).