### PR TITLE
Asl scope & done callback & running var

### DIFF
--- a/lua/asl.lua
+++ b/lua/asl.lua
@@ -16,6 +16,7 @@ function Asl.new(id)
     asl.locked  = false    -- flag to lockout bangs during lock{}
     asl.retStk = {}
     asl.pc = 1
+    asl.done = function() end -- function that does nothing
     setmetatable( asl, Asl )
     return asl
 end
@@ -125,6 +126,9 @@ function Asl:step()
         if self:exit() then
             if self:nek() then print'layer doesnt exist'
             else self:step() end
+        else
+            print'asl complete?'
+            self.done()
         end
         return
     end

--- a/lua/asl.lua
+++ b/lua/asl.lua
@@ -30,6 +30,10 @@ function Asl:init() -- reset to defaults
     return self
 end
 
+
+-------------------------------
+-- setting & calling .action
+
 local function set_action( self, exe )
     if type(exe) == 'function' then
         self.exe = {exe}
@@ -40,7 +44,6 @@ local function set_action( self, exe )
     self.pc = 1
 end
 
--- FIXME why can't we use :method call on restart, release & step?
 local function do_action( self, dir )
     local t = type(dir)
     if t == 'table' then
@@ -74,6 +77,35 @@ local function do_action( self, dir )
     end
 end
 
+
+-------------------------------------
+-- metamethods for handling .action
+
+Asl.__newindex = function(self, ix, val)
+    if ix == 'action' then set_action( self, val) end
+end
+
+Asl.__index = function(self, ix)
+    if ix == 'action' then
+        return function(self,a) do_action(self,a) end
+    elseif ix == 'step' then return Asl.step
+    elseif ix == 'init' then return Asl.init
+    -- private fns below (called from step)
+    elseif ix == 'nek' then return Asl.nek
+    elseif ix == 'enter' then return Asl.enter
+    elseif ix == 'exit' then return Asl.exit
+    elseif ix == 'recur' then return Asl.recur
+    elseif ix == 'release' then return Asl.release
+    elseif ix == 'restart' then return Asl.restart
+    elseif ix == 'cleanup' then return Asl.cleanup
+    elseif ix == 'isOver' then return Asl.cleanup
+    end
+end
+
+
+--------------------------------------------
+-- program counter (runtime) manipulations
+
 local function get_frame( self )
     local f = self.exe
     for i=1, #self.retStk do
@@ -82,9 +114,12 @@ local function get_frame( self )
     return f
 end
 
+-- Asl:step() is the primary entry point for a to-callback
 function Asl:step()
     if self.exe == nil then print'no asl active' return end
 
+    -- get the new frame
+    -- escape up a layer if it doesn't exist & recurse
     local p = get_frame(self)[self.pc]
     if not p then
         if self:exit() then
@@ -94,22 +129,24 @@ function Asl:step()
         return
     end
 
+    -- execute the next element in the asl table
     local t = type(p)
     if t == 'function' then
+        -- run a function & recurse until seeing a 'wait'
+        -- 'wait' is typically the result of a call to 'to'
         local wait = p(self)
         if self:nek() then print'last exit'
         elseif not wait then self:step()
         end
     elseif t == 'string' then
+        -- skip strings (they are comments or tags)
         if self:nek() then print'string exit'
         else self:step() end
     elseif t == 'table' then
+        -- enter a table which should contain another asl
         self:enter(p):step()
     end
 end
-
---------------------------------
--- program counter manipulations
 
 function Asl:nek()
     if self.pc then
@@ -152,7 +189,6 @@ function Asl:cleanup(str)
     end
 end
 
--- TODO abstract out common parts from Asl:step
 function Asl:release()
     while self.in_hold do
         local f = get_frame(self)
@@ -167,33 +203,64 @@ function Asl:release()
     end
 end
 
---------------
--- metamethods
 
-Asl.__newindex = function(self, ix, val)
-    if ix == 'action' then set_action( self, val) end
+----------------------------
+-- low-level ASL constructs
+
+function Asl.prepend( fn_head, fns )
+    table.insert( fns, 1, fn_head )
+    return fns
 end
 
-Asl.__index = function(self, ix)
-    if ix == 'action' then
-        return function(self,a) do_action(self,a) end
-    elseif ix == 'step' then return Asl.step
-    elseif ix == 'init' then return Asl.init
-    -- private fns below
-    elseif ix == 'nek' then return Asl.nek
-    elseif ix == 'enter' then return Asl.enter
-    elseif ix == 'exit' then return Asl.exit
-    elseif ix == 'recur' then return Asl.recur
-    elseif ix == 'release' then return Asl.release
-    elseif ix == 'restart' then return Asl.restart
-    elseif ix == 'cleanup' then return Asl.cleanup
-    elseif ix == 'isOver' then return Asl.cleanup
+function Asl.append( fn_tail, fns )
+    table.insert( fns, fn_tail )
+    return fns
+end
+
+function Asl._if( fn_to_bool, fns )
+    return {Asl.prepend(
+              function(self)
+                if not fn_to_bool(self) then self:exit() end
+              end
+            , fns )}
+end
+
+function Asl.wrap( fn_head, fns, fn_tail )
+    return Asl.append( fn_tail
+                     , Asl.prepend( fn_head
+                                  , fns ))
+end
+
+function Asl._while( fn_to_bool, fns )
+    return {Asl.wrap( function(self)
+                        if not fn_to_bool(self) then self:exit() end
+                      end
+                    , fns
+                    , Asl.recur
+                    )}
+end
+
+
+-----------------------------------------------
+-- helper for deferring computation to runtime
+
+function Asl.runtime(fn,...)
+    local args = {...}
+    if #args == 0 then
+        return fn
+    else
+        local a = table.remove(args,1)
+        if type(a) == 'function' then
+            return Asl.runtime(function(...) return fn(a(),...) end, table.unpack(args))
+        else
+            return Asl.runtime(function(...) return fn(a,...) end, table.unpack(args))
+        end
     end
 end
 
 
---------------------------------
--- low level ASL building blocks
+-------------------------------------
+-- public (global) ASL constructs
 
 function to( dest, time, shape )
     -- COMPILE TIME
@@ -216,63 +283,13 @@ function to( dest, time, shape )
     end
 end
 
-function Asl.runtime(fn,...)
-    local args = {...}
-    if #args == 0 then
-        return fn
-    else
-        local a = table.remove(args,1)
-        if type(a) == 'function' then
-            return Asl.runtime(function(...) return fn(a(),...) end, table.unpack(args))
-        else
-            return Asl.runtime(function(...) return fn(a,...) end, table.unpack(args))
-        end
-    end
-end
-
-function asl_prepend( fn_head, fns )
-    table.insert( fns, 1, fn_head )
-    return fns
-end
-
-function asl_append( fn_tail, fns )
-    table.insert( fns, fn_tail )
-    return fns
-end
-
-function asl_if( fn_to_bool, fns )
-    return {asl_prepend(
-              function(self)
-                if not fn_to_bool(self) then self:exit() end
-              end
-            , fns )}
-end
-
 function loop( fns )
-    return {asl_append( Asl.recur, fns )}
+    return {Asl.append( Asl.recur, fns )}
 end
-
-function asl_wrap( fn_head, fns, fn_tail )
-    return asl_append( fn_tail
-                     , asl_prepend( fn_head
-                                  , fns ))
-end
-
-function asl_while( fn_to_bool, fns )
-    return {asl_wrap( function(self)
-                        if not fn_to_bool(self) then self:exit() end
-                      end
-                    , fns
-                    , Asl.recur
-                    )}
-end
-
-----------------------------
--- high level ASL constructs
 
 function times( count, fns )
     local c
-    return asl_while(
+    return Asl._while(
               function(self)
                   if not c then c = count end
                   if c <= 0 then c = nil
@@ -283,22 +300,26 @@ function times( count, fns )
 end
 
 function lock( fns ) -- table -> table
-    return{ asl_append( function(self) self.lock = true end
+    return{ Asl.append( function(self) self.lock = true end
                       , fns )
           , 'unlock'
           }
 end
 
 function held( fns ) -- table -> table
-    return{ asl_if( function(self) return self.hold end
-                , asl_append( function(self) return 'wait' end
-                  , asl_prepend( function(self) self.in_hold = true end
+    return{ Asl._if( function(self) return self.hold end
+                , Asl.append( function(self) return 'wait' end
+                  , Asl.prepend( function(self) self.in_hold = true end
                     , fns )))
           , 'unhold'
           }
 end
 
--- at bottom to make sure we capture all the metamethods & Asl namespace functions
+
+---------------------------------------------------------
+-- capture all the metamethods & Asl namespace functions
+
 setmetatable(Asl, Asl)
+
 
 return Asl

--- a/lua/asl.lua
+++ b/lua/asl.lua
@@ -14,6 +14,7 @@ function Asl.new(id)
     asl.hold    = false    -- is the slope trigger currently held high
     asl.in_hold = false    -- is eval currently in a held construct
     asl.locked  = false    -- flag to lockout bangs during lock{}
+    asl.running = false    -- flag to mark if asl is active
     asl.retStk = {}
     asl.pc = 1
     asl.done = function() end -- function that does nothing
@@ -26,6 +27,7 @@ function Asl:init() -- reset to defaults
     self.hold    = false  -- is the slope trigger currently held high
     self.in_hold = false  -- is eval currently in a held construct
     self.locked  = false  -- flag to lockout bangs during lock{}
+    self.running = false  -- flag to mark if asl is active
     self.retStk = {}
     self.pc = 1
     return self
@@ -46,6 +48,7 @@ local function set_action( self, exe )
 end
 
 local function do_action( self, dir )
+    self.running = true  -- mark asl as running
     local t = type(dir)
     if t == 'table' then
         set_action(self,dir) -- assign new action. dir is an ASL!
@@ -127,8 +130,8 @@ function Asl:step()
             if self:nek() then print'layer doesnt exist'
             else self:step() end
         else
-            print'asl complete?'
-            self.done()
+            self.running = false
+            self.done() -- user callback on completion
         end
         return
     end

--- a/lua/output.lua
+++ b/lua/output.lua
@@ -40,7 +40,7 @@ end
 Output.__index = function(self, ix)
     if     ix == 'action'  then return self.asl.action
     elseif ix == 'volts'   then return LL_get_state(self.channel)
-    elseif ix == 'running' then return self.asl:isOver() or false
+    elseif ix == 'running' then return self.asl.running
     end
 end
 

--- a/lua/output.lua
+++ b/lua/output.lua
@@ -16,7 +16,12 @@ function Output.new( chan )
     o.asl.action = lfo( function() return o.rate  end
                       , function() return o.level end
                       )
+    -- function to be called on completion of asl sequence
+    o.done = function() _c.tell('asl_done',o.channel) end
+    o.asl.done = o.done
+
     setmetatable( o, Output )
+
     return o
 end
 
@@ -43,6 +48,7 @@ end
 Output.__call = function(self, ...)
     self.asl:action(...)
 end
+
 
 setmetatable(Output, Output) -- capture the metamethods
 

--- a/lua/output.lua
+++ b/lua/output.lua
@@ -16,9 +16,6 @@ function Output.new( chan )
     o.asl.action = lfo( function() return o.rate  end
                       , function() return o.level end
                       )
-    -- function to be called on completion of asl sequence
-    o.done = function() _c.tell('asl_done',o.channel) end
-    o.asl.done = o.done
 
     setmetatable( o, Output )
 
@@ -33,6 +30,8 @@ Output.__newindex = function(self, ix, val)
     elseif ix == 'volts' then
         self.asl.action = {to(val, self.slew)}
         self.asl:action()
+    elseif ix == 'done' then
+        self.asl.done = val
     end
 end
 

--- a/lua/output.lua
+++ b/lua/output.lua
@@ -38,10 +38,9 @@ end
 
 -- getters
 Output.__index = function(self, ix)
-    if ix == 'action' then
-        return self.asl.action
-    elseif ix == 'volts' then
-        return LL_get_state(self.channel)
+    if     ix == 'action'  then return self.asl.action
+    elseif ix == 'volts'   then return LL_get_state(self.channel)
+    elseif ix == 'running' then return self.asl:isOver()
     end
 end
 

--- a/lua/output.lua
+++ b/lua/output.lua
@@ -40,7 +40,7 @@ end
 Output.__index = function(self, ix)
     if     ix == 'action'  then return self.asl.action
     elseif ix == 'volts'   then return LL_get_state(self.channel)
-    elseif ix == 'running' then return self.asl:isOver()
+    elseif ix == 'running' then return self.asl:isOver() or false
     end
 end
 


### PR DESCRIPTION
Fixes #183 

Adds an event to the output lib to be called whenever a running ASL completes:
`output[1].done = function() <do things> end`

Adds a query to the output lib to find out if the ASL is running:
`print( output[1].running )` -> prints true/false

Pulled all of the low-level ASL building blocks into the Asl namespace so they don't pollute the global vars table.