### PR TITLE
avoid undefined behavior in REPL_print_script_name

### DIFF
--- a/lib/repl.c
+++ b/lib/repl.c
@@ -158,8 +158,7 @@ void REPL_print_script_name( char* buffer )
         case USERSCRIPT_Default:
             Caw_send_luachunk("Running: First.lua");
             break;
-        case USERSCRIPT_User:
-            buffer[0] = buffer[0]; // satisfy switch
+        case USERSCRIPT_User: {
             char script[64];
             memset( script, '\0', 64 );
             strcpy( script, "Running: " );
@@ -170,6 +169,7 @@ void REPL_print_script_name( char* buffer )
                                      );
             Caw_send_luachunk(script);
             break;
+	}
         case USERSCRIPT_Clear:
             Caw_send_luachunk("No user script.");
             break;


### PR DESCRIPTION
This patch uses a scope to get around the compiler error preventing variable declarations as the first line of a `case`, instead of the existing `buffer[0] = buffer[0];` statement. In some cases (e.g. after script upload) the param`buffer` is null, but compilers are allowed to assume that any pointer that's dereferenced is not null. Presumably GCC 5.4.0 (in my docker environment) does assume this, and uses it to inline the ternary expression conditional on `buffer`, whereas GCC 4.9.3 behaves differently. This causes a null pointer to be passed to `REPL_script_name_from_mem`, resulting in [this](https://github.com/monome/druid/pull/57#issuecomment-545708063) mysterious 54 bytes of uninitialized junk in the USB buffer followed by a UTF8 decoding error in druid. This patch resolves that error and I believe makes https://github.com/monome/druid/pull/57 unnecessary.