### PR TITLE
delay() to postpone execution of a provided function

### DIFF
--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -159,6 +159,20 @@ for _,fn in ipairs( wrapped_fns ) do
     -- fn = closure_if_table( fn ) -- this *doesn't* redirect the identifier
 end
 
+--- Delay execution of a function
+-- dynamically assigns metros (clashes with indexed metro syntax)
+function delay(time, action)
+    local d = {}
+    function devent(c)
+        if c > 1 then
+            action()
+            metro.free(d.id)
+        end
+    end
+    d = metro.init(devent, time)
+    if d then d:start() end
+end
+
 -- empty init function in case userscript doesn't define it
 function init() end
 


### PR DESCRIPTION
Uses the metro system, to dynamically create a timer which is thrown away after the action occurs.

Fixes #249 but note the limitations posted in that thread.

I think this is a good interim solution, and would be nice to have access to it in the crowlib. I think the syntax is about as good as we can get.