### PR TITLE
Add CI using GitHub Actions

### DIFF
--- a/.github/actions/build-firmware/README.md
+++ b/.github/actions/build-firmware/README.md
@@ -1,0 +1,7 @@
+# GitHub Action to build crow firmware
+Builds crow firmware, requires no configuration.
+
+## How to use
+```yaml
+- uses: ./.github/actions/build-firmware
+```

--- a/.github/actions/build-firmware/action.yml
+++ b/.github/actions/build-firmware/action.yml
@@ -1,0 +1,12 @@
+name: Build firmware
+
+runs:
+  using: docker
+  image: ../../../Dockerfile
+  args:
+    - R=${{ inputs.release }}
+inputs:
+  release:
+    description: Enables release build
+    required: false
+    default: '0'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,22 @@
+name: Build release firmware
+on:
+  release:
+    types: [created, edited]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Build
+      uses: ./.github/actions/build-firmware
+      with:
+        release: '1'
+    - name: Upload artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: crow-${{ github.sha }}.bin
+        path: crow.bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,18 @@
+name: Build firmware
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: Build
+      uses: ./.github/actions/build-firmware
+    - name: Upload artifact
+      uses: actions/upload-artifact@master
+      with:
+        name: crow-${{ github.sha }}.bin
+        path: crow.bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,19 @@
 FROM ubuntu:xenial
-WORKDIR /home/dev
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends software-properties-common && \
+    add-apt-repository ppa:team-gcc-arm-embedded/ppa -y && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
     build-essential \
     bzip2 \
     dfu-util \
+    gcc-arm-embedded \
     git \
     libreadline-dev \
-    software-properties-common \
     unzip \
-    wget
-RUN apt clean
-RUN add-apt-repository ppa:team-gcc-arm-embedded/ppa -y && \
-    apt-get update && \
-    apt-get install -y gcc-arm-embedded
+    wget && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN wget --quiet https://www.lua.org/ftp/lua-5.3.4.tar.gz -O lua.tar.gz && \
     wget --quiet https://luarocks.org/releases/luarocks-3.0.4.tar.gz -O luarocks.tar.gz
@@ -31,4 +29,4 @@ RUN tar -xzf lua.tar.gz && \
 RUN luarocks install fennel
 
 WORKDIR /target
-CMD make
+CMD ["make"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ RUN tar -xzf lua.tar.gz && \
 RUN luarocks install fennel
 
 WORKDIR /target
-CMD ["make"]
+ENTRYPOINT ["make"]


### PR DESCRIPTION
Currently simply builds Crow firmware

Basics are there, it builds the firmware, although there's still a failure because of #40 so I don't think the built firmware works. IMHO we should fix that separately.

It will also create a release build when a new release is made.

/cc @csboling 