### PR TITLE
i2c pullup resistors are enabled by default

### DIFF
--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -81,6 +81,7 @@ for chan = 1, #output do
     output[chan] = Output.new( chan )
 end
 
+
 --- asl
 function toward_handler( id ) end -- do nothing if asl not active
 -- if defined, make sure active before setting up actions and banging
@@ -102,7 +103,11 @@ function LL_get_state( id )
 end
 
 
---- ii default actions
+--- ii
+-- pullups on by default
+ii.pullup(true)
+
+--- follower default actions
 ii.self.output = function(chan,val)
     output[chan].volts = val
 end
@@ -110,6 +115,7 @@ end
 ii.self.slew = function(chan,slew)
     output[chan].slew = slew/1000 -- ms
 end
+
 
 --- True Random Number Generator
 -- redefine library function to use stm native rng
@@ -119,6 +125,7 @@ math.random = function(a,b)
     else return random_int(a,b)
     end
 end
+
 
 --- Syntax extensions
 function closure_if_table( f )


### PR DESCRIPTION
fixes #259 
Just enabling i2c pullup resistors be default. I don't think there's any potential for this to cause harm, and it will solve 90% of cases with pullup resistor issues. Better than having to always ask "did you enable pullups"?