### PR TITLE
Very fast slopes ok

### DIFF
--- a/lib/slopes.c
+++ b/lib/slopes.c
@@ -112,7 +112,10 @@ void S_toward( int        index
         if( overflow > 0.0 ){
             self->here += overflow * self->delta;
             self->countdown -= overflow;
-            // TODO add protection against overshoot for very <1block slopes
+            if( self->countdown <= 0.0 ){ // guard against overflow hitting callback
+                self->countdown = 0.00001; // force callback on next sample
+                self->here = 1.0; // set to destination
+            }
         }
     }
 }

--- a/lua/asllib.lua
+++ b/lua/asllib.lua
@@ -7,7 +7,7 @@ Asllib = {}
 function n2v( n ) return asl.runtime( function(a) return a/12 end, n ) end
 function negate( n ) return asl.runtime( function(a) return -a end, n ) end
 function clamp( input, min, max )
-    min, max = min or 0.005, max or 1e10
+    min, max = min or 0.001, max or 1e10
     return asl.runtime( function( a, b, c )
                  return math.min( math.max( b, a ), c )
                end


### PR DESCRIPTION
Builds on PR #251.

Fixes case where ASL slopes with (0 < time < 0.002) could stop running. This happened when the 'overflow' compensation (for subsample accuracy) would complete the next `to` immediately on being set, resulting in the 'action' never being called as the slope was considered 'stopped'. My solution was to catch overflow that completes the next slope, and rewind it by 0.0001 samples to force the action to be called next sample.

Added benefit is we can now push the slope times down closer to 0 without fear of crashing. I've tuned the asllib `clamp()` function to default to 0.001 (1ms -> 1khz) allowing oscillations up to ~500Hz (though tuning gets worse the higher you go).

Fixes #245