### PR TITLE
add support for i2c devices with no setters (only getters)

### DIFF
--- a/lua/ii/txi.lua
+++ b/lua/ii/txi.lua
@@ -10,15 +10,6 @@ do return
 , manufacturer = 'bpc'
 , i2c_address  = {0x68, 0x69, 0x6A, 0x6B, 0x6C, 0x6D, 0x6E, 0x6F}
 , lua_name     = 'txi'
-, commands     =
-  { { name = 'nop'
-    , cmd  = 2
-    , docs = 'place holder'
-    , args = { { 'channel', s8 }
-             , { 'state', s8 }
-             }
-    }
-  }
 , getters =
   { { name = 'param'
     , cmd  = PARAM

--- a/util/ii_lua_module.lua
+++ b/util/ii_lua_module.lua
@@ -20,6 +20,7 @@ function prepare_multi_address(f)
 end
 
 function lua_cmds(f)
+    if not f.commands then return '' end
     local c = ''
     for _,v in ipairs( f.commands ) do
         c = c .. 'function ' .. f.lua_name .. '.' .. v.name .. '(...)ii.set('
@@ -30,9 +31,11 @@ end
 
 function lua_getters(f)
     local g = f.lua_name .. '.g={\n'
-    for _,v in ipairs( f.commands ) do
-        if v.get == true then
-            g = g .. '\t[\'' .. v.name .. '\']=' .. (v.cmd + get_offset) .. ',\n'
+    if f.commands then
+        for _,v in ipairs( f.commands ) do
+            if v.get == true then
+                g = g .. '\t[\'' .. v.name .. '\']=' .. (v.cmd + get_offset) .. ',\n'
+            end
         end
     end
     if f.getters ~= nil then
@@ -49,9 +52,11 @@ end
 
 function lua_events(f)
     local e = f.lua_name .. '.e={\n'
-    for _,v in ipairs( f.commands ) do
-        if v.get == true then
-            e = e .. '\t[' .. (v.cmd + get_offset) .. ']=\'' .. v.name .. '\',\n'
+    if f.commands then
+        for _,v in ipairs( f.commands ) do
+            if v.get == true then
+                e = e .. '\t[' .. (v.cmd + get_offset) .. ']=\'' .. v.name .. '\',\n'
+            end
         end
     end
     if f.getters ~= nil then


### PR DESCRIPTION
Currently, devices that only support getters need a dummy set command due to the ii code generation. This PR removes the need for this dummy command, allowing for devices that don't have a `commands` table in their descriptor.

See the deletion in `txi.lua` for an example of what this cleans up.