### PR TITLE
Improve timer accuracy

### DIFF
--- a/ll/timers.c
+++ b/ll/timers.c
@@ -128,7 +128,6 @@ void Timer_Set_Params( int ix, float seconds )
                     : (pf > (float)0xFFFF) ? 0xFFFF
                     : (uint16_t)pf;
 
-    printf("timer: per 0x%x, ps 0x%x\n",p,ps);
     TimHandle[ix].Init.Period    = p;
     TimHandle[ix].Init.Prescaler = ps;
     uint8_t err;


### PR DESCRIPTION
Before the hardware timers were just approximately chosen to give accurate timing. With this PR the timing is calculated directly from the clock speed of the module (216MHz) so timing will be as accurate as the crystal.

Previously, a static prescaler was chosen which limited the slowest timer to ~16s, and gave resolution of ~0.3ms. Now the prescaler is maximized to allow up to ~20s intervals, and recursively searches for the ideal prescaler for faster clocks. This means the timing values are usable down into the uS and high nS range.

The main purpose for this is it allows the timer library to be used by other LL peripherals, rather than special casing & having the timer init functions spread across multiple files. eg: the USB driver can now just take a generic timer from timers.c and simplify the event callback structure.