### PR TITLE
CPU usage dramatically reduced in the ADC driver

### DIFF
--- a/lib/io.c
+++ b/lib/io.c
@@ -11,10 +11,10 @@
 
 #define IN_CHANNELS ADDA_ADC_CHAN_COUNT
 
-void IO_Init( void )
+void IO_Init( int adc_timer_ix )
 {
     // hardware layer
-    ADDA_Init();
+    ADDA_Init(adc_timer_ix);
 
     // dsp objects
     Detect_init( IN_CHANNELS );

--- a/lib/io.h
+++ b/lib/io.h
@@ -2,7 +2,7 @@
 
 #include <stm32f7xx.h>
 
-void IO_Init( void );
+void IO_Init( int adc_timer_ix );
 void IO_Start( void );
 
 void IO_Process( void );

--- a/ll/adda.c
+++ b/ll/adda.c
@@ -91,10 +91,11 @@ void CAL_WriteFlash( void )
     }
 }
 
-uint16_t ADDA_Init( void )
+uint16_t ADDA_Init( int adc_timer_ix )
 {
     ADC_Init( ADDA_BLOCK_SIZE
             , ADDA_ADC_CHAN_COUNT
+            , adc_timer_ix
             );
     DAC_Init( ADDA_BLOCK_SIZE
             , ADDA_DAC_CHAN_COUNT

--- a/ll/adda.h
+++ b/ll/adda.h
@@ -12,7 +12,7 @@ typedef struct{
     uint16_t size;
 } IO_block_t;
 
-uint16_t ADDA_Init( void );
+uint16_t ADDA_Init( int adc_timer_ix );
 void ADDA_Start( void );
 void ADDA_BlockProcess( uint32_t* dac_pickle_ptr );
 

--- a/ll/ads131.h
+++ b/ll/ads131.h
@@ -98,7 +98,7 @@
 
 #define ADS_DATAWORDSIZE 0x4 // 32bit, pin M1 pulled high to IOVDD
 
-void ADC_Init( uint16_t bsize, uint8_t chan_count );
+void ADC_Init( uint16_t bsize, uint8_t chan_count, int timer_ix );
 
 //int32_t
 uint16_t ADC_GetU16( uint8_t channel );

--- a/main.c
+++ b/main.c
@@ -26,11 +26,11 @@ int main(void)
     printf("\n\nhi from crow!\n");
 
     // Drivers
-    IO_Init();
+    int max_timers = Timer_Init();
+    IO_Init( max_timers-2 ); // use second-last timer
     IO_Start(); // must start IO before running lua init() script
     events_init();
-    int max_timers = Timer_Init();
-    Metro_Init( max_timers-1 ); // reserve timer for USB
+    Metro_Init( max_timers-2 ); // reserve 2 timers for USB & ADC
     Caw_Init( max_timers-1 ); // use last timer
     CDC_clear_buffers();
     ii_init( II_CROW );


### PR DESCRIPTION
Previously, the ADC driver had a blocking delay waiting for the ADS131 to have valid data to be clocked out in the SPI driver.

In this PR that delay is replaced with a timer that delays a continuation which requests samples for the next block. The wait time happens in the background.

The net result is ~35% less CPU usage. Specifically this increases the amount of time available for the DSP loop (so we can do more stuff!), and/or reduces latency & jitter for the event queue as the main loop has about 2x the cycles each time around. This is likely only noticeable with a CPU intensive lua script as the C side of the project never uses more than ~25% cpu.

Fixes #272 