### PR TITLE
Syntax-check Lua files at compile time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,6 +270,7 @@ zip: $(BIN)
 	@$(FENNEL) --compile $< > $@
 
 %.lua.h: %.lua util/l2h.lua
+	@luac -p $<
 	@echo l2h $< "->" $@
 	@lua util/l2h.lua $<
 

--- a/lua/ii.lua
+++ b/lua/ii.lua
@@ -45,8 +45,7 @@ function ii_LeadRx_handler( addr, cmd, data )
     ii[name].event(ii[name].e[cmd], data, ix)
 end
 
--- NOTE: weird double-escaped quotes down here for the c compiler
-function ii.e( name, event, ... ) crow.tell('ii.'..name,'\\''..tostring(event)..'\\'',...) end
+function ii.e( name, event, ... ) crow.tell('ii.'..name,'[['..tostring(event)..']]',...) end
 
 ii.self =
     { cmds = { [1]='output'


### PR DESCRIPTION
Using `luac` with the `-p` option, this checks every lua file for syntax errors at compile time. This helps when making quick changes to the crow-lua-libs as typos are only caught by a text editor with linting, otherwise crow will probably just fail to boot into the lua env properly, erroring on the syntax error and abandoning the whole file.

Additionally, this removes a double-escape quote required by the lua -> c-header converter, by using the `[[`, `]]` string identifier syntax.

@simonvanderveldt I'm not sure if this requires any changes to the Actions setup, but I believe `luac` is part of the standard Lua install. Do changes to the Makefile need to be manually updated, or will the build process automatically use the updated Makefile?