### PR TITLE
add error handler for lua_pcall

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -498,14 +498,13 @@ static int Lua_handle_error( lua_State *L )
     const char *msg = lua_tostring( L, 1 );
     if( msg == NULL ){
         if( luaL_callmeta( L, 1, "__tostring" )
-	 && lua_type ( L, -1 ) == LUA_TSTRING ) {
-	    return 1;
-	}
-	else {
-	    msg = lua_pushfstring( L
-				 , "(error object is a %s value)"
-				 , luaL_typename( L, 1 ) );
-	}
+         && lua_type ( L, -1 ) == LUA_TSTRING ) {
+            return 1;
+        } else {
+            msg = lua_pushfstring( L
+                                 , "(error object is a %s value)"
+                                 , luaL_typename( L, 1 ) );
+        }
     }
     luaL_traceback( L, L, msg, 1 );
     return 1;

--- a/lib/repl.c
+++ b/lib/repl.c
@@ -154,8 +154,8 @@ void REPL_eval( char* buf, uint32_t len, ErrorHandler_t errfn )
 {
     if( repl_mode == REPL_normal ){
         if(Lua_eval( Lua, buf
-                     , len
-                     , errfn
+                   , len
+                   , errfn
                    )){
             printf("!eval\n");
         }


### PR DESCRIPTION
Fix #228 

Adds an error handler for the `lua_pcall` invocation, patterned after what [`docall`](https://github.com/trentgill/lua/blob/9d2732aaab53926662f352e347484a92f7afa0bd/src/lua.c#L176) does.

Example:
```
 <crow connected>

> print(5)
5

> print(jfd'
[string "eval"]:1: unfinished string near '''

> r lua/bad.lua
running lua/bad.lua
[string "eval"]:10: attempt to call a nil value (global 'boom')
stack traceback:
  [string "eval"]:10: in function 'three'
  [string "eval"]:6: in function 'two'
  [string "eval"]:2: in function 'one'
  [string "eval"]:13: in main chunk
User script evaluation failed.
```
where `bad.lua` is:
```lua
 1  function one()
 2   two()
 3  end
 4
 5  function two()
 6    three()
 7  end
 8
 9  function three()
10    boom()
11  end
12
13  one()
```

Notes:
* need to `goto` the "send error" code if `luaL_loadbuffer` failed due to a syntax error, otherwise we would always get "attempt to call a string value" instead of the actual error message in repl mode
* still always shows the chunk name as `[string "eval"]:`. From [here](https://github.com/trentgill/lua/blob/9d2732aaab53926662f352e347484a92f7afa0bd/src/lua.c#L335) I think possibly passing "=eval" rather than "eval" to `luaL_loadbuffer` would give `eval:1:...`