### PR TITLE
init() function correctly reports errors

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -531,7 +531,10 @@ void Lua_crowbegin( void )
 {
     printf("init()\n"); // call in C to avoid user seeing in lua
     lua_getglobal(L,"init");
-    lua_pcall(L,0,0,0);
+    if( lua_pcall(L,0,0,0) ){
+        Caw_send_luachunk( (char*)lua_tostring( L, -1 ) );
+        lua_pop( L, 1 );
+    }
 }
 
 // Public Callbacks from C to Lua


### PR DESCRIPTION
Previously we just `pcall`d the user's `init` function and hoped for the best. Now it at least checks for an error & prints the lua message.

Fixes #280.

This should be refactored after merging #287 so as to get the full stack trace & reuse the error handling for debugging. @csboling 