### PR TITLE
output shapers with arbitrary scales

### DIFF
--- a/lib/ashapes.c
+++ b/lib/ashapes.c
@@ -49,7 +49,7 @@ void AShaper_set_scale( int    index
         self->divlist[0] = 0.0; // set to unity
 
         self->modulo = 1.0;
-        self->scaling = scaling / self->modulo;
+        self->scaling = scaling / modulo;
     } else {
         for( int i=0; i<(self->dlLen); i++ ){
             self->divlist[i] = divlist[i];

--- a/lib/ashapes.c
+++ b/lib/ashapes.c
@@ -1,0 +1,94 @@
+#include "ashapes.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+int ashaper_count = 0;
+AShape_t* ashapers = NULL;
+
+void AShaper_init( int channels )
+{
+    ashaper_count = channels;
+    ashapers = malloc( sizeof( AShape_t ) * channels );
+    if( !ashapers ){ printf("ashapers malloc failed\n"); return; }
+    for( int j=0; j<ASHAPER_CHANNELS; j++ ){
+        ashapers[j].index  = j;
+        for( int d=0; d<MAX_DIV_LIST_LEN; d++ ){
+            ashapers[j].divlist[d] = d; // ascending vals to 24
+        }
+        ashapers[j].dlLen   = 12;
+        ashapers[j].modulo  = 12.0;
+        ashapers[j].scaling = 1.0;
+        ashapers[j].active  = false;
+    }
+}
+
+void AShaper_unset_scale( int index )
+{
+    if( index < 0 || index >= ASHAPER_CHANNELS ){ return; }
+    AShape_t* self = &ashapers[index]; // safe pointer
+
+    self->active = false;
+}
+
+void AShaper_set_scale( int    index
+                      , float* divlist
+                      , int    dlLen
+                      , float  modulo
+                      , float  scaling
+                      )
+{
+    if( index < 0 || index >= ASHAPER_CHANNELS ){ return; }
+    AShape_t* self = &ashapers[index]; // safe pointer
+
+    self->active = true;
+
+    self->dlLen = (dlLen > 24 ) ? 24 : dlLen;
+    if( self->dlLen == 0 ){ // if empty list, assume chromatic
+        self->dlLen = 1; // one step
+        self->divlist[0] = 0.0; // set to unity
+
+        self->modulo = 1.0;
+        self->scaling = scaling / self->modulo;
+    } else {
+        for( int i=0; i<(self->dlLen); i++ ){
+            self->divlist[i] = divlist[i];
+        }
+        self->modulo = modulo;
+        self->scaling = scaling;
+    }
+
+    // private calculations //
+
+    // pushes values up so capture window is centred on output window
+    self->offset = 0.5 * self->scaling / self->modulo;
+}
+
+// TODO optimization
+float* AShaper_v( int     index
+                , float*  out
+                , int     size
+                )
+{
+    if( index < 0 || index >= ASHAPER_CHANNELS ){ return out; }
+    AShape_t* self = &ashapers[index]; // safe pointer
+
+    if( !self->active ){ return out; } // shaper inactive so just return
+
+    float* out2 = out;
+    for( int i=0; i<size; i++ ){
+        float samp = *out2 + self->offset; // apply shift for centering and transpose
+
+        float n_samp = samp/self->scaling; // samp normalized to [0,1.0)
+
+        float divs = (float)(int)n_samp;
+        float phase = n_samp - divs; // [0,1.0)
+
+        int note = (int)(phase * self->dlLen); // map phase to num of note choices
+        float note_map = self->divlist[note]; // apply lookup table
+        note_map /= self->modulo; // remap via num of options
+
+        *out2++ = self->scaling * (divs + note_map);
+    }
+    return out;
+}

--- a/lib/ashapes.h
+++ b/lib/ashapes.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <stdbool.h>
+
+#define MAX_DIV_LIST_LEN 24
+
+#define ASHAPER_CHANNELS 4
+
+typedef struct{
+    int    index;
+    float  divlist[MAX_DIV_LIST_LEN];
+    int    dlLen;
+    float  modulo;
+    float  scaling;
+    float  offset;
+    bool   active;
+} AShape_t;
+
+void AShaper_init( int channels );
+
+void AShaper_unset_scale( int index );
+void AShaper_set_scale( int    index
+                      , float* divlist
+                      , int    dlLen
+                      , float  modulo
+                      , float  scaling
+                      );
+
+float* AShaper_v( int     index
+                , float*  out
+                , int     size
+                );

--- a/lib/io.c
+++ b/lib/io.c
@@ -4,6 +4,7 @@
 
 #include "../ll/adda.h"        // _Init(), _Start(), _GetADCValue(), IO_block_t
 #include "slopes.h"            // S_init(), S_step_v()
+#include "ashapes.h"           // AShaper_init(), AShaper_v()
 #include "detect.h"            // Detect_init(), Detect(), Detect_ix_to_p()
 #include "metro.h"
 
@@ -19,6 +20,7 @@ void IO_Init( void )
     // dsp objects
     Detect_init( IN_CHANNELS );
     S_init( SLOPE_CHANNELS );
+    AShaper_init( SLOPE_CHANNELS );
 }
 
 void IO_Start( void )
@@ -39,6 +41,12 @@ IO_block_t* IO_BlockProcess( IO_block_t* b )
                 , b->out[j]
                 , b->size
                 );
+    }
+    for( int j=0; j<SLOPE_CHANNELS; j++ ){
+        AShaper_v( j
+                 , b->out[j]
+                 , b->size
+                 );
     }
     return b;
 }

--- a/lua/output.lua
+++ b/lua/output.lua
@@ -6,6 +6,7 @@ function Output.new( chan )
               , rate    = 1/chan
               , shape   = 'linear'
               , slew    = 0.0
+              , _scale   = 'none'
               , asl     = asl.new( chan )
 --              , trig    = { asl      = asl.new(k)
 --                          , polarity = 1
@@ -40,6 +41,8 @@ Output.__index = function(self, ix)
     if     ix == 'action'  then return self.asl.action
     elseif ix == 'volts'   then return LL_get_state(self.channel)
     elseif ix == 'running' then return self.asl.running
+    elseif ix == 'scale'   then return
+        function(...) set_output_scale(self.channel, ...) end
     end
 end
 


### PR DESCRIPTION
Fixes #68 

The idea here is to implement quantization of the ASL outputs, so that slopes can be seen as sequences of notes. With this extension, the ASL language takes on a new role as describing the 'shape' of melodies (or harmonies), and the absolute-shaper acts as a dynamic quantizer. This is not the final version, but an initial POC to explore what it feels like to play with slopes as melody-shapes.

I'm posting this now because I'm not by my synthesizer very much during the lockdown, and I'd love to see how anyone feels about it in practice. The driving idea behind the functionality is to provide a new way of writing melodies - *as chains of slopes* - so it's probably a little strange & requires thinking outside traditional compositional workflows.

General usage:
```lua
 -- no quantizing / shaping (same as current behaviour)
output[1].scale( 'none' ) -- set by default

-- 12TET ionian
output[1].scale{ 0,2,4,5,7,9,11 }

-- 12TET chromatic
output[1].scale{ 0,1,2,3,4,5,6,7,8,9,10,11 }

-- 19TET pentatonic
output[1].scale( {0,3,6,11,14}, 19 ) -- 2nd argument is nTET

-- 12TET pentatonic with 1.2V / octave
output[1].scale( {0,2,4,7,9}, 12, 1.2 )

-- shortcut for 12TET chromatic
output[1].scale()
output[1].scale{} -- both work

-- easy to make tables (or borrow from norns) of different scales
lydian = {0,2,4,6,7,9,11}
output[1].scale( lydian ) -- defaults to 12TET, 1V/8ve
```

Limitations:
* equal-temperament only (though can be n-TET!)
* scale lists are limited to 24 selections
* root-note is always 0V output
* the 'scaling' parameter doesn't convert types, just changes what is expected (so 1.2v/8 requires input values at 1.2v/8ve).

There are a few areas that need design consideration:
* naming (currently called `output.scale` in lua, though functionality isn't limited to 'scales'). Should it be called `output.quantize`?
* How to shift the 'root note'? This is particularly important for just intonation where scales are not directly transposable without harmonic implications.

The library is pretty basically implemented, which means it can do some strange things that are not like 'quantizers', but more like creative melody manipulators:
* scales are not ordered, so they can arbitrarily jumble the scale. eg: `{11,9,7,5,4,2,0}` would result in descending major scales transposed up/down by whole volts.
* scales are not range-limited so it's also possible to map to notes 'outside' the input range. eg: `{0,24,12,-12}` maps the [0,1)V range to a sequence of 4 different octaves.

And some features forthcoming:
* Just Intonation support: `.scale( {table-of-ratios}, 'just' )`
* Considering a 'weighting' list (or note/weighting tuples) to lean on eg. chord tones see @whimsical-sam s shapers lib

### some other usage examples than plain output quantizing

```lua
-- input->quantizer with harmony
function init()
  input[1].mode('stream', 0.002)
  output[1].slew = 0
  output[2].slew = 0
  output[1].scale{0,2,4,5,7,9,11}
  output[2].scale{0,2,4,7,9}
end

input[1].stream = function( val )
  output[1].volts = val
  output[2].volts = val - 1.0 -- sub-octave in pentatonic
end
```

```lua
-- continuous control of equal-temperament divisions
-- input[1]: dynamic temperament input
-- output[1]: LFO sweeping with dynamic temperament
function init()
  input[1].mode('stream', 0.02) -- update nTET every 20ms
  output[1].scale( {}, 12 )
  output[1]( lfo() )
end

input[1].stream = function( val )
  -- would be better with expo shaping but probably too CPU intensive?
  val = val * 20 -- 1 to 200 TET
  val = (val <= 0.001) and 0.001 or val -- limit negative vals
  output[1].scale( {}, val ) -- NOTE: temperament need not be an integer
end
```

```lua
-- changing scale inside of an ASL
-- NOTE: this uses an underdocumented feature of ASL that it can call arbitrary functions, and will immediately proceed to the next slope

-- note how the 3rd scale reorders the notes
my_scales = { {0,2,4,5,7,9,11}, {0,2,3,6,7}, {0,4,7,2} }
local current_scale = 0
function next_scale( channel )
  current_scale = (current_scale % 3) + 1
  output[channel].scale( my_scales[current_scale] )
end

-- NOTE: 
output[1].action =
loop{ to(0,0)
    , to(2,1)
    , to(1,0)
    , to(1.5,1)
    , next_scale(1) -- will execute immediately then proceed (hence loop)
    }
```