### PR TITLE
event system not to need knowledge of event options

### DIFF
--- a/lib/events.c
+++ b/lib/events.c
@@ -20,23 +20,11 @@ volatile static int getIdx = 0;
 // NOTE be aware of event_t and MAX_EVENTS for RAM usage
 volatile static event_t sysEvents[ MAX_EVENTS ];
 
-void (*app_event_handlers[E_COUNT])(event_t *e) = { handler_none };
-
 // initialize event handler
 void events_init() {
     printf("\ninitializing event handler\n");
 
     events_clear();
-
-    // assign event handlers
-    app_event_handlers[E_none] = &handler_none;
-    app_event_handlers[E_metro] = &handler_metro;
-    app_event_handlers[E_stream] = &handler_stream;
-    app_event_handlers[E_change] = &handler_change;
-    app_event_handlers[E_toward] = &handler_toward;
-    app_event_handlers[E_midi] = &handler_midi;
-    app_event_handlers[E_ii_leadRx] = &handler_ii_leadRx;
-    app_event_handlers[E_ii_followRx] = &handler_ii_followRx;
 }
 
 void events_clear(void)
@@ -47,39 +35,30 @@ void events_clear(void)
 
     // zero out the event records
     for ( int k = 0; k < MAX_EVENTS; k++ ) {
-        sysEvents[ k ].type   = 0;
-        sysEvents[ k ].data.i = 0;
+        sysEvents[ k ].data.i  = 0;
+        sysEvents[ k ].handler = NULL;
     }
 }
 
 // get next event
 // returns non-zero if an event was available
-uint8_t event_next( event_t *e ) {
-    uint8_t status;
+void event_next( void ){
+    event_t* e = NULL;
 
     BLOCK_IRQS(
         // if pointers are equal, the queue is empty... don't allow idx's to wrap!
         if ( getIdx != putIdx ) {
             INCR_EVENT_INDEX( getIdx );
-            e->type  = sysEvents[ getIdx ].type;
-            e->index = sysEvents[ getIdx ].index;
-            e->data  = sysEvents[ getIdx ].data;
-            status = 1;
-        } else {
-            e->type    = 0xff;
-            e->index.i = 0;
-            e->data.i  = 0;
-            status = 0;
+            e = (event_t*)&sysEvents[ getIdx ];
         }
     );
 
-    return status;
+    if( e != NULL ){ (*e->handler)(e); } // call the event handler after enabling IRQs
 }
 
 
 // add event to queue, return success status
 uint8_t event_post( event_t *e ) {
-    //printf("posting event, type: %d\n",e->type);
     uint8_t status = 0;
 
     BLOCK_IRQS(
@@ -87,9 +66,9 @@ uint8_t event_post( event_t *e ) {
         int saveIndex = putIdx;
         INCR_EVENT_INDEX( putIdx );
         if ( putIdx != getIdx  ) {
-            sysEvents[ putIdx ].type  = e->type;
-            sysEvents[ putIdx ].index = e->index;
-            sysEvents[ putIdx ].data  = e->data;
+            sysEvents[ putIdx ].handler = e->handler;
+            sysEvents[ putIdx ].index   = e->index;
+            sysEvents[ putIdx ].data    = e->data;
             status = 1;
         } else {
             // idx wrapped, so queue is full, restore idx
@@ -100,43 +79,4 @@ uint8_t event_post( event_t *e ) {
     if( !status ){ printf("event queue full!\n"); }
 
     return status;
-}
-
-
-// EVENT HANDLERS
-
-static void handler_none(event_t *e) {}
-
-static void handler_metro(event_t *e) {
-    //printf("metro event\n");
-    L_handle_metro( e->index.i, e->data.i );
-}
-
-static void handler_stream(event_t *e) {
-    //printf("stream event %f\n",e->data);
-    L_handle_in_stream( e->index.i, e->data.f );
-}
-
-static void handler_change(event_t *e) {
-    //printf("change event %f\n",e->data);
-    L_handle_change( e->index.i, e->data.f );
-}
-
-static void handler_toward(event_t *e) {
-    //printf("toward %d\n",e->index);
-    L_handle_toward( e->index.i );
-}
-
-static void handler_midi(event_t *e) {
-    //printf("midi %d\n",e->data.u8s[0]);
-    L_handle_midi( e->data.u8s );
-}
-
-static void handler_ii_leadRx(event_t *e) {
-    //printf("ii_leadRx %d\n",e->data.f);
-    L_handle_ii_leadRx( e->index.u8s[0], e->index.u8s[1], e->data.f );
-}
-static void handler_ii_followRx(event_t *e) {
-    //printf("ii_followRx %p\n",e->data.p);
-    L_handle_ii_followRx();
 }

--- a/lib/events.h
+++ b/lib/events.h
@@ -2,18 +2,6 @@
 
 #include <stdint.h>
 
-typedef enum {
-    E_none,
-    E_metro,
-    E_stream,
-    E_change,
-    E_toward,
-    E_midi,
-    E_ii_leadRx,
-    E_ii_followRx,
-    E_COUNT
-} event_type_t;
-
 union Data{
     void* p;
     int i;
@@ -21,27 +9,13 @@ union Data{
     uint8_t u8s[4];
 };
 
-typedef struct {
-    event_type_t type;
+typedef struct event{
+    void (*handler)( struct event* e );
     union Data   index;
     union Data   data;
 } event_t;
 
-
-// global array of pointers to handlers
-extern void (*app_event_handlers[])(event_t *e);
-
-
 extern void events_init(void);
 extern void events_clear(void);
 extern uint8_t event_post(event_t *e);
-extern uint8_t event_next(event_t *e);
-
-static void handler_none(event_t *e);
-static void handler_metro(event_t *e);
-static void handler_stream(event_t *e);
-static void handler_change(event_t *e);
-static void handler_toward(event_t *e);
-static void handler_midi(event_t *e);
-static void handler_ii_leadRx(event_t *e);
-static void handler_ii_followRx(event_t *e);
+extern void event_next( void );

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -64,6 +64,16 @@ static float Lua_check_memory( void );
 static void hook( lua_State* L, lua_Debug* ar );
 static int lua_pcall_protected( lua_State* L, int nargs, int nresults, int errFunc );
 
+// Handler prototypes
+void L_handle_toward( event_t* e );
+void L_handle_metro( event_t* e );
+void L_handle_in_stream( event_t* e );
+void L_handle_change( event_t* e );
+void L_handle_ii_leadRx( event_t* e );;
+void L_handle_ii_followRx( event_t* e );
+void L_handle_ii_followRx_cont( uint8_t cmd, int args, float* data );
+void L_handle_midi( event_t* e );
+
 void _printf(char* error_message)
 {
     printf("%s\n",error_message);
@@ -565,15 +575,15 @@ static int lua_pcall_protected( lua_State* L, int nargs, int nresults, int errFu
 // Public Callbacks from C to Lua
 void L_queue_toward( int id )
 {
-    event_t e = { .type    = E_toward
+    event_t e = { .handler = L_handle_toward
                 , .index.i = id
                 };
     event_post(&e);
 }
-void L_handle_toward( int id )
+void L_handle_toward( event_t* e )
 {
     lua_getglobal(L, "toward_handler");
-    lua_pushinteger(L, id+1); // 1-ix'd
+    lua_pushinteger(L, e->index.i + 1); // 1-ix'd
     if( lua_pcall_protected(L, 1, 0, 0) != LUA_OK ){
         Caw_send_luachunk("error running toward_handler");
         Caw_send_luachunk( (char*)lua_tostring(L, -1) );
@@ -584,17 +594,17 @@ void L_handle_toward( int id )
 
 void L_queue_metro( int id, int state )
 {
-    event_t e = { .type    = E_metro
+    event_t e = { .handler = L_handle_metro
                 , .index.i = id
                 , .data.i  = state
                 };
     event_post(&e);
 }
-void L_handle_metro( const int id, const int stage)
+void L_handle_metro( event_t* e )
 {
     lua_getglobal(L, "metro_handler");
-    lua_pushinteger(L, id+1 -2); // 1-ix'd, less 2 for adc rebase
-    lua_pushinteger(L, stage+1); // 1-ix'd
+    lua_pushinteger(L, e->index.i +1 -2); // 1-ix'd, less 2 for adc rebase
+    lua_pushinteger(L, e->data.i +1);     // 1-ix'd
     if( lua_pcall_protected(L, 2, 0, 0) != LUA_OK ){
         Caw_send_luachunk("error running metro_handler");
         Caw_send_luachunk( (char*)lua_tostring(L, -1) );
@@ -604,17 +614,17 @@ void L_handle_metro( const int id, const int stage)
 
 void L_queue_in_stream( int id )
 {
-    event_t e = { .type    = E_stream
+    event_t e = { .handler = L_handle_in_stream
                 , .index.i = id
                 , .data.f  = IO_GetADC(id)
                 };
     event_post(&e);
 }
-void L_handle_in_stream( int id, float value )
+void L_handle_in_stream( event_t* e )
 {
     lua_getglobal(L, "stream_handler");
-    lua_pushinteger(L, id+1); // 1-ix'd
-    lua_pushnumber(L, value);
+    lua_pushinteger(L, e->index.i +1); // 1-ix'd
+    lua_pushnumber(L, e->data.f);
     if( lua_pcall_protected(L, 2, 0, 0) != LUA_OK ){
         Caw_send_luachunk("error: input stream");
         Caw_send_luachunk( (char*)lua_tostring(L, -1) );
@@ -624,17 +634,17 @@ void L_handle_in_stream( int id, float value )
 
 void L_queue_change( int id, float state )
 {
-    event_t e = { .type    = E_change
+    event_t e = { .handler = L_handle_change
                 , .index.i = id
                 , .data.f  = state
                 };
     event_post(&e);
 }
-void L_handle_change( int id, float state )
+void L_handle_change( event_t* e )
 {
     lua_getglobal(L, "change_handler");
-    lua_pushinteger(L, id+1); // 1-ix'd
-    lua_pushnumber(L, state);
+    lua_pushinteger(L, e->index.i +1); // 1-ix'd
+    lua_pushnumber(L, e->data.f);
     if( lua_pcall_protected(L, 2, 0, 0) != LUA_OK ){
         printf("ch er\n");
         Caw_send_luachunk("error: input change");
@@ -645,19 +655,19 @@ void L_handle_change( int id, float state )
 
 void L_queue_ii_leadRx( uint8_t address, uint8_t cmd, float data )
 {
-    event_t e = { .type   = E_ii_leadRx
-                , .data.f = data
+    event_t e = { .handler = L_handle_ii_leadRx
+                , .data.f  = data
                 };
     e.index.u8s[0] = address;
     e.index.u8s[1] = cmd;
     event_post(&e);
 }
-void L_handle_ii_leadRx( uint8_t address, uint8_t cmd, float data )
+void L_handle_ii_leadRx( event_t* e )
 {
     lua_getglobal(L, "ii_LeadRx_handler");
-    lua_pushinteger(L, address);
-    lua_pushinteger(L, cmd);
-    lua_pushnumber(L, data);
+    lua_pushinteger(L, e->index.u8s[0]); // address
+    lua_pushinteger(L, e->index.u8s[1]); // command
+    lua_pushnumber(L, e->data.f);
     if( lua_pcall_protected(L, 3, 0, 0) != LUA_OK ){
         printf("!ii.leadRx\n");
         Caw_send_luachunk("error: ii lead event");
@@ -668,11 +678,12 @@ void L_handle_ii_leadRx( uint8_t address, uint8_t cmd, float data )
 
 void L_queue_ii_followRx( void )
 {
-    event_t e = { .type = E_ii_followRx };
+    event_t e = { .handler = L_handle_ii_followRx };
     event_post(&e);
 }
-void L_handle_ii_followRx( void )
+void L_handle_ii_followRx( event_t* e )
 {
+    // FIXME: should pass the 'cont' as a fnptr continuation
     ii_process_dequeue_decode();
 }
 void L_handle_ii_followRx_cont( uint8_t cmd, int args, float* data )
@@ -691,6 +702,7 @@ void L_handle_ii_followRx_cont( uint8_t cmd, int args, float* data )
     }
 }
 
+// FIXME called directly from ii lib for now
 float L_handle_ii_followRxTx( uint8_t cmd, int args, float* data )
 {
     lua_getglobal(L, "ii_followRxTx_handler");
@@ -712,14 +724,15 @@ float L_handle_ii_followRxTx( uint8_t cmd, int args, float* data )
 
 void L_queue_midi( uint8_t* data )
 {
-    event_t e = { .type = E_midi };
+    event_t e = { .handler = L_handle_midi };
     e.data.u8s[0] = data[0];
     e.data.u8s[1] = data[1];
     e.data.u8s[2] = data[2];
     event_post(&e);
 }
-void L_handle_midi( uint8_t* data )
+void L_handle_midi( event_t* e )
 {
+    uint8_t* data = e->data.u8s;
     lua_getglobal(L, "midi_handler");
     int count = MIDI_byte_count(data[0]) + 1; // +1 for cmd byte itself
     for( int i=0; i<count; i++ ){

--- a/lib/lualink.h
+++ b/lib/lualink.h
@@ -30,12 +30,5 @@ extern void L_queue_ii_leadRx( uint8_t address, uint8_t cmd, float data );
 extern void L_queue_ii_followRx( void );
 
 // Callback declarations
-extern void L_handle_toward( int id );
-extern void L_handle_metro( const int id, const int stage);
-extern void L_handle_in_stream( int id, float value );
-extern void L_handle_change( int id, float state );
-extern void L_handle_midi( uint8_t* data );
-extern void L_handle_ii_leadRx( uint8_t address, uint8_t cmd, float data );
-extern void L_handle_ii_followRx( void );
-extern void L_handle_ii_followRx_cont( uint8_t cmd, int args, float* data );
 extern float L_handle_ii_followRxTx( uint8_t cmd, int args, float* data );
+extern void L_handle_ii_followRx_cont( uint8_t cmd, int args, float* data );

--- a/main.c
+++ b/main.c
@@ -62,11 +62,7 @@ int main(void)
             default: break; // 'C_none' does nothing
         }
         Random_Update();
-        // check/execute single event
-        event_t e;
-        if( event_next(&e) ){
-            (*app_event_handlers[e.type])(&e);
-        }
+        event_next(); // check/execute single event
         ii_leader_process();
     }
 }


### PR DESCRIPTION
Fixes #293 

The event system can be extended without modifying the `event.h/c` files at all. Instead of having an enum of event types, we just send a pointer-to-a-handler to the event system. The handler must have a unified type signature: `void (*handler)( event_t* e )`.

The motivation here is making it easier to add new functionalities that require a lua callback. Now when adding functions, the user should only need to implement the feature, and plumb it into the `lualink.c` file -- the event system comes for free.