### PR TITLE
add a super basic CPU counter

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -22,6 +22,7 @@
 #include "lib/midi.h"       // MIDI_Active()
 #include "../ll/timers.h"   // Timer_*()
 #include "stm32f7xx_hal.h"  // HAL_GetTick()
+#include "stm32f7xx_it.h"   // CPU_GetCount()
 
 // Lua libs wrapped in C-headers: Note the extra '.h'
 #include "lua/bootstrap.lua.h" // MUST LOAD THIS MANUALLY FIRST
@@ -239,6 +240,12 @@ static int _unique_id( lua_State *L )
 static int _time( lua_State *L )
 {
     lua_pushinteger(L, HAL_GetTick());
+    return 1;
+}
+static int _cpu_time( lua_State *L )
+{
+    // returns count of background loops for the last 8ms
+    lua_pushinteger(L, CPU_GetCount());
     return 1;
 }
 static int _go_toward( lua_State *L )
@@ -467,6 +474,7 @@ static const struct luaL_Reg libCrow[]=
     , { "sys_bootloader"   , _bootloader       }
     , { "unique_id"        , _unique_id        }
     , { "time"             , _time             }
+    , { "cputime"          , _cpu_time         }
     //, { "sys_cpu_load"     , _sys_cpu          }
         // io
     , { "go_toward"        , _go_toward        }

--- a/lib/lualink.h
+++ b/lib/lualink.h
@@ -8,6 +8,8 @@
 typedef void (*ErrorHandler_t)(char* error_message);
 struct lua_lib_locator{ const char* name; const char* addr_of_luacode; };
 
+extern volatile int CPU_count; // count from main.c
+
 lua_State* Lua_Init(void);
 lua_State* Lua_Reset( void );
 void Lua_DeInit(void);

--- a/main.c
+++ b/main.c
@@ -14,6 +14,8 @@
 #include "usbd/usbd_cdc_interface.h" // CDC_main_init()
 #include "lib/bootloader.h" // bootloader_enter(), bootloader_restart()
 #include "lib/flash.h" // Flash_clear_user_script()
+#include "stm32f7xx_it.h" // CPU_count;
+
 
 int main(void)
 {
@@ -42,6 +44,7 @@ int main(void)
     Lua_crowbegin();
 
     while(1){
+        CPU_count++;
         U_PrintNow();
         switch( Caw_try_receive() ){ // true on pressing 'enter'
             case C_repl:        REPL_eval( Caw_get_read()

--- a/stm32f7xx_it.c
+++ b/stm32f7xx_it.c
@@ -6,6 +6,8 @@
 
 #include "ll/debug_usart.h" // U_PrintNow
 
+volatile int CPU_count = 0;
+
 static void error( char* msg ){
     //__disable_irq();
 
@@ -22,7 +24,24 @@ void SVC_Handler(void){ error("!SVC"); }
 void DebugMon_Handler(void){ error("!DebugMon"); }
 void PendSV_Handler(void){ error("!PendSV"); }
 
-void SysTick_Handler(void){ HAL_IncTick(); }
+int counts[8] = {0,0,0,0,0,0,0,0};
+int pCount = 0;
+void SysTick_Handler(void)
+{
+    HAL_IncTick();
+    counts[pCount] = CPU_count;
+    if( (++pCount) >= 8 ){ pCount = 0; }
+    CPU_count = 0;
+}
+
+int CPU_GetCount( void )
+{
+    int c = 0;
+    for( int i=0; i<8; i++ ){
+        c += counts[i];
+    }
+    return c;
+}
 
 
 ///* The fault handler implementation calls a function called

--- a/stm32f7xx_it.h
+++ b/stm32f7xx_it.h
@@ -2,7 +2,12 @@
 
 /* The prototype shows it is a naked function - in effect this is just an
 assembly function. */
+
+extern volatile int CPU_count;
+
 void HardFault_Handler( void ) __attribute__( ( naked ) );
+
+int CPU_GetCount( void );
 
 void NMI_Handler(void);
 //void HardFault_Handler(void);


### PR DESCRIPTION
Adds a basic CPU readout to lua env as `cputime()`.

Returns a count of cycles through the background loop (ie the `while(1){...}` in main.c) over the course of 8ms. Thus, as you're running out of CPU time the number approaches zero. You should be at ~3600 with no script running. Down to ~2300 with 4 `lfo()`s running on the outputs. The numbers are arbitrary!

There's no fancy wrapping over this because it's really just intended for development.