### PR TITLE
Input 'volume' mode for tracking amplitude of signals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,10 @@ SRC = main.c \
 	$(WRLIB)/str_buffer.c \
 	$(WRLIB)/wrConvert.c \
 	$(WRLIB)/wrMath.c \
+	$(WRLIB)/wrMeters.c \
 	$(WRLIB)/wrQueue.c \
 	$(WRDSP)/wrBlocks.c \
+	$(WRDSP)/wrFilter.c \
 
 
 # lua tests

--- a/lib/detect.c
+++ b/lib/detect.c
@@ -7,6 +7,20 @@ uint8_t channel_count = 0;
 
 Detect_t*  selves = NULL;
 
+
+////////////////////////////////////////////////
+// signal processor declarations
+
+static void d_none( Detect_t* self, float level );
+static void d_change( Detect_t* self, float level );
+static void d_window( Detect_t* self, float level );
+static void d_scale( Detect_t* self, float level );
+static void d_volume( Detect_t* self, float level );
+
+
+///////////////////////////////////////////
+// init
+
 void Detect_init( int channels )
 {
     channel_count = channels;
@@ -18,6 +32,7 @@ void Detect_init( int channels )
         selves[j].state   = 0;
         Detect_none( &(selves[j]) );
         selves[j].win.lastWin = 0;
+        selves[j].volume.vu = VU_init();
     }
 }
 
@@ -26,15 +41,14 @@ void Detect_deinit( void )
     free(selves); selves = NULL;
 }
 
+
+/////////////////////////////////////////
+// global helpers
+
 Detect_t* Detect_ix_to_p( uint8_t index )
 {
     if( index < 0 || index >= channel_count ){ return NULL; } // TODO error msg
     return &(selves[index]);
-}
-
-void Detect_none( Detect_t* self )
-{
-    self->mode = Detect_NONE;
 }
 
 int8_t Detect_str_to_dir( const char* str )
@@ -43,6 +57,16 @@ int8_t Detect_str_to_dir( const char* str )
     else if( *str == 'f'){ return -1; }
     else{ return 0; } // default to 'both'
 }
+
+
+//////////////////////////////////////////
+// mode configuration
+
+void Detect_none( Detect_t* self )
+{
+    self->modefn = d_none;
+}
+
 void Detect_change( Detect_t*         self
                   , Detect_callback_t cb
                   , float             threshold
@@ -50,7 +74,7 @@ void Detect_change( Detect_t*         self
                   , int8_t            direction
                   )
 {
-    self->mode              = Detect_CHANGE;
+    self->modefn            = d_change;
     self->action            = cb;
     self->change.threshold  = threshold;
     self->change.hysteresis = hysteresis;
@@ -67,7 +91,7 @@ void Detect_scale( Detect_t*         self
                  , float             scaling
                  )
 {
-    self->mode          = Detect_SCALE;
+    self->modefn        = d_scale;
     self->action        = cb;
     self->scale.sLen    = (sLen > SCALE_MAX_COUNT) ? SCALE_MAX_COUNT : sLen;
     if( sLen == 0 ){ // assume chromatic
@@ -94,7 +118,7 @@ void Detect_window( Detect_t*         self
                   )
 {
     printf("TODO need to sort the windows!\n");
-    self->mode           = Detect_WINDOW;
+    self->modefn         = d_window;
     self->action         = cb;
     self->win.wLen       = (wLen > WINDOW_MAX_COUNT) ? WINDOW_MAX_COUNT : wLen;
     self->win.hysteresis = hysteresis;
@@ -103,90 +127,99 @@ void Detect_window( Detect_t*         self
     }
 }
 
-void Detect( Detect_t* self, float level )
+// this is the same as Stream
+void Detect_volume( Detect_t*         self
+                  , Detect_callback_t cb
+                  , float             interval
+                  )
 {
-    switch( self->mode ){
-        case Detect_NONE:
-            break;
+    self->modefn         = d_volume;
+    self->action         = cb;
+    // SAMPLE_RATE * i / BLOCK_SIZE
+    self->volume.blocks  = (int)((48000.0 * interval) / 32.0);
+    if( self->volume.blocks <= 0 ){ self->volume.blocks = 1; }
+    self->volume.countdown = self->volume.blocks;
+}
 
-        case Detect_CHANGE:
-            if( self->state ){ // high to low
-                if( level < (self->change.threshold - self->change.hysteresis) ){
-                    self->state = 0;
-                    if( self->change.direction != 1 ){ // not 'rising' only
-                        (*self->action)( self->channel, (float)self->state );
-                    }
-                }
-            } else { // low to high
-                if( level > (self->change.threshold + self->change.hysteresis) ){
-                    self->state = 1;
-                    if( self->change.direction != -1 ){ // not 'falling' only
-                        (*self->action)( self->channel, (float)self->state );
-                    }
-                }
+
+//////////////////////////////////////////////
+// signal processors
+static void d_none( Detect_t* self, float level ){ return; }
+
+static void d_change( Detect_t* self, float level )
+{
+    if( self->state ){ // high to low
+        if( level < (self->change.threshold - self->change.hysteresis) ){
+            self->state = 0;
+            if( self->change.direction != 1 ){ // not 'rising' only
+                (*self->action)( self->channel, (float)self->state );
             }
-            break;
-
-        case Detect_WINDOW: {
-            // search index containing 'level'
-            int ix = 0;
-                // TODO optimize: start from 'lastWin' rather than 0
-            for(; ix<self->win.wLen; ix++ ){
-                if( level < self->win.windows[ix] ){
-                    break;
-                }
+        }
+    } else { // low to high
+        if( level > (self->change.threshold + self->change.hysteresis) ){
+            self->state = 1;
+            if( self->change.direction != -1 ){ // not 'falling' only
+                (*self->action)( self->channel, (float)self->state );
             }
-            ix++; // 1-base the index so it can be passed with sign
-            // compare the found win with 'lastWin'
-            int lW = self->win.lastWin;
-            if( ix != lW ){ // window has changed
-                (*self->action)( self->channel
-                               , (ix > lW) // sign of index determines direction
-                                    ? ix
-                                    : -ix
-                               ); // callback!
-                self->win.lastWin = ix; // save newly entered window
-            }
-            break; }
-
-         case Detect_SCALE:
-            // TODO add hysteresis to avoid jittering
-            level += self->scale.offset;
-            float n_level = level / self->scale.scaling;
-            int octaves = (int)floorf(n_level);
-            float phase = n_level - (float)octaves; // [0,1.0)
-            float fix = phase * self->scale.sLen;
-            int ix = (int)fix; // map phase to #scale
-
-            if( ix      != self->scale.lastIndex
-             || octaves != self->scale.lastOct
-              ){ // new note detected
-                float note = self->scale.scale[ix]; // apply LUT within octave
-                float noteOct = note + (float)octaves*self->scale.divs;
-                float volts = (note / self->scale.divs + (float)octaves)
-                               * self->scale.scaling;
-                self->scale.lastIndex = ix;
-                self->scale.lastOct   = octaves;
-                self->scale.lastNote  = noteOct;
-                self->scale.lastVolts = volts;
-                (*self->action)( self->channel, 0.0 ); // callback! 0.0 is ignored
-            }
-            break;
-
-        default:
-            break;
+        }
     }
 }
 
-Detect_mode_t Detect_str_to_mode( const char* mode )
+static void d_window( Detect_t* self, float level )
 {
-    if( *mode == 's' ){
-        if( mode[1] == 'c' ){  return Detect_SCALE;  //In_scale;
-        } else {               return Detect_NONE; } //In_stream;
-    } else if( *mode == 'c' ){ return Detect_CHANGE; //In_change;
-    } else if( *mode == 'w' ){ return Detect_WINDOW; //In_window;
-    } else if( *mode == 'q' ){ return Detect_NONE;   //In_quantize;
-    } else if( *mode == 'j' ){ return Detect_NONE;   //In_justintonation;
-    } else {                   return Detect_NONE;   //Detect_NONE;
+    // search index containing 'level'
+    int ix = 0;
+        // TODO optimize: start from 'lastWin' rather than 0
+    for(; ix<self->win.wLen; ix++ ){
+        if( level < self->win.windows[ix] ){
+            break;
+        }
+    }
+    ix++; // 1-base the index so it can be passed with sign
+    // compare the found win with 'lastWin'
+    int lW = self->win.lastWin;
+    if( ix != lW ){ // window has changed
+        (*self->action)( self->channel
+                       , (ix > lW) // sign of index determines direction
+                            ? ix
+                            : -ix
+                       ); // callback!
+        self->win.lastWin = ix; // save newly entered window
+    }
+}
+
+static void d_scale( Detect_t* self, float level )
+{
+    // TODO add hysteresis to avoid jittering
+    level += self->scale.offset;
+    float n_level = level / self->scale.scaling;
+    int octaves = (int)floorf(n_level);
+    float phase = n_level - (float)octaves; // [0,1.0)
+    float fix = phase * self->scale.sLen;
+    int ix = (int)fix; // map phase to #scale
+
+    if( ix      != self->scale.lastIndex
+     || octaves != self->scale.lastOct
+      ){ // new note detected
+        float note = self->scale.scale[ix]; // apply LUT within octave
+        float noteOct = note + (float)octaves*self->scale.divs;
+        float volts = (note / self->scale.divs + (float)octaves)
+                       * self->scale.scaling;
+        self->scale.lastIndex = ix;
+        self->scale.lastOct   = octaves;
+        self->scale.lastNote  = noteOct;
+        self->scale.lastVolts = volts;
+        (*self->action)( self->channel, 0.0 ); // callback! 0.0 is ignored
+    }
+}
+
+static void d_volume( Detect_t* self, float level )
+{
+    float v = VU_step( self->volume.vu, level );
+    if( --self->volume.countdown <= 0 ){
+        self->volume.countdown = self->volume.blocks; // reset counter
+        (*self->action)( self->channel
+                       , v
+                       ); // callback!
     }
 }

--- a/lib/detect.h
+++ b/lib/detect.h
@@ -1,16 +1,11 @@
 #pragma once
 
 #include <stm32f7xx.h>
+
 #include "wrMeters.h"
 
 #define SCALE_MAX_COUNT 16
 #define WINDOW_MAX_COUNT 16
-
-typedef enum{ Detect_NONE
-            , Detect_CHANGE
-            , Detect_WINDOW
-            , Detect_SCALE
-} Detect_mode_t;
 
 typedef void (*Detect_callback_t)(int channel, float value);
 
@@ -41,28 +36,51 @@ typedef struct{
 } D_window_t;
 
 typedef struct{
+    VU_meter_t* vu;
+    int         blocks;
+    int         countdown;
+} D_volume_t;
+
+typedef struct detect{
     uint8_t            channel;
-    Detect_mode_t      mode;
+    void (*modefn)(struct detect* self, float level);
+
     Detect_callback_t  action;
 
 // mode specifics
-  // Detect_change
+  // Detect_CHANGE
     // params
-    D_change_t    change;
+    D_change_t change;
     // state
-    float         last;
-    uint8_t       state;
-  // Detect_scale
-    D_scale_t     scale;
-  // Detect_window
-    D_window_t    win;
+    float      last;
+    uint8_t    state;
+  // Detect_WINDOW
+    D_window_t win;
+  // Detect_SCALE
+    D_scale_t  scale;
+  // Detect_VOLUME
+    D_volume_t volume;
 } Detect_t;
 
-void Detect_init( int channels );
+typedef void (*Detect_mode_fn_t)(Detect_t* self, float level);
 
-// mode functions
+
+////////////////////////////////////
+// init
+
+void Detect_init( int channels );
+void Detect_deinit( void );
+
+
+////////////////////////////////////
+// global functions
+
 Detect_t* Detect_ix_to_p( uint8_t index );
 int8_t Detect_str_to_dir( const char* str );
+
+
+/////////////////////////////////////
+// mode configuration
 
 void Detect_none( Detect_t* self );
 void Detect_change( Detect_t*         self
@@ -84,6 +102,7 @@ void Detect_window( Detect_t*         self
                   , int               wLen
                   , float             hysteresis
                   );
-
-// process fns
-void Detect( Detect_t* self, float level );
+void Detect_volume( Detect_t*         self
+                  , Detect_callback_t cb
+                  , float             interval
+                  );

--- a/lib/detect.h
+++ b/lib/detect.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stm32f7xx.h>
+#include "wrMeters.h"
 
 #define SCALE_MAX_COUNT 16
 #define WINDOW_MAX_COUNT 16

--- a/lib/io.c
+++ b/lib/io.c
@@ -30,9 +30,8 @@ void IO_Start( void )
 IO_block_t* IO_BlockProcess( IO_block_t* b )
 {
     for( int j=0; j<IN_CHANNELS; j++ ){
-        Detect( Detect_ix_to_p( j )
-              , b->in[j][b->size-1]
-              );
+        Detect_t* d = Detect_ix_to_p(j);
+        (*d->modefn)( d, b->in[j][b->size-1] );
     }
     for( int j=0; j<SLOPE_CHANNELS; j++ ){
         S_step_v( j

--- a/lib/lualink.h
+++ b/lib/lualink.h
@@ -29,6 +29,7 @@ extern void L_queue_in_stream( int id );
 extern void L_queue_change( int id, float state );
 extern void L_queue_midi( uint8_t* data );
 extern void L_queue_window( int id, float window );
+extern void L_queue_volume( int id, float level );
 extern void L_queue_in_scale( int id, float note );
 extern void L_queue_ii_leadRx( uint8_t address, uint8_t cmd, float data );
 extern void L_queue_ii_followRx( void );

--- a/ll/dac8565.c
+++ b/ll/dac8565.c
@@ -122,7 +122,6 @@ void DAC_PickleBlock( uint32_t* dac_pickle_ptr
     for( uint8_t j=0; j<4; j++ ){
         mul_vf_f( &(unpickled_data[j*bsize])
                 , dac_calibrated_scalar[j] // scale volts up to u16
-                , &(unpickled_data[j*bsize])
                 , bsize
                 );
     }

--- a/lua/input.lua
+++ b/lua/input.lua
@@ -22,7 +22,8 @@ function Input.new( chan )
               , change     = function(state) _c.tell('change',chan,state and 1 or 0) end
               , midi       = function(data) _c.tell('midi',table.unpack(data)) end
               , window     = function(win, dir) _c.tell('window',chan,win,dir and 1 or 0) end
-              , scale      = function(s) _c.tell('scale',s.note) end
+              , scale      = function(s) _c.tell('scale',chan,s.note) end
+              , volume     = function(level) _c.tell('volume',chan,level) end
               }
     setmetatable( i, Input )
     Input.inputs[chan] = i -- save reference for callback engine
@@ -63,6 +64,9 @@ function Input:set_mode( mode, ... )
                        , self.temp
                        , self.scaling
                        )
+    elseif mode == 'volume' then
+        self.time = args[1] or self.time
+        set_input_volume( self.channel, self.time )
     else
         set_input_none( self.channel )
     end
@@ -115,5 +119,6 @@ function scale_handler(chan,i,o,n,v)
     s={index=i, octave=o, note=n, volts=v}
     Input.inputs[chan].scale(s)
 end
+function volume_handler( chan, val ) Input.inputs[chan].volume( val ) end
 
 return Input


### PR DESCRIPTION
Using a basic RMS calculation with a ~300ms settling time for VU style amplitude tracking. Works like 'stream' (ie polling), so it's useful for mapping the amplitude of an audio signal to a voltage (ie. envelope following). Due to the RMS shaping, different waveforms will give different amplitudes, while DC signals will settle to their nominal voltage (with slew).

```lua
--- volume usage:
-- envelope follow the signal on input 1 and send a smoothed version out on output 1
input[1].mode( 'volume', 0.01 ) -- detect RMS volume and call the event every 10ms seconds
output[1].slew = 0.01
input[1].volume = function(level)
  output[1].volts = level
end
```

Fixes #242 