### PR TITLE
Stop metro from triggering instantly

### DIFF
--- a/ll/timers.c
+++ b/ll/timers.c
@@ -77,7 +77,6 @@ int Timer_Init(void)
         // static setup
         TimHandle[i].Init.ClockDivision     = TIM_CLOCKDIVISION_DIV4;
         TimHandle[i].Init.CounterMode       = TIM_COUNTERMODE_UP;
-        TimHandle[i].Init.RepetitionCounter = 0;
         TimHandle[i].Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;
 
         Timer_Set_Params( i, 1.0 );
@@ -133,6 +132,8 @@ void Timer_Set_Params( int ix, float seconds )
     uint8_t err;
     BLOCK_IRQS(
         err = HAL_TIM_Base_Init( &(TimHandle[ix]) );
+        // Clear the update flag to avoid an instant callback
+        __HAL_TIM_CLEAR_FLAG( &(TimHandle[ix]), TIM_FLAG_UPDATE );
     );
     if( err != HAL_OK ){
         printf("Timer_Set_Params(%i) failed\n", ix);

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -158,12 +158,10 @@ function delay(action, time, repeats)
     local r = repeats or 1
     local d = {}
     function devent(c)
-        if c > 1 then
-            action(c-1) -- make the action aware of current iteration
-            if c > r then
-                metro.free(d.id)
-                d = nil
-            end
+        action(c) -- make the action aware of current iteration
+        if c > r then
+            metro.free(d.id)
+            d = nil
         end
     end
     d = metro.init(devent, time)


### PR DESCRIPTION
Currently running `metro[n]:start()` would cause the first `.event` to be called instantly. Additionally, any time the speed was changed with `.time` it would immediately complete the current stage.

This workaround is required due to the way the stm32 HAL library calls an event immediately to force the timing to be correctly applied. This commit simply clears that UPDATE interrupt flag after (re)initializing the timer.

The `delay()` lua function has been updated to take this into account (it would previously wait for the second iteration to workaround this issue).

This is a breaking change for existing scripts that rely on the count to be set to 1 instantly.