### PR TITLE
II getters that take a parameter now return that parameter

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -750,13 +750,14 @@ void L_handle_change( event_t* e )
     }
 }
 
-void L_queue_ii_leadRx( uint8_t address, uint8_t cmd, float data )
+void L_queue_ii_leadRx( uint8_t address, uint8_t cmd, float data, uint8_t arg )
 {
     event_t e = { .handler = L_handle_ii_leadRx
                 , .data.f  = data
                 };
     e.index.u8s[0] = address;
     e.index.u8s[1] = cmd;
+    e.index.u8s[2] = arg;
     event_post(&e);
 }
 void L_handle_ii_leadRx( event_t* e )
@@ -764,8 +765,9 @@ void L_handle_ii_leadRx( event_t* e )
     lua_getglobal(L, "ii_LeadRx_handler");
     lua_pushinteger(L, e->index.u8s[0]); // address
     lua_pushinteger(L, e->index.u8s[1]); // command
+    lua_pushinteger(L, e->index.u8s[2]); // arg
     lua_pushnumber(L, e->data.f);
-    if( Lua_call_usercode(L, 3, 0) != LUA_OK ){
+    if( Lua_call_usercode(L, 4, 0) != LUA_OK ){
         lua_pop( L, 1 );
     }
 }

--- a/lib/lualink.h
+++ b/lib/lualink.h
@@ -31,7 +31,7 @@ extern void L_queue_midi( uint8_t* data );
 extern void L_queue_window( int id, float window );
 extern void L_queue_volume( int id, float level );
 extern void L_queue_in_scale( int id, float note );
-extern void L_queue_ii_leadRx( uint8_t address, uint8_t cmd, float data );
+extern void L_queue_ii_leadRx( uint8_t address, uint8_t cmd, float data, uint8_t arg );
 extern void L_queue_ii_followRx( void );
 
 // Callback declarations

--- a/lua/ii.lua
+++ b/lua/ii.lua
@@ -40,12 +40,22 @@ function ii.get( address, cmd, ... )
     else ii_lead( address, cmd, ... ) end
 end
 
-function ii_LeadRx_handler( addr, cmd, data )
-    local name, ix = ii.is.lookup(addr) -- optionally returns a device index
-    ii[name].event(ii[name].e[cmd], data, ix)
+function ii_LeadRx_handler( addr, cmd, _arg, data )
+    local name, ix = ii.is.lookup(addr)
+    local rx_event = { name   = ii[name].e[cmd]
+                     , device = ix or 1
+                     , arg    = _arg
+                     }
+    ii[name].event(rx_event, data)
 end
 
-function ii.e( name, event, ... ) crow.tell('ii.'..name,'[['..tostring(event)..']]',...) end
+function ii.e( name, event, ... )
+    local e_string = '{name=[['..event.name..']]'
+                  .. ',device='..event.device
+                  .. ',arg='..event.arg
+                  .. '}'
+    crow.tell('ii.'..name,e_string,...)
+end
 
 ii.self =
     { cmds = { [1]='output'

--- a/util/ii_lua_module.lua
+++ b/util/ii_lua_module.lua
@@ -74,11 +74,7 @@ function lua_events(f)
     end
     e = e .. '}\n'
           .. 'function ' .. f.lua_name
-    if type(f.i2c_address) == 'table' then
-        e = e .. '.event(e,data,ix)ii.e(\'' .. f.lua_name .. '\',e,data,ix)end\n\n'
-    else
-        e = e .. '.event(e,data)ii.e(\'' .. f.lua_name .. '\',e,data)end\n\n'
-    end
+    e = e .. '.event(e,data)ii.e(\'' .. f.lua_name .. '\',e,data)end\n\n'
     return e
 end
 


### PR DESCRIPTION
NOTE: Breaks existing ii getters. This will require updates to any M4L devices that use i2c getters, and any norns patches that do. @dndrks I'm not sure if you're doing any `ii.<module>.get()` calls in the M4L package? Probably not, but heads up just in case.

Fixes #281 

Norns support is already broken (see #320) so the update should account for this change too.

Updates the `ii.<module>.event` function to work like:

```lua
ii.txi.event = function( event, value )
  if event.name == 'param' then
    print( 'ii.txi.param response:')
    print( ' channel='..event.arg )
    print( ' device='..event.device )
    print( ' value='..value)
  end
end
```

ie. The `event` argument is a table containing a full description of the connected ii request. It gives access to `arg` which is the first parameter after a get request's name, and `device` which indicates which address the attached device is speaking on.