### PR TITLE
ii error reporting improved. recovery from bad state

### DIFF
--- a/ll/i2c.c
+++ b/ll/i2c.c
@@ -228,6 +228,7 @@ int I2C_LeadRx( uint8_t  address
             if( HAL_I2C_DisableListen_IT( &i2c_handle ) != HAL_OK ){
                 error |= 0x1;
             } else if( __HAL_I2C_GET_FLAG( &i2c_handle, I2C_FLAG_BUSY ) ){
+                // NB: Explicitly check BUSY flag as Sequential_Transmit doesn't
                 error |= 0x2;
                 HAL_I2C_ListenCpltCallback( &i2c_handle ); // re-enable listen
             } else if( HAL_I2C_Master_Sequential_Transmit_IT( &i2c_handle

--- a/ll/i2c.c
+++ b/ll/i2c.c
@@ -10,6 +10,7 @@
 
 // can probably replace with HAL state machine?
 typedef enum{ OP_NULL
+            , OP_ERROR
             , OP_LISTEN
             , OP_LEAD_TX
             , OP_LEAD_RX
@@ -35,8 +36,10 @@ I2C_HandleTypeDef i2c_handle;
 I2C_lead_callback_t   lead_response;
 I2C_follow_callback_t follow_action;
 I2C_follow_callback_t follow_request;
+I2C_error_callback_t  error_action;
 
 I2C_State_t buf;
+uint8_t pullup_state = 0;
 
 
 //////////////////////////////
@@ -46,6 +49,7 @@ uint8_t I2C_Init( uint8_t               address
                 , I2C_lead_callback_t   lead_callback
                 , I2C_follow_callback_t follow_action_callback
                 , I2C_follow_callback_t follow_request_callback
+                , I2C_error_callback_t  error_callback
                 )
 {
     uint8_t error = 0;
@@ -53,6 +57,7 @@ uint8_t I2C_Init( uint8_t               address
     lead_response  = lead_callback;
     follow_action  = follow_action_callback;
     follow_request = follow_request_callback;
+    error_action   = error_callback;
 
     i2c_handle.Instance              = I2Cx;
     i2c_handle.Init.Timing           = I2C_TIMING;
@@ -145,6 +150,8 @@ void HAL_I2C_MspDeInit( I2C_HandleTypeDef* h )
 
 void I2C_SetPullups( uint8_t state )
 {
+    pullup_state = state;
+
     GPIO_InitTypeDef gpio;
     gpio.Pin       = I2Cx_SCL_PIN
                    | I2Cx_SDA_PIN;
@@ -156,6 +163,11 @@ void I2C_SetPullups( uint8_t state )
     HAL_GPIO_DeInit( I2Cx_SCL_GPIO_PORT, I2Cx_SCL_PIN );
     HAL_GPIO_DeInit( I2Cx_SDA_GPIO_PORT, I2Cx_SDA_PIN );
     HAL_GPIO_Init( I2Cx_SCL_GPIO_PORT, &gpio );
+}
+
+uint8_t I2C_GetPullups( void )
+{
+    return pullup_state;
 }
 
 uint8_t I2C_GetAddress( void )
@@ -190,6 +202,7 @@ int I2C_LeadTx( uint8_t  address
                     , size
                     ) != HAL_OK ){
                 error |= 2;
+                HAL_I2C_ListenCpltCallback( &i2c_handle ); // re-enable listen
             } else { buf.operation = OP_LEAD_TX; }
         );
     } else {
@@ -212,19 +225,24 @@ int I2C_LeadRx( uint8_t  address
         buf.size    = rx_size;
         buf.command = data[0];
         BLOCK_IRQS(
-            if( HAL_I2C_DisableListen_IT( &i2c_handle ) != HAL_OK ){ error |= 1; }
-            if( HAL_I2C_Master_Sequential_Transmit_IT( &i2c_handle
-                    , address
-                    , data
-                    , size
-                    , I2C_FIRST_FRAME
-                    ) != HAL_OK ){
-                error |= 2;
+            if( HAL_I2C_DisableListen_IT( &i2c_handle ) != HAL_OK ){
+                error |= 0x1;
+            } else if( __HAL_I2C_GET_FLAG( &i2c_handle, I2C_FLAG_BUSY ) ){
+                error |= 0x2;
+                HAL_I2C_ListenCpltCallback( &i2c_handle ); // re-enable listen
+            } else if( HAL_I2C_Master_Sequential_Transmit_IT( &i2c_handle
+                            , address
+                            , data
+                            , size
+                            , I2C_FIRST_FRAME
+                            ) != HAL_OK ){
+                error |= 0x4;
+                HAL_I2C_ListenCpltCallback( &i2c_handle ); // re-enable listen
             } else { buf.operation = OP_LEAD_RX; }
         );
     } else {
         printf("can't leadRx because operation=%i\n",buf.operation);
-        error = 1;
+        error = 8;
     }
     return error;
 }
@@ -362,43 +380,20 @@ void HAL_I2C_ListenCpltCallback( I2C_HandleTypeDef* hi2c )
 
 void I2Cx_ER_IRQHandler( void )
 {
-    printf("I2C Error: %i\n", (int)HAL_I2C_GetError( &i2c_handle ));
-    buf.operation = OP_NULL;
+    buf.operation = OP_ERROR;
     HAL_I2C_ER_IRQHandler( &i2c_handle );
 }
 
 void HAL_I2C_ErrorCallback( I2C_HandleTypeDef* h )
 {
     if( h->ErrorCode == HAL_I2C_ERROR_AF ){
-        printf("I2C_ERROR_AF\n"); // means can't find device
-
-        // Seems to lock up i2c bus until whole driver is reset
-        // Software reset
-/* A software reset can be performed by clearing the PE bit in the I2C_CR1 register. In that
-case I2C lines SCL and SDA are released. Internal states machines are reset and
-communication control bits, as well as status bits come back to their reset value. The
-configuration registers are not impacted.
-Here is the list of impacted register bits:
-1.
- I2C_CR2 register: START, STOP, NACK
-2.
- I2C_ISR register: BUSY, TXE, TXIS, RXNE, ADDR, NACKF, TCR, TC, STOPF, BERR,
-ARLO, OVR
-and in addition when the SMBus feature is supported:
-1.
- I2C_CR2 register: PECBYTE
-2.
- I2C_ISR register: PECERR, TIMEOUT, ALERT
-PE must be kept low during at least 3 APB clock cycles in order to perform the software
-reset. This is ensured by writing the following software sequence: - Write PE=0 - Check
-PE=0 - Write PE=1.
-*/
+        (*error_action)( 0 );
     } else {
         if( h->ErrorCode == 2 ){
-            Caw_send_luachunk("ii: lines are low. try ii.pullup(true)");
+            (*error_action)( 1 );
         } else{
-            printf("I2C_ERROR %i\n", (int)h->ErrorCode);
+            (*error_action)( (int)h->ErrorCode );
         }
     }
-    HAL_I2C_ListenCpltCallback( &i2c_handle );
+    HAL_I2C_ListenCpltCallback( &i2c_handle ); // Re-enable Listen
 }

--- a/ll/i2c.h
+++ b/ll/i2c.h
@@ -44,6 +44,7 @@
 // fnptr typedefs for low-level
 typedef void (*I2C_lead_callback_t)( uint8_t address, uint8_t command, uint8_t* rx_data );
 typedef int (*I2C_follow_callback_t)( uint8_t* pdata );
+typedef void (*I2C_error_callback_t)( int error_code );
 
 
 /////////////////
@@ -51,12 +52,14 @@ typedef int (*I2C_follow_callback_t)( uint8_t* pdata );
 uint8_t I2C_Init( uint8_t               address
                 , I2C_lead_callback_t   lead_callback
                 , I2C_follow_callback_t follow_action_callback
-                , I2C_follow_callback_t follow_request_callback );
+                , I2C_follow_callback_t follow_request_callback
+                , I2C_error_callback_t  error_callback );
 void I2C_DeInit( void );
 
 uint8_t I2C_is_boot( void );
 
 void I2C_SetPullups( uint8_t state );
+uint8_t I2C_GetPullups( void );
 
 uint8_t I2C_GetAddress( void );
 void I2C_SetAddress( uint8_t address );


### PR DESCRIPTION
Fixes #308 

This is a bigger change than expected.

I added some infrastructure for passing an error callback to the hardware i2c driver (ll/i2c.c), so we can handle error reporting form the application ii layer (lib/ii.c). Added state management to know if the pullups are currently enabled/disabled in the low level driver.

As ii leader:
Previously sending a command (Tx) while the bus had a reverse connected / frozen device, would be fine after the issue was resolved. On the contrary, a getter command (TxRx) that failed due to a bus error would leave the i2c driver in a bad state that couldn't be escaped even after the issue was resolved. This has been remedied.

^^ I don't have an ER301 to test, but this could very likely solve #279 if @nordseele wants to check out this PR.

Either way, it's ready to merge as it improves the standard failure behaviour in the known contexts.