### PR TITLE
loosened restrictions on potentially valid calibration settings

### DIFF
--- a/ll/adda.c
+++ b/ll/adda.c
@@ -152,18 +152,18 @@ int CAL_ValidateData( void )
 {
     int errorcode = 0;
     for( int j=0; j<2; j++ ){
-        if( cal.adc[j].shift < -0.1
-         || cal.adc[j].shift > 0.1
-         || cal.adc[j].scale < 0.9
-         || cal.adc[j].scale > 1.1 ){
+        if( cal.adc[j].shift < -0.2
+         || cal.adc[j].shift > 0.2
+         || cal.adc[j].scale < 0.8
+         || cal.adc[j].scale > 1.2 ){
             errorcode |= 1 << j;
         }
     }
     for( int j=0; j<4; j++ ){
-        if( cal.dac[j].shift < -0.1
-         || cal.dac[j].shift > 0.1
-         || cal.dac[j].scale < 0.9
-         || cal.dac[j].scale > 1.1 ){
+        if( cal.dac[j].shift < -0.2
+         || cal.dac[j].shift > 0.2
+         || cal.dac[j].scale < 0.8
+         || cal.dac[j].scale > 1.2 ){
             errorcode |= 1 << (2+j);
         }
     }


### PR DESCRIPTION
Solves issue where new editions would fail calibration due to an overly pedantic validation routine.

All test devices i have here have passed, and are all acheiving ~5mV accuracy.