### PR TITLE
crow.reset now returns all input & ii events to their defaults

### DIFF
--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -42,11 +42,15 @@ end
 _crow.libs()
 
 function _crow.reset()
-    for n=1,2 do input[n].mode = 'none' end
+    for n=1,2 do
+        input[n].mode = 'none'
+        input[n]:reset_events()
+    end
     for n=1,4 do
         output[n].slew = 0
         output[n].volts = 0
     end
+    ii.reset_events(ii.self)
     metro.free_all()
 end
 

--- a/lua/ii.lua
+++ b/lua/ii.lua
@@ -70,20 +70,22 @@ ii.self =
              , [7+128]='query2'
              , [8+128]='query3'
              }
-    , output = function(chan,val) print('output '..chan..' to '..val)end
-    , slew = function(chan,slew) print('slew '..chan..' at '..slew)end
-    , call1 = function(arg) print('call1('..arg..')')end
-    , call2 = function(a,a2) print('call2('..a..','..a2..')')end
-    , call3 = function(a,a2,a3) print('call3('..a..','..a2..','..a3..')')end
-    , call4 = function(a,a2,a3,a4) print('call4('..a..','..a2..','..a3..','..a4..')')end
-
-    , query0 = function() print('query0()'); return 5 end
-    , query1 = function(a) print('query1('..a..')'); return 6 end
-    , query2 = function(a,a2) print('query2('..a..','..a2..')'); return 7 end
-    , query3 = function(a,a2,a3) print('query3('..a..','..a2..','..a3..')')
+    }
+function ii.reset_events()
+    ii.self.output = function(chan,val) print('output '..chan..' to '..val)end
+    ii.self.slew   = function(chan,slew) print('slew '..chan..' at '..slew)end
+    ii.self.call1  = function(arg) print('call1('..arg..')')end
+    ii.self.call2  = function(a,a2) print('call2('..a..','..a2..')')end
+    ii.self.call3  = function(a,a2,a3) print('call3('..a..','..a2..','..a3..')')end
+    ii.self.call4  = function(a,a2,a3,a4) print('call4('..a..','..a2..','..a3..','..a4..')')end
+    ii.self.query0 = function() print('query0()'); return 5 end
+    ii.self.query1 = function(a) print('query1('..a..')'); return 6 end
+    ii.self.query2 = function(a,a2) print('query2('..a..','..a2..')'); return 7 end
+    ii.self.query3 = function(a,a2,a3) print('query3('..a..','..a2..','..a3..')')
         return 8
     end
-}
+end
+ii.reset_events()
 
 function ii_followRx_handler( cmd, ... )
     local name = ii.self.cmds[cmd]

--- a/lua/input.lua
+++ b/lua/input.lua
@@ -17,24 +17,27 @@ function Input.new( chan )
               , notes      = {}
               , temp       = 12
               , scaling    = 1.0
-        -- user-customizable events
-              , stream     = function(value) _c.tell('stream',chan,value) end
-              , change     = function(state) _c.tell('change',chan,state and 1 or 0) end
-              , midi       = function(data) _c.tell('midi',table.unpack(data)) end
-              , window     = function(win, dir) _c.tell('window',chan,win,dir and 1 or 0) end
-              , scale      = function(s)
-                                local str = '{index=' .. s.index
-                                         .. ',octave=' .. s.octave
-                                         .. ',note=' .. s.note
-                                         .. ',volts=' .. s.volts .. '}'
-                                _c.tell('scale',chan,str)
-                             end
-              , volume     = function(level) _c.tell('volume',chan,level) end
-              , peak       = function() _c.tell('peak',chan) end
               }
     setmetatable( i, Input )
+    i:reset_events()
     Input.inputs[chan] = i -- save reference for callback engine
     return i
+end
+
+function Input:reset_events()
+    self.stream = function(value) _c.tell('stream',chan,value) end
+    self.change = function(state) _c.tell('change',chan,state and 1 or 0) end
+    self.midi   = function(data) _c.tell('midi',table.unpack(data)) end
+    self.window = function(win, dir) _c.tell('window',chan,win,dir and 1 or 0) end
+    self.scale  = function(s)
+                     local str = '{index=' .. s.index
+                              .. ',octave=' .. s.octave
+                              .. ',note=' .. s.note
+                              .. ',volts=' .. s.volts .. '}'
+                     _c.tell('scale',chan,str)
+                  end
+    self.volume = function(level) _c.tell('volume',chan,level) end
+    self.peak   = function() _c.tell('peak',chan) end
 end
 
 function Input:get_value()
@@ -102,6 +105,8 @@ Input.__index = function(self, ix)
         return function() _c.tell('stream',self.channel,Input.get_value(self)) end
     elseif ix == 'mode'  then
         return function(...) Input.set_mode( self, ...) end
+    elseif ix == 'reset_events' then
+        return function() Input.reset_events(self) end
     end
 end
 


### PR DESCRIPTION
Fixes the norns bug where setting the clock source to be crow would cause 'First' to restart when changing script.

`crow.reset()` is now much closer to a full reset (without trashing the lua VM or dropping the usb connection).

@dndrks @tehn if one of you could test this no longer repro's the bug that'd be great, but i'm 99% sure it's fixed