### PR TITLE
crow as ii follower commands

### DIFF
--- a/lib/ii.c
+++ b/lib/ii.c
@@ -296,6 +296,7 @@ static uint8_t type_size( ii_Type_t t )
                case ii_u16:   return 2;
                case ii_s16:   return 2;
                case ii_s16V:  return 2;
+               case ii_s16ms: return 2;
                case ii_float: return 4;
                case ii_s32T:  return 4;
                default:       return 0;
@@ -328,6 +329,11 @@ static float decode( uint8_t* data, ii_Type_t type )
             u16  = ((uint16_t)*data++)<<8;
             u16 |= *data++;
             val = ((float)*(int16_t*)&u16)*II_TT_iVOLT; // Scale Teletype down to float
+            break;
+        case ii_s16ms:
+            u16  = ((uint16_t)*data++)<<8;
+            u16 |= *data++;
+            val = (float)*(int16_t*)&u16/1000.0;
             break;
         case ii_float:
             val = *(float*)data;
@@ -369,6 +375,14 @@ static uint8_t encode( uint8_t* dest, ii_Type_t type, float data )
             data *= II_TT_VOLT; // Scale float up to Teletype
             // FLOWS THROUGH
         case ii_s16:
+            s16 = (int16_t)lim_f(data, -32768.0, 32767.0);
+            u16 = *(uint16_t*)&s16;
+            d[len++] = (uint8_t)(u16>>8);          // High byte first
+            d[len++] = (uint8_t)(u16 & 0x00FF);    // Low byte
+            break;
+        case ii_s16ms:
+            data *= 1000.0;
+            // as ii_s16
             s16 = (int16_t)lim_f(data, -32768.0, 32767.0);
             u16 = *(uint16_t*)&s16;
             d[len++] = (uint8_t)(u16>>8);          // High byte first

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -111,14 +111,32 @@ end
 -- pullups on by default
 ii.pullup(true)
 
+
 --- follower default actions
-ii.self.output = function(chan,val)
+ii.self.volts = function(chan,val)
     output[chan].volts = val
 end
 
 ii.self.slew = function(chan,slew)
-    output[chan].slew = slew/1000 -- ms
+    output[chan].slew = slew
 end
+
+ii.self.reset = function() _crow.reset() end
+
+ii.self.pulse = function(chan,ms,volts,pol)
+    output[chan](pulse(ms,volts,pol))
+end
+
+ii.self.ar = function(chan,atk,rel,volts)
+    output[chan](ar(atk,rel,volts))
+end
+
+ii.self.lfo = function(chan,freq,level,skew)
+    -- convert freq to seconds where freq==0 is 1Hz
+    output[chan](ramp(math.exp(2,-freq),level,skew))
+end
+
+
 
 
 --- True Random Number Generator

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -51,6 +51,7 @@ function _crow.reset()
         output[n].volts = 0
     end
     ii.reset_events(ii.self)
+    ii_follow_reset() -- resets forwarding to output libs
     metro.free_all()
 end
 
@@ -113,30 +114,16 @@ ii.pullup(true)
 
 
 --- follower default actions
-ii.self.volts = function(chan,val)
-    output[chan].volts = val
-end
-
-ii.self.slew = function(chan,slew)
-    output[chan].slew = slew
-end
-
-ii.self.reset = function() _crow.reset() end
-
-ii.self.pulse = function(chan,ms,volts,pol)
-    output[chan](pulse(ms,volts,pol))
-end
-
-ii.self.ar = function(chan,atk,rel,volts)
-    output[chan](ar(atk,rel,volts))
-end
-
-ii.self.lfo = function(chan,freq,level,skew)
+function ii_follow_reset()
+    ii.self.volts = function(chan,val) output[chan].volts = val end
+    ii.self.slew = function(chan,slew) output[chan].slew = slew end
+    ii.self.reset = function() _crow.reset() end
+    ii.self.pulse = function(chan,ms,volts,pol) output[chan](pulse(ms,volts,pol)) end
+    ii.self.ar = function(chan,atk,rel,volts) output[chan](ar(atk,rel,volts)) end
     -- convert freq to seconds where freq==0 is 1Hz
-    output[chan](ramp(math.exp(2,-freq),level,skew))
+    ii.self.lfo = function(chan,freq,level,skew) output[chan](ramp(math.exp(2,-freq),level,skew)) end
 end
-
-
+ii_follow_reset()
 
 
 --- True Random Number Generator

--- a/lua/ii.lua
+++ b/lua/ii.lua
@@ -76,18 +76,18 @@ ii.self =
              }
     }
 function ii.reset_events()
-    ii.self.volts  = function(chan,val) print('volts '..chan..' to '..val)end
-    ii.self.slew   = function(chan,slew) print('slew '..chan..' at '..slew)end
-    ii.self.call1  = function(arg) print('call1('..arg..')')end
-    ii.self.call2  = function(a,a2) print('call2('..a..','..a2..')')end
-    ii.self.call3  = function(a,a2,a3) print('call3('..a..','..a2..','..a3..')')end
-    ii.self.call4  = function(a,a2,a3,a4) print('call4('..a..','..a2..','..a3..','..a4..')')end
-    ii.self.query0 = function() print('query0()'); return 5 end
-    ii.self.query1 = function(a) print('query1('..a..')'); return 6 end
-    ii.self.query2 = function(a,a2) print('query2('..a..','..a2..')'); return 7 end
-    ii.self.query3 = function(a,a2,a3) print('query3('..a..','..a2..','..a3..')')
-        return 8
-    end
+    ii.self.call1  = function(a) ii.self.call{a} end
+    ii.self.call2  = function(a,a2) ii.self.call{a,a2} end
+    ii.self.call3  = function(a,a2,a3) ii.self.call{a,a2,a3} end
+    ii.self.call4  = function(a,a2,a3,a4) ii.self.call{a,a2,a3,a4} end
+    ii.self.query0 = function() return ii.self.query{} end
+    ii.self.query1 = function(a) return ii.self.query{a} end
+    ii.self.query2 = function(a,a2) return ii.self.query{a,a2} end
+    ii.self.query3 = function(a,a2,a3) return ii.self.query{a,a2,a3} end
+
+    -- all the individual call/queries forward to these 2 user fns
+    ii.self.call = function(args) print('call'..#args) end
+    ii.self.query = function(args) print('query'..#args); return 0 end
 end
 ii.reset_events()
 

--- a/lua/ii.lua
+++ b/lua/ii.lua
@@ -58,12 +58,16 @@ function ii.e( name, event, ... )
 end
 
 ii.self =
-    { cmds = { [1]='output'
+    { cmds = { [1]='volts'
              , [2]='slew'
              , [4]='call1'
              , [5]='call2'
              , [6]='call3'
              , [7]='call4'
+             , [8]='reset'
+             , [9]='pulse'
+             , [10]='ar'
+             , [11]='lfo'
              -- input & output queries in C only
              , [5+128]='query0'
              , [6+128]='query1'
@@ -72,7 +76,7 @@ ii.self =
              }
     }
 function ii.reset_events()
-    ii.self.output = function(chan,val) print('output '..chan..' to '..val)end
+    ii.self.volts  = function(chan,val) print('volts '..chan..' to '..val)end
     ii.self.slew   = function(chan,slew) print('slew '..chan..' at '..slew)end
     ii.self.call1  = function(arg) print('call1('..arg..')')end
     ii.self.call2  = function(a,a2) print('call2('..a..','..a2..')')end

--- a/lua/ii/crow.lua
+++ b/lua/ii/crow.lua
@@ -4,7 +4,7 @@ do return
 , i2c_address  = 0x01
 , lua_name     = 'crow'
 , commands     =
-  { { name = 'output'
+  { { name = 'volts'
     , cmd  = 1
     , args = { {'channel', s8, }
              , {'level', s16V }
@@ -13,7 +13,7 @@ do return
   , { name = 'slew'
     , cmd  = 2
     , args = { {'channel', s8, }
-             , {'time', s16 }
+             , {'time', s16ms }
              }
     }
   , { name = 'call1'
@@ -39,6 +39,33 @@ do return
              , { 'arg2', s16 }
              , { 'arg3', s16 }
              , { 'arg4', s16 }
+             }
+    }
+  , { name = 'reset'
+    , cmd  = 8
+    }
+  , { name = 'pulse'
+    , cmd  = 9
+    , args = { { 'chan', s8 }
+             , { 'time', s16ms }
+             , { 'level', s16V }
+             , { 'polarity', s8 }
+             }
+    }
+  , { name = 'ar'
+    , cmd  = 10
+    , args = { { 'chan', s8 }
+             , { 'attack', s16ms }
+             , { 'release', s16ms }
+             , { 'level', s16V }
+             }
+    }
+  , { name = 'lfo'
+    , cmd  = 11
+    , args = { { 'chan', s8 }
+             , { 'freq', s16V } -- 0 == 1Hz
+             , { 'level', s16V }
+             , { 'skew', s16V }
              }
     }
   }

--- a/util/ii_c_layer.lua
+++ b/util/ii_c_layer.lua
@@ -6,6 +6,7 @@ s8 = 'ii_s8'
 u8 = 'ii_u8'
 s16 = 'ii_s16'
 s16V = 'ii_s16V'
+s16ms = 'ii_s16ms'
 u16 = 'ii_u16'
 float = 'ii_float'
 s32T = 'ii_s32T'
@@ -25,6 +26,7 @@ typedef enum{ ii_void
             , ii_u16
             , ii_s16
             , ii_s16V
+            , ii_s16ms
             , ii_float   // 32bit (for crow to crow comm'n)
             , ii_s32T
 } ii_Type_t;


### PR DESCRIPTION
add crow commands for reset & some asllib actions.
add s16ms type to descriptor system for using s16 to represent milliseconds (like teletype ms).

UNTESTED

The API for using crow as a follower has been changed:

```lua
ii.self.call = function(args)
  -- 'args' is a table
  -- use `#args` if you want to switch on the count of args (like the old call1, call2)
end

ii.self.query = function(args)
  -- 'args' is a table. use `#args` if you want to switch on arg count.
  return 0 -- here is where you return the value to the leader
end
```

All other commands & queries are handled directly by the crowlib. They typically should not be redefined by the user, though they can be if so desired. eg. `ii.crow.reset()` will trigger `crow.reset()` on the follower, but you could redefine this behaviour with `ii.self.reset = function() <do something else here> end`.


Will fix #258 