### PR TITLE
Limit metro to 500uS or slower

### DIFF
--- a/lib/metro.c
+++ b/lib/metro.c
@@ -39,25 +39,16 @@ void Metro_Init( int num_metros )
     }
 }
 
-void Metro_start( int   ix
-                , float seconds
-                , int   count
-                , int   stage
-                )
+void Metro_start( int ix )
 {
     if( ix < 0
      || ix >= max_num_metros ){ printf("metro_start: bad index\n"); return; }
 
     Metro_t* t = &(metros[ix]);
     t->status = METRO_STATUS_RUNNING;
-    t->count  = count;
-    t->stage  = stage;
-
-    Timer_Set_Params( ix, seconds );
     Timer_Start( ix, Metro_bang );
 }
 
-// cancel all scheduled iterations
 void Metro_stop( int ix )
 {
     if( ix < 0
@@ -77,13 +68,30 @@ void Metro_stop_all( void )
     }
 }
 
-// set period of metro
 void Metro_set_time( int ix, float sec )
 {
     if( ix < 0
      || ix >= max_num_metros ){ printf("metro_set_time: bad index\n"); return; }
 
     Timer_Set_Params( ix, sec ); // only using struct accessor
+}
+
+void Metro_set_count( int ix, int count )
+{
+    if( ix < 0
+     || ix >= max_num_metros ){ printf("metro_set_count: bad index\n"); return; }
+
+    Metro_t* t = &(metros[ix]);
+    t->count = count;
+}
+
+void Metro_set_stage( int ix, int stage )
+{
+    if( ix < 0
+     || ix >= max_num_metros ){ printf("metro_set_stage: bad index\n"); return; }
+
+    Metro_t* t = &(metros[ix]);
+    t->stage = stage;
 }
 
 static void Metro_bang( int ix )

--- a/lib/metro.h
+++ b/lib/metro.h
@@ -4,19 +4,12 @@ extern const int MAX_NUM_METROS;
 
 void Metro_Init( int num_metros );
 
-// create a metro at the specified index
-// seconds < 0 == use previous period
-void Metro_start( int   idx
-                , float seconds
-                , int   count
-                , int   stage
-                );
-
-// cancel all scheduled iterations
-void Metro_stop( int idx );
+// control
+void Metro_start( int ix );
+void Metro_stop( int ix );
 void Metro_stop_all( void );
 
-// set period of metro
-// NB: if the metro is running, its hard to say if new value will take effect
-// on current period or next period
-void Metro_set_time( int idx, float sec );
+// params
+void Metro_set_time( int ix, float sec );
+void Metro_set_count( int ix, int count );
+void Metro_set_stage( int ix, int stage );


### PR DESCRIPTION
Fixes #349 

When setting a metro timer to 0s interval, it would freeze crow! Negative values might have as well.

Now negative values to `metro.init` or `metro.time` reuse the previous value (same as norns).
Time values in the [0 .. 0.0005) range now clamp to the latter (ie half a millisecond). This seems like more than enough for a Lua metro, without limiting the low-level library so it can be used at much higher rates by the C sub system.

UNTESTED.