### PR TITLE
moved midi handling into detect library

### DIFF
--- a/lib/detect.c
+++ b/lib/detect.c
@@ -66,6 +66,7 @@ int8_t Detect_str_to_dir( const char* str )
 
 void Detect_none( Detect_t* self )
 {
+    if( self->channel == 0 ){ MIDI_Active(0, NULL); }
     self->modefn = d_none;
 }
 
@@ -74,6 +75,7 @@ void Detect_stream( Detect_t*         self
                   , float             interval
                   )
 {
+    if( self->channel == 0 ){ MIDI_Active(0, NULL); }
     self->modefn         = d_stream;
     self->action         = cb;
     // SAMPLE_RATE * i / BLOCK_SIZE
@@ -89,6 +91,7 @@ void Detect_change( Detect_t*         self
                   , int8_t            direction
                   )
 {
+    if( self->channel == 0 ){ MIDI_Active(0, NULL); }
     self->modefn            = d_change;
     self->action            = cb;
     self->change.threshold  = threshold;
@@ -106,6 +109,7 @@ void Detect_scale( Detect_t*         self
                  , float             scaling
                  )
 {
+    if( self->channel == 0 ){ MIDI_Active(0, NULL); }
     self->modefn        = d_scale;
     self->action        = cb;
     self->scale.sLen    = (sLen > SCALE_MAX_COUNT) ? SCALE_MAX_COUNT : sLen;
@@ -137,6 +141,7 @@ void Detect_window( Detect_t*         self
                   , float             hysteresis
                   )
 {
+    if( self->channel == 0 ){ MIDI_Active(0, NULL); }
     printf("TODO need to sort the windows!\n");
     self->modefn         = d_window;
     self->action         = cb;
@@ -152,6 +157,7 @@ void Detect_volume( Detect_t*         self
                   , float             interval
                   )
 {
+    if( self->channel == 0 ){ MIDI_Active(0, NULL); }
     self->modefn         = d_volume;
     self->action         = cb;
 
@@ -168,6 +174,7 @@ void Detect_peak( Detect_t*         self
                 , float             hysteresis
                 )
 {
+    if( self->channel == 0 ){ MIDI_Active(0, NULL); }
     self->modefn            = d_peak;
     self->action            = cb;
     // TODO perhaps a abs->2lpf (no RMS averaging) is better?
@@ -179,6 +186,16 @@ void Detect_peak( Detect_t*         self
     self->peak.envelope   = 0.0;
 }
 
+void Detect_midi( Detect_t*              self
+                , Detect_void_callback_t cb
+                )
+{
+    // only first chan support MIDI. otherwise ignore
+    if( self->channel == 0 ){
+        self->modefn = d_none; // block processor does nothing
+        MIDI_Active(1, cb);
+    }
+}
 
 //////////////////////////////////////////////
 // signal processors

--- a/lib/detect.h
+++ b/lib/detect.h
@@ -3,10 +3,12 @@
 #include <stm32f7xx.h>
 
 #include "wrMeters.h"
+#include "midi.h" // MIDI_Active
 
 #define SCALE_MAX_COUNT 16
 #define WINDOW_MAX_COUNT 16
 
+typedef void (*Detect_void_callback_t)(uint8_t* data);
 typedef void (*Detect_callback_t)(int channel, float value);
 
 typedef struct{
@@ -123,4 +125,7 @@ void Detect_peak( Detect_t*         self
                 , Detect_callback_t cb
                 , float             threshold
                 , float             hysteresis
+                );
+void Detect_midi( Detect_t*              self
+                , Detect_void_callback_t cb
                 );

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -339,7 +339,6 @@ static int _set_input_none( lua_State *L )
     Detect_t* d = Detect_ix_to_p( ix ); // Lua is 1-based
     if(d){ // valid index
         Detect_none( d );
-        if( ix == 0 ){ MIDI_Active( 0 ); } // deactivate MIDI if first chan
     }
     lua_pop( L, 1 );
     lua_settop(L, 0);
@@ -354,7 +353,6 @@ static int _set_input_stream( lua_State *L )
                      , L_queue_stream
                      , luaL_checknumber(L, 2)
                      );
-        if( ix == 0 ){ MIDI_Active( 0 ); } // deactivate MIDI if first chan
     }
     lua_pop( L, 2 );
     lua_settop(L, 0);
@@ -371,7 +369,6 @@ static int _set_input_change( lua_State *L )
                      , luaL_checknumber(L, 3)
                      , Detect_str_to_dir( luaL_checkstring(L, 4) )
                      );
-        if( ix == 0 ){ MIDI_Active( 0 ); } // deactivate MIDI if first chan
     }
     lua_pop( L, 4 );
     lua_settop(L, 0);
@@ -380,12 +377,9 @@ static int _set_input_change( lua_State *L )
 static int _set_input_midi( lua_State *L )
 {
     uint8_t ix = luaL_checkinteger(L, 1)-1;
-    if( ix == 0 ){ // only first channel supports midi
-        Detect_t* d = Detect_ix_to_p( ix ); // Lua is 1-based
-        if(d){ // valid index
-            Detect_none( d );
-            MIDI_Active( 1 );
-        }
+    Detect_t* d = Detect_ix_to_p( ix ); // Lua is 1-based
+    if(d){ // valid index
+        Detect_midi( d, L_queue_midi );
     }
     lua_pop( L, 1 );
     lua_settop(L, 0);
@@ -411,7 +405,6 @@ static int _set_input_window( lua_State *L )
                      , wLen
                      , luaL_checknumber(L, 3) // hysteresis
                      );
-        if( ix == 0 ){ MIDI_Active( 0 ); } // deactivate MIDI if first chan
     }
     lua_pop( L, 3 );
     return 0;
@@ -436,7 +429,6 @@ static int _set_input_scale( lua_State *L )
                     , luaL_checknumber(L, 3) // divs-per-octave
                     , luaL_checknumber(L, 4) // volts-per-octave
                     );
-        if( ix == 0 ){ MIDI_Active( 0 ); } // deactivate MIDI if first chan
     }
     lua_pop( L, 4 );
     return 0;
@@ -450,7 +442,6 @@ static int _set_input_volume( lua_State *L )
                      , L_queue_volume
                      , luaL_checknumber(L, 2)
                      );
-        if( ix == 0 ){ MIDI_Active( 0 ); } // deactivate MIDI if first chan
     }
     lua_pop( L, 2 );
     lua_settop(L, 0);
@@ -466,7 +457,6 @@ static int _set_input_peak( lua_State *L )
                    , luaL_checknumber(L, 2)
                    , luaL_checknumber(L, 3)
                    );
-        if( ix == 0 ){ MIDI_Active( 0 ); } // deactivate MIDI if first chan
     }
     lua_pop( L, 3 );
     lua_settop(L, 0);

--- a/lib/midi.c
+++ b/lib/midi.c
@@ -35,10 +35,12 @@ static uint8_t MIDI_rx_data( uint8_t count );
 static void event_complete( uint8_t* d );
 void MIDI_Handle_Error( void );
 
+static void (*midi_event)(uint8_t* data);
 
 // public defns
-void MIDI_Active( int state )
+void MIDI_Active( int state, void(*midi_e)(uint8_t*) )
 {
+    midi_event = midi_e;
     static int is_active = 0;
     if( state && !is_active ){
         MIDI_ll_Init( &MIDI_Handle_LL
@@ -54,7 +56,7 @@ void MIDI_Active( int state )
     } // else ignore
 }
 
-uint8_t receiving_packet = 0;
+static uint8_t receiving_packet = 0;
 static uint8_t MIDI_rx_cmd( void )
 {
     receiving_packet = 0;
@@ -118,6 +120,6 @@ int MIDI_byte_count( uint8_t cmd_byte )
 
 static void event_complete( uint8_t* d )
 {
-    L_queue_midi(d);
+    midi_event(d);
     if( MIDI_rx_cmd() ){ printf("midi3\n"); }
 }

--- a/lib/midi.h
+++ b/lib/midi.h
@@ -2,6 +2,6 @@
 
 #include <stdint.h>
 
-void MIDI_Active( int state );
+void MIDI_Active( int state, void(*midi_e)(uint8_t*) );
 void MIDI_Handle_LL( uint8_t* buf );
 int MIDI_byte_count( uint8_t cmd_byte );


### PR DESCRIPTION
Fixes #315 

This just changes the location of the MIDI handling so it's a subset of the Detect library. This makes more sense because the 'Detect' functionality is a set of different modalities for the input jack. The weird thing is that the MIDI lib uses different hardware (a uart) to detect messages rather than the ADC reading, but it still feels like it's best to consolidate along with the other meta-functionality of the inputs.

This particularly makes sense in the context of the WIP frequency-detection mode, as they can both be captured in a similar fashion (nb. freq-detect also uses the alternate UART hardware, though simply treats it as an interrupt pin for freq counting).

UNTESTED