### PR TITLE
Fix buffer allocation when reading a userscript

### DIFF
--- a/lib/flash.c
+++ b/lib/flash.c
@@ -107,17 +107,27 @@ char* Flash_read_user_scriptaddr( void )
 uint8_t Flash_read_user_script( char* buffer )
 {
     if( Flash_which_user_script() != USERSCRIPT_User ){ return 1; } // no script
-    // FIXME: need to add 1 to length for null char?
 
-    uint16_t word_length = ((*(__IO uint32_t*)USER_SCRIPT_LOCATION) >> 16) >> 2;
-    word_length++;
+    uint16_t byte_length = Flash_read_user_scriptlen();
+    uint16_t word_length = byte_length >> 2; // drops 0-3 chars
+    uint16_t trailing_bytes = byte_length & 0x3; // handle last 0-3 chars
 
     uint32_t sd_addr = USER_SCRIPT_LOCATION + 4;
+
+    // write whole words
     uint32_t* word_buffer = (uint32_t*)buffer;
     while( word_length-- ){
         *word_buffer++ = (*(__IO uint32_t*)sd_addr);
         sd_addr += 4;
     }
+
+    // write final 0-3 bytes
+    uint32_t last_word = (*(__IO uint32_t*)sd_addr); // incomplete word
+    char* char_buffer = (char*)word_buffer; // continue where word_buffer left off
+    for( int i=0; i<trailing_bytes; i++ ){ // write final chars individually
+        char_buffer[i] = (last_word >> (i*8)) & 0xFF; // LSB first
+    }
+
     return 0;
 }
 

--- a/lib/flash.c
+++ b/lib/flash.c
@@ -96,7 +96,7 @@ uint8_t Flash_write_user_script( char* script, uint32_t length )
 
 uint16_t Flash_read_user_scriptlen( void )
 {
-    return (*((__IO uint16_t*)USER_SCRIPT_LOCATION + 1));
+    return (*((__IO uint16_t*)(USER_SCRIPT_LOCATION + 2)));
 }
 
 char* Flash_read_user_scriptaddr( void )

--- a/lib/repl.c
+++ b/lib/repl.c
@@ -202,14 +202,13 @@ static void REPL_receive_script( char* buf, uint32_t len, ErrorHandler_t errfn )
 
 static bool REPL_new_script_buffer( uint32_t len )
 {
-    new_script = malloc(len);
+    new_script = calloc( sizeof(char), len);
     if( new_script == NULL ){
         printf("malloc failed. REPL\n");
         Caw_send_luachunk("!ERROR! Out of memory.");
         return false;
     }
-    memset(new_script, 0, len);
-    new_script_len = 0;
+    new_script_len = 0; // reset counter as the buffer is empty
     return true;
 }
 


### PR DESCRIPTION
Fixes #365 (cc @dndrks )

Tracking down why adding an additional new-line to a script could cause it to trigger the 'out of memory' error. Turns out it had nothing to do with the line-endings, but rather was an issue caused by writing over the end of a malloc'd char array.

Essentially we were allocating an exact number of bytes to hold the userscript in memory, but were then filling it with whole-words (4 bytes) rounded-up to the nearest word. This caused 0 to 3 bytes to be written past the end of the buffer, trampling something in the heap.

I think in this specific script it was the precise length that caused "out of memory" error to occur, but the specific error that it caused was totally dependent on the size of the script (which would change where in memory the buffer would be allocated). Obviously, *most* of the time this didn't matter (because the heap is generally sparse after boot).

I have a sneaking suspicion this has also been causing the 'won't boot & need to 'erase_userscript' bug -- In that situation the system *is* booting, but the USB fails to enumerate, making it impossible to communicate with the device. I propose that the reason USB wouldn't enumerate is the Lua environment hangs because some state variable in memory is corrupted.