### PR TITLE
routines for sending raw bytes as i2c messages

### DIFF
--- a/lib/ii.c
+++ b/lib/ii.c
@@ -226,7 +226,7 @@ uint8_t* ii_processLeadRx( void )
 
 static void lead_callback( uint8_t address, uint8_t command, uint8_t* rx_data )
 {
-    if (!rx_is_raw) ii_unpickle( &address, &command, rx_data );
+    if( !rx_is_raw ){ ii_unpickle( &address, &command, rx_data ); }
     ii_Type_t return_type = ii_s32T;
     const ii_Cmd_t* cmd = ii_find_command(address, command);
     if( cmd != NULL ){

--- a/lib/ii.c
+++ b/lib/ii.c
@@ -159,7 +159,7 @@ uint8_t ii_leader_enqueue_bytes( uint8_t  address
 
     q->is_raw = true;
     q->address = address;
-    q->arg = tx_len > 1 ? data[1] : data[0];
+    q->arg = tx_len > 1 ? data[1] : 0;
     q->query_length = rx_len;
     q->length = tx_len;
     memcpy( q->data, data, tx_len );

--- a/lib/ii.c
+++ b/lib/ii.c
@@ -152,6 +152,9 @@ uint8_t ii_leader_enqueue_bytes( uint8_t  address
 
     ii_q_t* q = &l_iq[ix];
 
+    if( tx_len > II_MAX_BROADCAST_LEN ){ tx_len = II_MAX_BROADCAST_LEN; }
+    if( rx_len > II_MAX_RECEIVE_LEN ){ rx_len = II_MAX_RECEIVE_LEN; }
+
     q->address = address;
     q->query_length = rx_len;
     q->length = tx_len;

--- a/lib/ii.c
+++ b/lib/ii.c
@@ -30,6 +30,7 @@ typedef struct{
     uint8_t query_length; // 0 for broadcast, >0 is return type byte size
     uint8_t data[II_MAX_BROADCAST_LEN];
     uint8_t arg; // just carrying this through for the follower response
+    bool is_raw;
 } ii_q_t;
 
 
@@ -56,6 +57,7 @@ queue_t* f_qix;
 ii_q_t   l_iq[II_QUEUE_LENGTH];
 uint8_t  f_iq[II_QUEUE_LENGTH][II_MAX_RECEIVE_LEN];
 uint8_t  rx_arg = 0; // FIXME is there a better solution?
+bool     rx_is_raw = false;
 
 
 ////////////////////////
@@ -155,11 +157,12 @@ uint8_t ii_leader_enqueue_bytes( uint8_t  address
     if( tx_len > II_MAX_BROADCAST_LEN ){ tx_len = II_MAX_BROADCAST_LEN; }
     if( rx_len > II_MAX_RECEIVE_LEN ){ rx_len = II_MAX_RECEIVE_LEN; }
 
+    q->is_raw = true;
     q->address = address;
+    q->arg = tx_len > 1 ? data[1] : data[0];
     q->query_length = rx_len;
     q->length = tx_len;
     memcpy( q->data, data, tx_len );
-    ii_pickle( &q->address, q->data, &q->length );
     return 0;
 }
 
@@ -173,6 +176,7 @@ void ii_leader_process( void )
     int error = 0;
     if( q->query_length ){
         rx_arg = q->arg;
+        rx_is_raw = q->is_raw;
         if( (error = I2C_LeadRx( q->address
                       , q->data
                       , q->length
@@ -222,7 +226,7 @@ uint8_t* ii_processLeadRx( void )
 
 static void lead_callback( uint8_t address, uint8_t command, uint8_t* rx_data )
 {
-    ii_unpickle( &address, &command, rx_data );
+    if (!rx_is_raw) ii_unpickle( &address, &command, rx_data );
     ii_Type_t return_type = ii_s32T;
     const ii_Cmd_t* cmd = ii_find_command(address, command);
     if( cmd != NULL ){

--- a/lib/ii.h
+++ b/lib/ii.h
@@ -28,6 +28,7 @@ const char* ii_list_cmds( uint8_t address );
 
 /////////////////////////
 uint8_t ii_leader_enqueue( uint8_t address, uint8_t cmd, float* data );
+uint8_t ii_leader_enqueue_bytes( uint8_t address , uint8_t* data , uint8_t tx_len, uint8_t rx_len );
 void ii_leader_process( void ); // call from event loop
 
 

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -513,6 +513,23 @@ static int _ii_lead( lua_State *L )
     lua_settop(L, 0);
     return 0;
 }
+static int _ii_lead_bytes( lua_State *L )
+{
+    int nargs = lua_gettop(L);
+    if( nargs != 3 ) return 0;
+    uint8_t address = luaL_checkinteger(L, 1);
+    size_t len;
+    uint8_t *data = (uint8_t *)luaL_checklstring(L, 2, &len);
+    uint8_t rx_len = (uint8_t)luaL_checkinteger(L, 3);
+    if( ii_leader_enqueue_bytes( address
+                               , data
+                               , (uint8_t)len
+                               , rx_len
+                               ) ){ printf("ii_lead_bytes failed\n"); }
+    lua_settop(L, 0);
+    return 0;
+}
+
 static int _ii_address( lua_State *L )
 {
     ii_set_address( luaL_checkinteger(L, 1) );
@@ -636,6 +653,7 @@ static const struct luaL_Reg libCrow[]=
     , { "ii_list_commands" , _ii_list_commands }
     , { "ii_pullup"        , _ii_pullup        }
     , { "ii_lead"          , _ii_lead          }
+    , { "ii_lead_bytes"    , _ii_lead_bytes    }
     , { "ii_set_add"       , _ii_address       }
     , { "ii_get_add"       , _ii_get_address   }
         // metro

--- a/lua/ii.lua
+++ b/lua/ii.lua
@@ -45,13 +45,15 @@ function ii.get( address, cmd, ... )
 end
 
 function ii_LeadRx_handler( addr, cmd, _arg, data )
-    if ii.event_raw(addr, cmd, data) then return end
+    if ii.event_raw(addr, cmd, data, arg) then return end
     local name, ix = ii.is.lookup(addr)
-    local rx_event = { name   = ii[name].e[cmd]
-                     , device = ix or 1
-                     , arg    = _arg
-                     }
-    ii[name].event(rx_event, data)
+    if name ~= nil then
+      local rx_event = { name   = ii[name].e[cmd]
+                       , device = ix or 1
+                       , arg    = _arg
+                       }
+      ii[name].event(rx_event, data)
+    end
 end
 
 function ii.e( name, event, ... )
@@ -94,7 +96,7 @@ function ii.reset_events()
     ii.self.call = function(args) print('call'..#args) end
     ii.self.query = function(args) print('query'..#args); return 0 end
 
-    ii.event_raw = function(addr, cmd, data) end
+    ii.event_raw = function(addr, cmd, data, arg) end
 end
 ii.reset_events()
 

--- a/lua/ii.lua
+++ b/lua/ii.lua
@@ -35,12 +35,17 @@ function ii.set( address, cmd, ... )
     ii_lead( address, cmd, ... )
 end
 
+function ii.raw( address, bytes, rx_len )
+    ii_lead_bytes( address, bytes, rx_len or 0 )
+end
+
 function ii.get( address, cmd, ... )
     if not cmd then print'param not found'
     else ii_lead( address, cmd, ... ) end
 end
 
 function ii_LeadRx_handler( addr, cmd, _arg, data )
+    if ii.event_raw(addr, cmd, data) then return end
     local name, ix = ii.is.lookup(addr)
     local rx_event = { name   = ii[name].e[cmd]
                      , device = ix or 1
@@ -88,6 +93,8 @@ function ii.reset_events()
     -- all the individual call/queries forward to these 2 user fns
     ii.self.call = function(args) print('call'..#args) end
     ii.self.query = function(args) print('query'..#args); return 0 end
+
+    ii.event_raw = function(addr, cmd, data) end
 end
 ii.reset_events()
 

--- a/lua/ii.lua
+++ b/lua/ii.lua
@@ -48,11 +48,11 @@ function ii_LeadRx_handler( addr, cmd, _arg, data )
     if ii.event_raw(addr, cmd, data, arg) then return end
     local name, ix = ii.is.lookup(addr)
     if name ~= nil then
-      local rx_event = { name   = ii[name].e[cmd]
-                       , device = ix or 1
-                       , arg    = _arg
-                       }
-      ii[name].event(rx_event, data)
+        local rx_event = { name   = ii[name].e[cmd]
+                         , device = ix or 1
+                         , arg    = _arg
+                         }
+        ii[name].event(rx_event, data)
     end
 end
 


### PR DESCRIPTION
Closes https://github.com/monome/crow/issues/353

The API is as follows:
```lua
ii.raw( addr   -- i2c address, as an int
      , data   -- bytes to send, as a string
      , rx_len -- number of response bytes to read (optional, default 0)
      )
```
You may register an event handler:
```lua
ii.event_raw = function(addr, cmd, data) print(cmd..' from '..addr) end
```
which is passed data from _all_ received ii packets before other handlers run. If this handler returns truthy then normal ii event handling is suppressed, allowing you to handle everything in raw mode if desired. The `data` argument is parsed according to the ii device definitions for return values. If the command is unknown (I haven't tested this, but previously I think it might have resulted in a null pointer dereference?) then the return value type defaults to `s32T` to give a chance to handle as much data as currently possible. Carrying the `arg` through from raw calls currently isn't possible since there is only storage for a single float argument to the getter.

---

Usage example:

```
-- equivalent to ii.jf.play_note(0, 5)
> ii.raw(0x70, '\x09\x00\x00\x20\x00')

> ii.event_raw = function(addr, cmd, data) print('from '..addr..': '..cmd..' '..data) end

-- equivalent to ii.jf.get('speed')
> ii.raw(0x70, '\x8f', 1)
from 112: 143 1.0
^^ii.jf({name=[[speed]], device=1, arg=0}, 1.0)

-- suppress normal ii handler
> ii.event_raw = function(addr, cmd, data) print('from '..addr..': '..cmd..' '..data); return true end
> ii.raw(0x70, '\x8f', 1)
from 112: 143 1.0
```

