### PR TITLE
Adc timing improvement

### DIFF
--- a/ll/ads131.h
+++ b/ll/ads131.h
@@ -96,7 +96,7 @@
 #define ADS_CLK2      0x0E
 #define ADS_ADC_ENA   0x0F
 
-#define ADS_DATAWORDSIZE 0x4 // 32bit, pin M1 pulled high to IOVDD
+#define ADS_DATAWORDSIZE 0x2 // 16bit, pin M1 floats
 
 void ADC_Init( uint16_t bsize, uint8_t chan_count, int timer_ix );
 

--- a/ll/timers.c
+++ b/ll/timers.c
@@ -109,9 +109,10 @@ void HAL_TIM_PeriodElapsedCallback( TIM_HandleTypeDef *htim )
 void Timer_Set_Params( int ix, float seconds )
 {
     //FIXME limited to max~20s (p=0xFFFF & ps=0xFFFF)
-    const float SECOND_SCALER = (float)((double)216000000.0 / (double)0x10000)-1.0;
+    const double SECOND_SCALER = ((double)216000000.0 / (double)0x10000)-(double)1.0;
 
-    float pf = seconds * SECOND_SCALER; // exact when ps == 0xFFFF
+// do this multiplication in *double* precision bc seconds could be very small (uS), and SCALER is very big (3500)
+    float pf = (double)seconds * SECOND_SCALER; // exact when ps == 0xFFFF
     uint16_t ps = 0xFFFF; // longest possible
     while( pf < (float)(0x7FFF) ){ // decrement prescaler to maximize accuracy
         ps >>= 1; // half the prescaler


### PR DESCRIPTION
Refines the timings of the ADC driver for more accurate readings and linearity across the voltage range.

The improvement is minor, but it's certainly *better*, and the big thing here is i added a bunch of documentation explaining some of the choices.

Initially I was trying to understand why there was a weird delay required in the ADC driver, so used the logic analyzer to understand what was going on. There was a bunch of weirdness (eg wrong transmission sizes), but the core problem is that the ADC is consistently raising a `!DRDY` error which resets the internal smoothing filter, meaning every sample was being filtered from scratch (rather than a running overage). I spent a solid 5 hours trying to reconfigure the clocking setup to solve this problem, but in the end had to admit defeat.

Basically I think it requires changing either the hardware pin assignments (to use the I2S interface), or some deeper architectural changes that allows the sampling clock (a PWM channel on the stm32) to be phase-locked with the DAC's MCLK (runs on I2S PLL at 48kHz which requires a custom PLL clock unavailable to the PWM channels).

//

Realistically we can add a moving average in the DSP realm if the values are not consistent enough. Even 3 samples would be plenty, and still allow 500Hz rates.