### PR TITLE
Scales can be dynamically set

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -272,6 +272,13 @@ static int _get_state( lua_State *L )
 }
 static int _set_scale( lua_State *L )
 {
+    // statically save the mod & scaling options
+    // if omitting mod & scaling, they use the most recent value of mod/scaling
+    // if no value ever provided, the initial values act as defaults
+    // NB: shared between outputs. if you need separate mod/scale, must be explicit
+    static float mod = 12.0; // default to 12TET
+    static float scaling = 1.0; // default to v/8
+
     int nargs = lua_gettop(L);
     // first arg is index!
 
@@ -305,13 +312,11 @@ static int _set_scale( lua_State *L )
         lua_pop( L, 1 );                     // remove our introspected value
     }
 
-    float mod = 12.0; // default to 12TET
     if( nargs >= 3 ){
         // TODO allow string = 'just' to select JI mode for note list
         mod = luaL_checknumber( L, 3 );
     }
 
-    float scaling = 1.0; // default to v/8
     if( nargs >= 4 ){
         scaling = luaL_checknumber( L, 4 );
     }

--- a/lua/output.lua
+++ b/lua/output.lua
@@ -33,6 +33,8 @@ Output.__newindex = function(self, ix, val)
         self.asl:action()
     elseif ix == 'done' then
         self.asl.done = val
+    elseif ix == 'scale' then
+        set_output_scale(self.channel, val)
     end
 end
 


### PR DESCRIPTION
Previously to update the output.scale setting, you would have to call the function with the full description.

Now you can just set the scale member in the output table and it will update the C layer in the background, preserving any other manipulations (like scaling & mod size).

```
output[1].scale({0,4,7,11,14,17,21},1.0,24) -- setup a 2-octave fully extended major arpeggio
output[1].scale = {0,2,4,7,9,21} -- change the scale, but maintain over settings
```