### PR TITLE
fix bug where aliasing an ii address before use could stack overflow

### DIFF
--- a/util/ii_lua_help.lua
+++ b/util/ii_lua_help.lua
@@ -37,9 +37,10 @@ end
 
 function Is.openlib( self )
     local n = self.name
-    ii[n] = dofile(string.format('build/ii_%s.lua',n))
-    ii[n].help = self.help
-    self = ii[n] -- redirect the whole table (to handle extant aliases)
+    if not rawget(ii, n) then -- confirm it hasnn't been loaded (handles pre-openlib aliases)
+        ii[n] = dofile(string.format('build/ii_%s.lua',n))
+        ii[n].help = self.help
+    end
     return ii[n]
 end
 

--- a/util/ii_lua_help.lua
+++ b/util/ii_lua_help.lua
@@ -39,6 +39,7 @@ function Is.openlib( self )
     local n = self.name
     ii[n] = dofile(string.format('build/ii_%s.lua',n))
     ii[n].help = self.help
+    self = ii[n] -- redirect the whole table (to handle extant aliases)
     return ii[n]
 end
 


### PR DESCRIPTION
Putting this here as I was staring at the code for an hour last night and think this could solve the problem in #341 

Testing looks something like:
```
s = ii.wsyn
for i=1,100 do
  print(i, collectgarbage'count')
  s.ramp(0)
end
```

Without this fix, the RAM should be exhausted within a few iterations. This fix should allow substantially more without crashing (and perhaps won't crash at all). I'm reasonably sure the above will crash on the current `main` but that should be tested too.

Super happy for anyone else to confirm this.

Fixes #341 