### PR TITLE
Python based bootloader support and dfureset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,8 +244,13 @@ debug:
 dfu: $(BIN)
 	sudo dfu-util -a 0 -s 0x08020000 -R -D $(BIN) -d ,0483:df11
 
+dfureset:
+	@stty -F /dev/ttyACM0 raw speed 115200
+	@echo '^^b' > /dev/ttyACM0
+	@sleep 1
+
 pydfu: $(TARGET).dfu $(BIN)
-	python3 util/pydfu.py --vid 0x0483 --pid 0xDF11 -u $<
+	@python3 util/pydfu.py --vid 0x0483 --pid 0xDF11 -u $<
 
 $(TARGET).dfu: $(BIN)
 	python3 util/dfu.py -D 0x0483:0xDF11 -b 0x08020000:$^ $@

--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,7 @@ boot:
 	cd $(BOOTLOADER) && \
 	make R=1 flash
 
-zip: $(BIN)
+zip: $(BIN) $(TARGET).dfu
 	mkdir -p $(TARGET)-$(GIT_VERSION)
 	cp util/osx_linux-update_firmware.command $(TARGET)-$(GIT_VERSION)/
 	cp util/osx_linux-erase_userscript.command $(TARGET)-$(GIT_VERSION)/
@@ -268,6 +268,7 @@ zip: $(BIN)
 	cp util/windows-erase_userscript.bat $(TARGET)-$(GIT_VERSION)/
 	cp util/blank.bin $(TARGET)-$(GIT_VERSION)/
 	cp $(BIN) $(TARGET)-$(GIT_VERSION)/
+	cp $(TARGET).dfu $(TARGET)-$(GIT_VERSION)/
 	zip -r $(TARGET)-$(GIT_VERSION).zip $(TARGET)-$(GIT_VERSION)/
 
 %.o: %.c
@@ -311,7 +312,7 @@ norns:
 .PHONY: clean
 clean:
 	@rm -rf Startup.lst $(TARGET).elf.lst $(OBJS) $(AUTOGEN) \
-	$(TARGET).bin  $(TARGET).out  $(TARGET).hex \
+	$(TARGET).bin  $(TARGET).out  $(TARGET).hex $(TARGET).dfu \
 	$(TARGET).map  $(TARGET).dmp  $(EXECUTABLE) $(DEP) \
 	$(BUILD_DIR) lua/*.lua.h \
 	$(TARGET)-$(GIT_VERSION)/  *.zip \

--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,8 @@ dfureset:
 	@sleep 1
 
 pydfu: $(TARGET).dfu $(BIN)
-	@python3 util/pydfu.py --vid 0x0483 --pid 0xDF11 -u $<
+	@python3 util/pydfu.py -u $<
+# 	@python3 util/pydfu.py --vid 0x0483 --pid 0xDF11 -u $<
 
 $(TARGET).dfu: $(BIN)
 	python3 util/dfu.py -D 0x0483:0xDF11 -b 0x08020000:$^ $@

--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,12 @@ debug:
 dfu: $(BIN)
 	sudo dfu-util -a 0 -s 0x08020000 -R -D $(BIN) -d ,0483:df11
 
+pydfu: $(TARGET).dfu $(BIN)
+	python3 util/pydfu.py --vid 0x0483 --pid 0xDF11 -u $<
+
+$(TARGET).dfu: $(BIN)
+	python3 util/dfu.py -D 0x0483:0xDF11 -b 0x08020000:$^ $@
+
 boot:
 	cd $(BOOTLOADER) && \
 	make R=1 flash

--- a/readme-development.md
+++ b/readme-development.md
@@ -8,7 +8,7 @@ crow development can mean many things, but if you want to write anything beyond 
 
 - [arm-none-eabi-gcc 4.9.3](https://launchpad.net/gcc-arm-embedded/4.9)
 - lua 5.2 or higher
-- dfu-util 0.8+
+- dfu-util 0.8+ OR python3 with pyusb
 
 ### Get the project
 - `git clone --recursive https://github.com/monome/crow.git`
@@ -44,10 +44,19 @@ exit.
 
 #### DFU Programmer
 
-For dfu programming over usb, replace `make` above with:
-- `make dfu`
+Before flashing with DFU, crow must be put into bootloader mode. That can be acheived with any of the following:
+* send `^^b` to crow from druid or similar
+* `make dfureset` *linux only, uses `stty`, assumes crow is on /dev/ttyACM0*
+* 'force' the bootloader by bridging i2c pins and resetting crow
+
+There are 2 options for DFU programming crow:
+
+* dfu-util: `make dfu`
+* pydfu: `make pydfu`
 
 This will build the project and then attempt to flash it over the crow USB port.
+
+`pydfu` is preferred as it has faster upload speeds, and less ambiguous error messaging.
 
 #### ST-link / Discovery board
 

--- a/util/dfu.py
+++ b/util/dfu.py
@@ -1,0 +1,163 @@
+#!/usr/bin/python
+
+# Written by Antonio Galea - 2010/11/18
+# Distributed under Gnu LGPL 3.0
+# see http://www.gnu.org/licenses/lgpl-3.0.txt
+
+import sys, struct, zlib, os
+from optparse import OptionParser
+
+DEFAULT_DEVICE = "0x0483:0xdf11"
+
+
+def named(tuple, names):
+    return dict(zip(names.split(), tuple))
+
+
+def consume(fmt, data, names):
+    n = struct.calcsize(fmt)
+    return named(struct.unpack(fmt, data[:n]), names), data[n:]
+
+
+def cstring(string):
+    return string.split("\0", 1)[0]
+
+
+def compute_crc(data):
+    return 0xFFFFFFFF & -zlib.crc32(data) - 1
+
+
+def parse(file, dump_images=False):
+    print('File: "%s"' % file)
+    data = open(file, "rb").read()
+    crc = compute_crc(data[:-4])
+    prefix, data = consume("<5sBIB", data, "signature version size targets")
+    print("%(signature)s v%(version)d, image size: %(size)d, targets: %(targets)d" % prefix)
+    for t in range(prefix["targets"]):
+        tprefix, data = consume(
+            "<6sBI255s2I", data, "signature altsetting named name size elements"
+        )
+        tprefix["num"] = t
+        if tprefix["named"]:
+            tprefix["name"] = cstring(tprefix["name"])
+        else:
+            tprefix["name"] = ""
+        print(
+            '%(signature)s %(num)d, alt setting: %(altsetting)s, name: "%(name)s", size: %(size)d, elements: %(elements)d'
+            % tprefix
+        )
+        tsize = tprefix["size"]
+        target, data = data[:tsize], data[tsize:]
+        for e in range(tprefix["elements"]):
+            eprefix, target = consume("<2I", target, "address size")
+            eprefix["num"] = e
+            print("  %(num)d, address: 0x%(address)08x, size: %(size)d" % eprefix)
+            esize = eprefix["size"]
+            image, target = target[:esize], target[esize:]
+            if dump_images:
+                out = "%s.target%d.image%d.bin" % (file, t, e)
+                open(out, "wb").write(image)
+                print('    DUMPED IMAGE TO "%s"' % out)
+        if len(target):
+            print("target %d: PARSE ERROR" % t)
+    suffix = named(struct.unpack("<4H3sBI", data[:16]), "device product vendor dfu ufd len crc")
+    print(
+        "usb: %(vendor)04x:%(product)04x, device: 0x%(device)04x, dfu: 0x%(dfu)04x, %(ufd)s, %(len)d, 0x%(crc)08x"
+        % suffix
+    )
+    if crc != suffix["crc"]:
+        print("CRC ERROR: computed crc32 is 0x%08x" % crc)
+    data = data[16:]
+    if data:
+        print("PARSE ERROR")
+
+
+def build(file, targets, device=DEFAULT_DEVICE):
+    data = b""
+    for t, target in enumerate(targets):
+        tdata = b""
+        for image in target:
+            # pad image to 8 bytes (needed at least for L476)
+            pad = (8 - len(image["data"]) % 8) % 8
+            image["data"] = image["data"] + bytes(bytearray(8)[0:pad])
+            #
+            tdata += struct.pack("<2I", image["address"], len(image["data"])) + image["data"]
+        tdata = (
+            struct.pack("<6sBI255s2I", b"Target", 0, 1, b"ST...", len(tdata), len(target)) + tdata
+        )
+        data += tdata
+    data = struct.pack("<5sBIB", b"DfuSe", 1, len(data) + 11, len(targets)) + data
+    v, d = map(lambda x: int(x, 0) & 0xFFFF, device.split(":", 1))
+    data += struct.pack("<4H3sB", 0, d, v, 0x011A, b"UFD", 16)
+    crc = compute_crc(data)
+    data += struct.pack("<I", crc)
+    open(file, "wb").write(data)
+
+
+if __name__ == "__main__":
+    usage = """
+%prog [-d|--dump] infile.dfu
+%prog {-b|--build} address:file.bin [-b address:file.bin ...] [{-D|--device}=vendor:device] outfile.dfu"""
+    parser = OptionParser(usage=usage)
+    parser.add_option(
+        "-b",
+        "--build",
+        action="append",
+        dest="binfiles",
+        help="build a DFU file from given BINFILES",
+        metavar="BINFILES",
+    )
+    parser.add_option(
+        "-D",
+        "--device",
+        action="store",
+        dest="device",
+        help="build for DEVICE, defaults to %s" % DEFAULT_DEVICE,
+        metavar="DEVICE",
+    )
+    parser.add_option(
+        "-d",
+        "--dump",
+        action="store_true",
+        dest="dump_images",
+        default=False,
+        help="dump contained images to current directory",
+    )
+    (options, args) = parser.parse_args()
+
+    if options.binfiles and len(args) == 1:
+        target = []
+        for arg in options.binfiles:
+            try:
+                address, binfile = arg.split(":", 1)
+            except ValueError:
+                print("Address:file couple '%s' invalid." % arg)
+                sys.exit(1)
+            try:
+                address = int(address, 0) & 0xFFFFFFFF
+            except ValueError:
+                print("Address %s invalid." % address)
+                sys.exit(1)
+            if not os.path.isfile(binfile):
+                print("Unreadable file '%s'." % binfile)
+                sys.exit(1)
+            target.append({"address": address, "data": open(binfile, "rb").read()})
+        outfile = args[0]
+        device = DEFAULT_DEVICE
+        if options.device:
+            device = options.device
+        try:
+            v, d = map(lambda x: int(x, 0) & 0xFFFF, device.split(":", 1))
+        except:
+            print("Invalid device '%s'." % device)
+            sys.exit(1)
+        build(outfile, [target], device)
+    elif len(args) == 1:
+        infile = args[0]
+        if not os.path.isfile(infile):
+            print("Unreadable file '%s'." % infile)
+            sys.exit(1)
+        parse(infile, dump_images=options.dump_images)
+    else:
+        parser.print_help()
+        sys.exit(1)

--- a/util/pydfu.py
+++ b/util/pydfu.py
@@ -1,0 +1,630 @@
+#!/usr/bin/env python
+# This file is part of the OpenMV project.
+# Copyright (c) 2013/2014 Ibrahim Abdelkader <i.abdalkader@gmail.com>
+# This work is licensed under the MIT license, see the file LICENSE for
+# details.
+
+"""This module implements enough functionality to program the STM32F4xx over
+DFU, without requiring dfu-util.
+
+See app note AN3156 for a description of the DFU protocol.
+See document UM0391 for a dscription of the DFuse file.
+"""
+
+from __future__ import print_function
+
+import argparse
+import collections
+import inspect
+import re
+import struct
+import sys
+import usb.core
+import usb.util
+import zlib
+
+# VID/PID
+__VID = 0x0483
+__PID = 0xDF11
+
+# USB request __TIMEOUT
+__TIMEOUT = 4000
+
+# DFU commands
+__DFU_DETACH = 0
+__DFU_DNLOAD = 1
+__DFU_UPLOAD = 2
+__DFU_GETSTATUS = 3
+__DFU_CLRSTATUS = 4
+__DFU_GETSTATE = 5
+__DFU_ABORT = 6
+
+# DFU status
+__DFU_STATE_APP_IDLE = 0x00
+__DFU_STATE_APP_DETACH = 0x01
+__DFU_STATE_DFU_IDLE = 0x02
+__DFU_STATE_DFU_DOWNLOAD_SYNC = 0x03
+__DFU_STATE_DFU_DOWNLOAD_BUSY = 0x04
+__DFU_STATE_DFU_DOWNLOAD_IDLE = 0x05
+__DFU_STATE_DFU_MANIFEST_SYNC = 0x06
+__DFU_STATE_DFU_MANIFEST = 0x07
+__DFU_STATE_DFU_MANIFEST_WAIT_RESET = 0x08
+__DFU_STATE_DFU_UPLOAD_IDLE = 0x09
+__DFU_STATE_DFU_ERROR = 0x0A
+
+_DFU_DESCRIPTOR_TYPE = 0x21
+
+__DFU_STATUS_STR = {
+    __DFU_STATE_APP_IDLE: "STATE_APP_IDLE",
+    __DFU_STATE_APP_DETACH: "STATE_APP_DETACH",
+    __DFU_STATE_DFU_IDLE: "STATE_DFU_IDLE",
+    __DFU_STATE_DFU_DOWNLOAD_SYNC: "STATE_DFU_DOWNLOAD_SYNC",
+    __DFU_STATE_DFU_DOWNLOAD_BUSY: "STATE_DFU_DOWNLOAD_BUSY",
+    __DFU_STATE_DFU_DOWNLOAD_IDLE: "STATE_DFU_DOWNLOAD_IDLE",
+    __DFU_STATE_DFU_MANIFEST_SYNC: "STATE_DFU_MANIFEST_SYNC",
+    __DFU_STATE_DFU_MANIFEST: "STATE_DFU_MANIFEST",
+    __DFU_STATE_DFU_MANIFEST_WAIT_RESET: "STATE_DFU_MANIFEST_WAIT_RESET",
+    __DFU_STATE_DFU_UPLOAD_IDLE: "STATE_DFU_UPLOAD_IDLE",
+    __DFU_STATE_DFU_ERROR: "STATE_DFU_ERROR",
+}
+
+# USB device handle
+__dev = None
+
+# Configuration descriptor of the device
+__cfg_descr = None
+
+__verbose = None
+
+# USB DFU interface
+__DFU_INTERFACE = 0
+
+# Python 3 deprecated getargspec in favour of getfullargspec, but
+# Python 2 doesn't have the latter, so detect which one to use
+getargspec = getattr(inspect, "getfullargspec", inspect.getargspec)
+
+if "length" in getargspec(usb.util.get_string).args:
+    # PyUSB 1.0.0.b1 has the length argument
+    def get_string(dev, index):
+        return usb.util.get_string(dev, 255, index)
+
+
+else:
+    # PyUSB 1.0.0.b2 dropped the length argument
+    def get_string(dev, index):
+        return usb.util.get_string(dev, index)
+
+
+def find_dfu_cfg_descr(descr):
+    if len(descr) == 9 and descr[0] == 9 and descr[1] == _DFU_DESCRIPTOR_TYPE:
+        nt = collections.namedtuple(
+            "CfgDescr",
+            [
+                "bLength",
+                "bDescriptorType",
+                "bmAttributes",
+                "wDetachTimeOut",
+                "wTransferSize",
+                "bcdDFUVersion",
+            ],
+        )
+        return nt(*struct.unpack("<BBBHHH", bytearray(descr)))
+    return None
+
+
+def init():
+    """Initializes the found DFU device so that we can program it."""
+    global __dev, __cfg_descr
+    devices = get_dfu_devices(idVendor=__VID, idProduct=__PID)
+    if not devices:
+        raise ValueError("No DFU device found")
+    if len(devices) > 1:
+        raise ValueError("Multiple DFU devices found")
+    __dev = devices[0]
+    __dev.set_configuration()
+
+    # Claim DFU interface
+    usb.util.claim_interface(__dev, __DFU_INTERFACE)
+
+    # Find the DFU configuration descriptor, either in the device or interfaces
+    __cfg_descr = None
+    for cfg in __dev.configurations():
+        __cfg_descr = find_dfu_cfg_descr(cfg.extra_descriptors)
+        if __cfg_descr:
+            break
+        for itf in cfg.interfaces():
+            __cfg_descr = find_dfu_cfg_descr(itf.extra_descriptors)
+            if __cfg_descr:
+                break
+
+    # Get device into idle state
+    for attempt in range(4):
+        status = get_status()
+        if status == __DFU_STATE_DFU_IDLE:
+            break
+        elif status == __DFU_STATE_DFU_DOWNLOAD_IDLE or status == __DFU_STATE_DFU_UPLOAD_IDLE:
+            abort_request()
+        else:
+            clr_status()
+
+
+def abort_request():
+    """Sends an abort request."""
+    __dev.ctrl_transfer(0x21, __DFU_ABORT, 0, __DFU_INTERFACE, None, __TIMEOUT)
+
+
+def clr_status():
+    """Clears any error status (perhaps left over from a previous session)."""
+    __dev.ctrl_transfer(0x21, __DFU_CLRSTATUS, 0, __DFU_INTERFACE, None, __TIMEOUT)
+
+
+def get_status():
+    """Get the status of the last operation."""
+    stat = __dev.ctrl_transfer(0xA1, __DFU_GETSTATUS, 0, __DFU_INTERFACE, 6, 20000)
+
+    # firmware can provide an optional string for any error
+    if stat[5]:
+        message = get_string(__dev, stat[5])
+        if message:
+            print(message)
+
+    return stat[4]
+
+
+def check_status(stage, expected):
+    status = get_status()
+    if status != expected:
+        raise SystemExit("DFU: %s failed (%s)" % (stage, __DFU_STATUS_STR.get(status, status)))
+
+
+def mass_erase():
+    """Performs a MASS erase (i.e. erases the entire device)."""
+    # Send DNLOAD with first byte=0x41
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, "\x41", __TIMEOUT)
+
+    # Execute last command
+    check_status("erase", __DFU_STATE_DFU_DOWNLOAD_BUSY)
+
+    # Check command state
+    check_status("erase", __DFU_STATE_DFU_DOWNLOAD_IDLE)
+
+
+def page_erase(addr):
+    """Erases a single page."""
+    if __verbose:
+        print("Erasing page: 0x%x..." % (addr))
+
+    # Send DNLOAD with first byte=0x41 and page address
+    buf = struct.pack("<BI", 0x41, addr)
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, buf, __TIMEOUT)
+
+    # Execute last command
+    check_status("erase", __DFU_STATE_DFU_DOWNLOAD_BUSY)
+
+    # Check command state
+    check_status("erase", __DFU_STATE_DFU_DOWNLOAD_IDLE)
+
+
+def set_address(addr):
+    """Sets the address for the next operation."""
+    # Send DNLOAD with first byte=0x21 and page address
+    buf = struct.pack("<BI", 0x21, addr)
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, buf, __TIMEOUT)
+
+    # Execute last command
+    check_status("set address", __DFU_STATE_DFU_DOWNLOAD_BUSY)
+
+    # Check command state
+    check_status("set address", __DFU_STATE_DFU_DOWNLOAD_IDLE)
+
+
+def write_memory(addr, buf, progress=None, progress_addr=0, progress_size=0):
+    """Writes a buffer into memory. This routine assumes that memory has
+    already been erased.
+    """
+
+    xfer_count = 0
+    xfer_bytes = 0
+    xfer_total = len(buf)
+    xfer_base = addr
+
+    while xfer_bytes < xfer_total:
+        if __verbose and xfer_count % 512 == 0:
+            print(
+                "Addr 0x%x %dKBs/%dKBs..."
+                % (xfer_base + xfer_bytes, xfer_bytes // 1024, xfer_total // 1024)
+            )
+        if progress and xfer_count % 2 == 0:
+            progress(progress_addr, xfer_base + xfer_bytes - progress_addr, progress_size)
+
+        # Set mem write address
+        set_address(xfer_base + xfer_bytes)
+
+        # Send DNLOAD with fw data
+        chunk = min(__cfg_descr.wTransferSize, xfer_total - xfer_bytes)
+        __dev.ctrl_transfer(
+            0x21, __DFU_DNLOAD, 2, __DFU_INTERFACE, buf[xfer_bytes : xfer_bytes + chunk], __TIMEOUT
+        )
+
+        # Execute last command
+        check_status("write memory", __DFU_STATE_DFU_DOWNLOAD_BUSY)
+
+        # Check command state
+        check_status("write memory", __DFU_STATE_DFU_DOWNLOAD_IDLE)
+
+        xfer_count += 1
+        xfer_bytes += chunk
+
+
+def write_page(buf, xfer_offset):
+    """Writes a single page. This routine assumes that memory has already
+    been erased.
+    """
+
+    xfer_base = 0x08000000
+
+    # Set mem write address
+    set_address(xfer_base + xfer_offset)
+
+    # Send DNLOAD with fw data
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 2, __DFU_INTERFACE, buf, __TIMEOUT)
+
+    # Execute last command
+    check_status("write memory", __DFU_STATE_DFU_DOWNLOAD_BUSY)
+
+    # Check command state
+    check_status("write memory", __DFU_STATE_DFU_DOWNLOAD_IDLE)
+
+    if __verbose:
+        print("Write: 0x%x " % (xfer_base + xfer_offset))
+
+
+def exit_dfu():
+    """Exit DFU mode, and start running the program."""
+    # Set jump address
+    set_address(0x08000000)
+
+    # Send DNLOAD with 0 length to exit DFU
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, None, __TIMEOUT)
+
+    try:
+        # Execute last command
+        if get_status() != __DFU_STATE_DFU_MANIFEST:
+            print("Failed to reset device")
+
+        # Release device
+        usb.util.dispose_resources(__dev)
+    except:
+        pass
+
+
+def named(values, names):
+    """Creates a dict with `names` as fields, and `values` as values."""
+    return dict(zip(names.split(), values))
+
+
+def consume(fmt, data, names):
+    """Parses the struct defined by `fmt` from `data`, stores the parsed fields
+    into a named tuple using `names`. Returns the named tuple, and the data
+    with the struct stripped off."""
+
+    size = struct.calcsize(fmt)
+    return named(struct.unpack(fmt, data[:size]), names), data[size:]
+
+
+def cstring(string):
+    """Extracts a null-terminated string from a byte array."""
+    return string.decode("utf-8").split("\0", 1)[0]
+
+
+def compute_crc(data):
+    """Computes the CRC32 value for the data passed in."""
+    return 0xFFFFFFFF & -zlib.crc32(data) - 1
+
+
+def read_dfu_file(filename):
+    """Reads a DFU file, and parses the individual elements from the file.
+    Returns an array of elements. Each element is a dictionary with the
+    following keys:
+        num     - The element index.
+        address - The address that the element data should be written to.
+        size    - The size of the element data.
+        data    - The element data.
+    If an error occurs while parsing the file, then None is returned.
+    """
+
+    print("File: {}".format(filename))
+    with open(filename, "rb") as fin:
+        data = fin.read()
+    crc = compute_crc(data[:-4])
+    elements = []
+
+    # Decode the DFU Prefix
+    #
+    # <5sBIB
+    #   <   little endian           Endianness
+    #   5s  char[5]     signature   "DfuSe"
+    #   B   uint8_t     version     1
+    #   I   uint32_t    size        Size of the DFU file (without suffix)
+    #   B   uint8_t     targets     Number of targets
+    dfu_prefix, data = consume("<5sBIB", data, "signature version size targets")
+    print(
+        "    %(signature)s v%(version)d, image size: %(size)d, "
+        "targets: %(targets)d" % dfu_prefix
+    )
+    for target_idx in range(dfu_prefix["targets"]):
+        # Decode the Image Prefix
+        #
+        # <6sBI255s2I
+        #   <       little endian           Endianness
+        #   6s      char[6]     signature   "Target"
+        #   B       uint8_t     altsetting
+        #   I       uint32_t    named       Bool indicating if a name was used
+        #   255s    char[255]   name        Name of the target
+        #   I       uint32_t    size        Size of image (without prefix)
+        #   I       uint32_t    elements    Number of elements in the image
+        img_prefix, data = consume(
+            "<6sBI255s2I", data, "signature altsetting named name " "size elements"
+        )
+        img_prefix["num"] = target_idx
+        if img_prefix["named"]:
+            img_prefix["name"] = cstring(img_prefix["name"])
+        else:
+            img_prefix["name"] = ""
+        print(
+            "    %(signature)s %(num)d, alt setting: %(altsetting)s, "
+            'name: "%(name)s", size: %(size)d, elements: %(elements)d' % img_prefix
+        )
+
+        target_size = img_prefix["size"]
+        target_data = data[:target_size]
+        data = data[target_size:]
+        for elem_idx in range(img_prefix["elements"]):
+            # Decode target prefix
+            #
+            # <2I
+            #   <   little endian           Endianness
+            #   I   uint32_t    element     Address
+            #   I   uint32_t    element     Size
+            elem_prefix, target_data = consume("<2I", target_data, "addr size")
+            elem_prefix["num"] = elem_idx
+            print("      %(num)d, address: 0x%(addr)08x, size: %(size)d" % elem_prefix)
+            elem_size = elem_prefix["size"]
+            elem_data = target_data[:elem_size]
+            target_data = target_data[elem_size:]
+            elem_prefix["data"] = elem_data
+            elements.append(elem_prefix)
+
+        if len(target_data):
+            print("target %d PARSE ERROR" % target_idx)
+
+    # Decode DFU Suffix
+    #
+    # <4H3sBI
+    #   <   little endian           Endianness
+    #   H   uint16_t    device      Firmware version
+    #   H   uint16_t    product
+    #   H   uint16_t    vendor
+    #   H   uint16_t    dfu         0x11a   (DFU file format version)
+    #   3s  char[3]     ufd         "UFD"
+    #   B   uint8_t     len         16
+    #   I   uint32_t    crc32       Checksum
+    dfu_suffix = named(
+        struct.unpack("<4H3sBI", data[:16]), "device product vendor dfu ufd len crc"
+    )
+    print(
+        "    usb: %(vendor)04x:%(product)04x, device: 0x%(device)04x, "
+        "dfu: 0x%(dfu)04x, %(ufd)s, %(len)d, 0x%(crc)08x" % dfu_suffix
+    )
+    if crc != dfu_suffix["crc"]:
+        print("CRC ERROR: computed crc32 is 0x%08x" % crc)
+        return
+    data = data[16:]
+    if data:
+        print("PARSE ERROR")
+        return
+
+    return elements
+
+
+class FilterDFU(object):
+    """Class for filtering USB devices to identify devices which are in DFU
+    mode.
+    """
+
+    def __call__(self, device):
+        for cfg in device:
+            for intf in cfg:
+                return intf.bInterfaceClass == 0xFE and intf.bInterfaceSubClass == 1
+
+
+def get_dfu_devices(*args, **kwargs):
+    """Returns a list of USB devices which are currently in DFU mode.
+    Additional filters (like idProduct and idVendor) can be passed in
+    to refine the search.
+    """
+
+    # Convert to list for compatibility with newer PyUSB
+    return list(usb.core.find(*args, find_all=True, custom_match=FilterDFU(), **kwargs))
+
+
+def get_memory_layout(device):
+    """Returns an array which identifies the memory layout. Each entry
+    of the array will contain a dictionary with the following keys:
+        addr        - Address of this memory segment.
+        last_addr   - Last address contained within the memory segment.
+        size        - Size of the segment, in bytes.
+        num_pages   - Number of pages in the segment.
+        page_size   - Size of each page, in bytes.
+    """
+
+    cfg = device[0]
+    intf = cfg[(0, 0)]
+    mem_layout_str = get_string(device, intf.iInterface)
+    mem_layout = mem_layout_str.split("/")
+    result = []
+    for mem_layout_index in range(1, len(mem_layout), 2):
+        addr = int(mem_layout[mem_layout_index], 0)
+        segments = mem_layout[mem_layout_index + 1].split(",")
+        seg_re = re.compile(r"(\d+)\*(\d+)(.)(.)")
+        for segment in segments:
+            seg_match = seg_re.match(segment)
+            num_pages = int(seg_match.groups()[0], 10)
+            page_size = int(seg_match.groups()[1], 10)
+            multiplier = seg_match.groups()[2]
+            if multiplier == "K":
+                page_size *= 1024
+            if multiplier == "M":
+                page_size *= 1024 * 1024
+            size = num_pages * page_size
+            last_addr = addr + size - 1
+            result.append(
+                named(
+                    (addr, last_addr, size, num_pages, page_size),
+                    "addr last_addr size num_pages page_size",
+                )
+            )
+            addr += size
+    return result
+
+
+def list_dfu_devices(*args, **kwargs):
+    """Prints a lits of devices detected in DFU mode."""
+    devices = get_dfu_devices(*args, **kwargs)
+    if not devices:
+        raise SystemExit("No DFU capable devices found")
+    for device in devices:
+        print(
+            "Bus {} Device {:03d}: ID {:04x}:{:04x}".format(
+                device.bus, device.address, device.idVendor, device.idProduct
+            )
+        )
+        layout = get_memory_layout(device)
+        print("Memory Layout")
+        for entry in layout:
+            print(
+                "    0x{:x} {:2d} pages of {:3d}K bytes".format(
+                    entry["addr"], entry["num_pages"], entry["page_size"] // 1024
+                )
+            )
+
+
+def write_elements(elements, mass_erase_used, progress=None):
+    """Writes the indicated elements into the target memory,
+    erasing as needed.
+    """
+
+    mem_layout = get_memory_layout(__dev)
+    for elem in elements:
+        addr = elem["addr"]
+        size = elem["size"]
+        data = elem["data"]
+        elem_size = size
+        elem_addr = addr
+        if progress and elem_size:
+            progress(elem_addr, 0, elem_size)
+        while size > 0:
+            write_size = size
+            if not mass_erase_used:
+                for segment in mem_layout:
+                    if addr >= segment["addr"] and addr <= segment["last_addr"]:
+                        # We found the page containing the address we want to
+                        # write, erase it
+                        page_size = segment["page_size"]
+                        page_addr = addr & ~(page_size - 1)
+                        if addr + write_size > page_addr + page_size:
+                            write_size = page_addr + page_size - addr
+                        page_erase(page_addr)
+                        break
+            write_memory(addr, data[:write_size], progress, elem_addr, elem_size)
+            data = data[write_size:]
+            addr += write_size
+            size -= write_size
+            if progress:
+                progress(elem_addr, addr - elem_addr, elem_size)
+
+
+def cli_progress(addr, offset, size):
+    """Prints a progress report suitable for use on the command line."""
+    width = 25
+    done = offset * width // size
+    print(
+        "\r0x{:08x} {:7d} [{}{}] {:3d}% ".format(
+            addr, size, "=" * done, " " * (width - done), offset * 100 // size
+        ),
+        end="",
+    )
+    try:
+        sys.stdout.flush()
+    except OSError:
+        pass  # Ignore Windows CLI "WinError 87" on Python 3.6
+    if offset == size:
+        print("")
+
+
+def main():
+    """Test program for verifying this files functionality."""
+    global __verbose
+    global __VID
+    global __PID
+    # Parse CMD args
+    parser = argparse.ArgumentParser(description="DFU Python Util")
+    parser.add_argument(
+        "-l", "--list", help="list available DFU devices", action="store_true", default=False
+    )
+    parser.add_argument("--vid", help="USB Vendor ID", type=lambda x: int(x, 0), default=__VID)
+    parser.add_argument("--pid", help="USB Product ID", type=lambda x: int(x, 0), default=__PID)
+    parser.add_argument(
+        "-m", "--mass-erase", help="mass erase device", action="store_true", default=False
+    )
+    parser.add_argument(
+        "-u", "--upload", help="read file from DFU device", dest="path", default=False
+    )
+    parser.add_argument("-x", "--exit", help="Exit DFU", action="store_true", default=False)
+    parser.add_argument(
+        "-v", "--verbose", help="increase output verbosity", action="store_true", default=False
+    )
+    args = parser.parse_args()
+
+    __verbose = args.verbose
+
+    __VID = args.vid
+    __PID = args.pid
+
+    if args.list:
+        list_dfu_devices(idVendor=__VID, idProduct=__PID)
+        return
+
+    init()
+
+    command_run = False
+    if args.mass_erase:
+        print("Mass erase...")
+        mass_erase()
+        command_run = True
+
+    if args.path:
+        elements = read_dfu_file(args.path)
+        if not elements:
+            print("No data in dfu file")
+            return
+        print("Writing memory...")
+        write_elements(elements, args.mass_erase, progress=cli_progress)
+
+        print("Exiting DFU...")
+        exit_dfu()
+        command_run = True
+
+    if args.exit:
+        print("Exiting DFU...")
+        exit_dfu()
+        command_run = True
+
+    if command_run:
+        print("Finished")
+    else:
+        print("No command specified")
+
+
+if __name__ == "__main__":
+    main()

--- a/util/pydfu.py
+++ b/util/pydfu.py
@@ -1,192 +1,134 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # This file is part of the OpenMV project.
-# Copyright (c) 2013/2014 Ibrahim Abdelkader <i.abdalkader@gmail.com>
-# This work is licensed under the MIT license, see the file LICENSE for
-# details.
-
-"""This module implements enough functionality to program the STM32F4xx over
-DFU, without requiring dfu-util.
-
-See app note AN3156 for a description of the DFU protocol.
-See document UM0391 for a dscription of the DFuse file.
-"""
+#
+# Copyright (c) 2013-2021 Ibrahim Abdelkader <iabdalkader@openmv.io>
+# Copyright (c) 2013-2021 Kwabena W. Agyeman <kwagyeman@openmv.io>
+#
+# This work is licensed under the MIT license, see the file LICENSE for details.
+#
+# This module implements the DFU protocol for STM32 chips.
+# See app note AN3156 for a description of the DFU protocol.
+# See document UM0391 for a dscription of the DFuse file.
 
 from __future__ import print_function
 
 import argparse
-import collections
-import inspect
 import re
 import struct
 import sys
 import usb.core
 import usb.util
 import zlib
+import os
+import time
 
 # VID/PID
 __VID = 0x0483
-__PID = 0xDF11
+__PID = 0xdf11
 
 # USB request __TIMEOUT
-__TIMEOUT = 4000
+__TIMEOUT = 5000
 
 # DFU commands
-__DFU_DETACH = 0
-__DFU_DNLOAD = 1
-__DFU_UPLOAD = 2
+__DFU_DETACH    = 0
+__DFU_DNLOAD    = 1
+__DFU_UPLOAD    = 2
 __DFU_GETSTATUS = 3
 __DFU_CLRSTATUS = 4
-__DFU_GETSTATE = 5
-__DFU_ABORT = 6
+__DFU_GETSTATE  = 5
+__DFU_ABORT     = 6
 
 # DFU status
-__DFU_STATE_APP_IDLE = 0x00
-__DFU_STATE_APP_DETACH = 0x01
-__DFU_STATE_DFU_IDLE = 0x02
-__DFU_STATE_DFU_DOWNLOAD_SYNC = 0x03
-__DFU_STATE_DFU_DOWNLOAD_BUSY = 0x04
-__DFU_STATE_DFU_DOWNLOAD_IDLE = 0x05
-__DFU_STATE_DFU_MANIFEST_SYNC = 0x06
-__DFU_STATE_DFU_MANIFEST = 0x07
-__DFU_STATE_DFU_MANIFEST_WAIT_RESET = 0x08
-__DFU_STATE_DFU_UPLOAD_IDLE = 0x09
-__DFU_STATE_DFU_ERROR = 0x0A
+__DFU_STATE_APP_IDLE                 = 0x00
+__DFU_STATE_APP_DETACH               = 0x01
+__DFU_STATE_DFU_IDLE                 = 0x02
+__DFU_STATE_DFU_DOWNLOAD_SYNC        = 0x03
+__DFU_STATE_DFU_DOWNLOAD_BUSY        = 0x04
+__DFU_STATE_DFU_DOWNLOAD_IDLE        = 0x05
+__DFU_STATE_DFU_MANIFEST_SYNC        = 0x06
+__DFU_STATE_DFU_MANIFEST             = 0x07
+__DFU_STATE_DFU_MANIFEST_WAIT_RESET  = 0x08
+__DFU_STATE_DFU_UPLOAD_IDLE          = 0x09
+__DFU_STATE_DFU_ERROR                = 0x0a
 
-_DFU_DESCRIPTOR_TYPE = 0x21
+__DFU_STATUS = [
+    "DFU_STATE_APP_IDLE",
+    "DFU_STATE_APP_DETACH",
+    "DFU_STATE_DFU_IDLE",
+    "DFU_STATE_DFU_DOWNLOAD_SYNC",
+    "DFU_STATE_DFU_DOWNLOAD_BUSY",
+    "DFU_STATE_DFU_DOWNLOAD_IDLE",
+    "DFU_STATE_DFU_MANIFEST_SYNC",
+    "DFU_STATE_DFU_MANIFEST",
+    "DFU_STATE_DFU_MANIFEST_WAIT_RESET",
+    "DFU_STATE_DFU_UPLOAD_IDLE",
+    "DFU_STATE_DFU_ERROR"
+]
 
-__DFU_STATUS_STR = {
-    __DFU_STATE_APP_IDLE: "STATE_APP_IDLE",
-    __DFU_STATE_APP_DETACH: "STATE_APP_DETACH",
-    __DFU_STATE_DFU_IDLE: "STATE_DFU_IDLE",
-    __DFU_STATE_DFU_DOWNLOAD_SYNC: "STATE_DFU_DOWNLOAD_SYNC",
-    __DFU_STATE_DFU_DOWNLOAD_BUSY: "STATE_DFU_DOWNLOAD_BUSY",
-    __DFU_STATE_DFU_DOWNLOAD_IDLE: "STATE_DFU_DOWNLOAD_IDLE",
-    __DFU_STATE_DFU_MANIFEST_SYNC: "STATE_DFU_MANIFEST_SYNC",
-    __DFU_STATE_DFU_MANIFEST: "STATE_DFU_MANIFEST",
-    __DFU_STATE_DFU_MANIFEST_WAIT_RESET: "STATE_DFU_MANIFEST_WAIT_RESET",
-    __DFU_STATE_DFU_UPLOAD_IDLE: "STATE_DFU_UPLOAD_IDLE",
-    __DFU_STATE_DFU_ERROR: "STATE_DFU_ERROR",
-}
+_DFU_DESCRIPTOR_TYPE                 = 0x21
 
 # USB device handle
 __dev = None
-
-# Configuration descriptor of the device
-__cfg_descr = None
 
 __verbose = None
 
 # USB DFU interface
 __DFU_INTERFACE = 0
 
-# Python 3 deprecated getargspec in favour of getfullargspec, but
-# Python 2 doesn't have the latter, so detect which one to use
-getargspec = getattr(inspect, "getfullargspec", inspect.getargspec)
-
-if "length" in getargspec(usb.util.get_string).args:
+import inspect
+if 'length' in inspect.getargspec(usb.util.get_string).args:
     # PyUSB 1.0.0.b1 has the length argument
     def get_string(dev, index):
         return usb.util.get_string(dev, 255, index)
-
-
 else:
     # PyUSB 1.0.0.b2 dropped the length argument
     def get_string(dev, index):
         return usb.util.get_string(dev, index)
 
 
-def find_dfu_cfg_descr(descr):
-    if len(descr) == 9 and descr[0] == 9 and descr[1] == _DFU_DESCRIPTOR_TYPE:
-        nt = collections.namedtuple(
-            "CfgDescr",
-            [
-                "bLength",
-                "bDescriptorType",
-                "bmAttributes",
-                "wDetachTimeOut",
-                "wTransferSize",
-                "bcdDFUVersion",
-            ],
-        )
-        return nt(*struct.unpack("<BBBHHH", bytearray(descr)))
-    return None
-
-
 def init():
     """Initializes the found DFU device so that we can program it."""
-    global __dev, __cfg_descr
+    global __dev
     devices = get_dfu_devices(idVendor=__VID, idProduct=__PID)
     if not devices:
-        raise ValueError("No DFU device found")
+        raise ValueError('No DFU device found')
     if len(devices) > 1:
         raise ValueError("Multiple DFU devices found")
     __dev = devices[0]
-    __dev.set_configuration()
 
     # Claim DFU interface
     usb.util.claim_interface(__dev, __DFU_INTERFACE)
 
-    # Find the DFU configuration descriptor, either in the device or interfaces
-    __cfg_descr = None
-    for cfg in __dev.configurations():
-        __cfg_descr = find_dfu_cfg_descr(cfg.extra_descriptors)
-        if __cfg_descr:
-            break
-        for itf in cfg.interfaces():
-            __cfg_descr = find_dfu_cfg_descr(itf.extra_descriptors)
-            if __cfg_descr:
-                break
-
-    # Get device into idle state
-    for attempt in range(4):
-        status = get_status()
-        if status == __DFU_STATE_DFU_IDLE:
-            break
-        elif status == __DFU_STATE_DFU_DOWNLOAD_IDLE or status == __DFU_STATE_DFU_UPLOAD_IDLE:
-            abort_request()
-        else:
-            clr_status()
-
-
-def abort_request():
-    """Sends an abort request."""
-    __dev.ctrl_transfer(0x21, __DFU_ABORT, 0, __DFU_INTERFACE, None, __TIMEOUT)
-
+    # Clear status
+    clr_status()
 
 def clr_status():
     """Clears any error status (perhaps left over from a previous session)."""
-    __dev.ctrl_transfer(0x21, __DFU_CLRSTATUS, 0, __DFU_INTERFACE, None, __TIMEOUT)
+    while (get_status() != __DFU_STATE_DFU_IDLE):
+        __dev.ctrl_transfer(0x21, __DFU_CLRSTATUS, 0, __DFU_INTERFACE, None, __TIMEOUT)
+        time.sleep(0.100)
 
 
 def get_status():
     """Get the status of the last operation."""
     stat = __dev.ctrl_transfer(0xA1, __DFU_GETSTATUS, 0, __DFU_INTERFACE, 6, 20000)
-
-    # firmware can provide an optional string for any error
-    if stat[5]:
-        message = get_string(__dev, stat[5])
-        if message:
-            print(message)
-
+    #print ("DFU Status: ", __DFU_STATUS[stat[4]])
     return stat[4]
 
 
-def check_status(stage, expected):
-    status = get_status()
-    if status != expected:
-        raise SystemExit("DFU: %s failed (%s)" % (stage, __DFU_STATUS_STR.get(status, status)))
-
-
 def mass_erase():
-    """Performs a MASS erase (i.e. erases the entire device)."""
+    """Performs a MASS erase (i.e. erases the entire device."""
     # Send DNLOAD with first byte=0x41
-    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, "\x41", __TIMEOUT)
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE,
+                        "\x41", __TIMEOUT)
 
     # Execute last command
-    check_status("erase", __DFU_STATE_DFU_DOWNLOAD_BUSY)
+    if get_status() != __DFU_STATE_DFU_DOWNLOAD_BUSY:
+        raise Exception("DFU: erase failed")
 
     # Check command state
-    check_status("erase", __DFU_STATE_DFU_DOWNLOAD_IDLE)
+    if get_status() != __DFU_STATE_DFU_DOWNLOAD_IDLE:
+        raise Exception("DFU: erase failed")
 
 
 def page_erase(addr):
@@ -199,10 +141,13 @@ def page_erase(addr):
     __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, buf, __TIMEOUT)
 
     # Execute last command
-    check_status("erase", __DFU_STATE_DFU_DOWNLOAD_BUSY)
+    if get_status() != __DFU_STATE_DFU_DOWNLOAD_BUSY:
+        raise Exception("DFU: erase failed")
 
     # Check command state
-    check_status("erase", __DFU_STATE_DFU_DOWNLOAD_IDLE)
+    if get_status() != __DFU_STATE_DFU_DOWNLOAD_IDLE:
+
+        raise Exception("DFU: erase failed")
 
 
 def set_address(addr):
@@ -212,10 +157,12 @@ def set_address(addr):
     __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, buf, __TIMEOUT)
 
     # Execute last command
-    check_status("set address", __DFU_STATE_DFU_DOWNLOAD_BUSY)
+    if get_status() != __DFU_STATE_DFU_DOWNLOAD_BUSY:
+        raise Exception("DFU: set address failed")
 
     # Check command state
-    check_status("set address", __DFU_STATE_DFU_DOWNLOAD_IDLE)
+    if get_status() != __DFU_STATE_DFU_DOWNLOAD_IDLE:
+        raise Exception("DFU: set address failed")
 
 
 def write_memory(addr, buf, progress=None, progress_addr=0, progress_size=0):
@@ -230,27 +177,28 @@ def write_memory(addr, buf, progress=None, progress_addr=0, progress_size=0):
 
     while xfer_bytes < xfer_total:
         if __verbose and xfer_count % 512 == 0:
-            print(
-                "Addr 0x%x %dKBs/%dKBs..."
-                % (xfer_base + xfer_bytes, xfer_bytes // 1024, xfer_total // 1024)
-            )
-        if progress and xfer_count % 2 == 0:
-            progress(progress_addr, xfer_base + xfer_bytes - progress_addr, progress_size)
+            print ("Addr 0x%x %dKBs/%dKBs..." % (xfer_base + xfer_bytes,
+                                                 xfer_bytes // 1024,
+                                                 xfer_total // 1024))
+        if progress and xfer_count % 256 == 0:
+            progress(progress_addr, xfer_base + xfer_bytes - progress_addr,
+                     progress_size)
 
         # Set mem write address
-        set_address(xfer_base + xfer_bytes)
+        set_address(xfer_base+xfer_bytes)
 
         # Send DNLOAD with fw data
-        chunk = min(__cfg_descr.wTransferSize, xfer_total - xfer_bytes)
-        __dev.ctrl_transfer(
-            0x21, __DFU_DNLOAD, 2, __DFU_INTERFACE, buf[xfer_bytes : xfer_bytes + chunk], __TIMEOUT
-        )
+        chunk = min(64, xfer_total-xfer_bytes)
+        __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 2, __DFU_INTERFACE,
+                            buf[xfer_bytes:xfer_bytes + chunk], __TIMEOUT)
 
         # Execute last command
-        check_status("write memory", __DFU_STATE_DFU_DOWNLOAD_BUSY)
+        if get_status() != __DFU_STATE_DFU_DOWNLOAD_BUSY:
+            raise Exception("DFU: write memory failed")
 
         # Check command state
-        check_status("write memory", __DFU_STATE_DFU_DOWNLOAD_IDLE)
+        if get_status() != __DFU_STATE_DFU_DOWNLOAD_IDLE:
+            raise Exception("DFU: write memory failed")
 
         xfer_count += 1
         xfer_bytes += chunk
@@ -264,28 +212,32 @@ def write_page(buf, xfer_offset):
     xfer_base = 0x08000000
 
     # Set mem write address
-    set_address(xfer_base + xfer_offset)
+    set_address(xfer_base+xfer_offset)
 
     # Send DNLOAD with fw data
     __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 2, __DFU_INTERFACE, buf, __TIMEOUT)
 
     # Execute last command
-    check_status("write memory", __DFU_STATE_DFU_DOWNLOAD_BUSY)
+    if get_status() != __DFU_STATE_DFU_DOWNLOAD_BUSY:
+        raise Exception("DFU: write memory failed")
 
     # Check command state
-    check_status("write memory", __DFU_STATE_DFU_DOWNLOAD_IDLE)
+    if get_status() != __DFU_STATE_DFU_DOWNLOAD_IDLE:
+        raise Exception("DFU: write memory failed")
 
     if __verbose:
-        print("Write: 0x%x " % (xfer_base + xfer_offset))
+        print ("Write: 0x%x " % (xfer_base + xfer_offset))
 
 
 def exit_dfu():
     """Exit DFU mode, and start running the program."""
-    # Set jump address
+
+    # set jump address
     set_address(0x08000000)
 
     # Send DNLOAD with 0 length to exit DFU
-    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE, None, __TIMEOUT)
+    __dev.ctrl_transfer(0x21, __DFU_DNLOAD, 0, __DFU_INTERFACE,
+                        None, __TIMEOUT)
 
     try:
         # Execute last command
@@ -307,14 +259,13 @@ def consume(fmt, data, names):
     """Parses the struct defined by `fmt` from `data`, stores the parsed fields
     into a named tuple using `names`. Returns the named tuple, and the data
     with the struct stripped off."""
-
     size = struct.calcsize(fmt)
     return named(struct.unpack(fmt, data[:size]), names), data[size:]
 
 
 def cstring(string):
     """Extracts a null-terminated string from a byte array."""
-    return string.decode("utf-8").split("\0", 1)[0]
+    return string.decode('utf-8').split('\0', 1)[0]
 
 
 def compute_crc(data):
@@ -326,15 +277,15 @@ def read_dfu_file(filename):
     """Reads a DFU file, and parses the individual elements from the file.
     Returns an array of elements. Each element is a dictionary with the
     following keys:
-        num     - The element index.
+        num     - The element index
         address - The address that the element data should be written to.
-        size    - The size of the element data.
+        size    - The size of the element ddata.
         data    - The element data.
     If an error occurs while parsing the file, then None is returned.
     """
 
     print("File: {}".format(filename))
-    with open(filename, "rb") as fin:
+    with open(filename, 'rb') as fin:
         data = fin.read()
     crc = compute_crc(data[:-4])
     elements = []
@@ -342,81 +293,72 @@ def read_dfu_file(filename):
     # Decode the DFU Prefix
     #
     # <5sBIB
-    #   <   little endian           Endianness
+    #   <   little endian
     #   5s  char[5]     signature   "DfuSe"
     #   B   uint8_t     version     1
-    #   I   uint32_t    size        Size of the DFU file (without suffix)
+    #   I   uint32_t    size        Size of the DFU file (not including suffix)
     #   B   uint8_t     targets     Number of targets
-    dfu_prefix, data = consume("<5sBIB", data, "signature version size targets")
-    print(
-        "    %(signature)s v%(version)d, image size: %(size)d, "
-        "targets: %(targets)d" % dfu_prefix
-    )
-    for target_idx in range(dfu_prefix["targets"]):
+    dfu_prefix, data = consume('<5sBIB', data,
+                               'signature version size targets')
+    print ("    %(signature)s v%(version)d, image size: %(size)d, "
+           "targets: %(targets)d" % dfu_prefix)
+    for target_idx in range(dfu_prefix['targets']):
         # Decode the Image Prefix
         #
         # <6sBI255s2I
-        #   <       little endian           Endianness
+        #   <   little endian
         #   6s      char[6]     signature   "Target"
         #   B       uint8_t     altsetting
-        #   I       uint32_t    named       Bool indicating if a name was used
-        #   255s    char[255]   name        Name of the target
-        #   I       uint32_t    size        Size of image (without prefix)
+        #   I       uint32_t    named       bool indicating if a name was used
+        #   255s    char[255]   name        name of the target
+        #   I       uint32_t    size        size of image (not incl prefix)
         #   I       uint32_t    elements    Number of elements in the image
-        img_prefix, data = consume(
-            "<6sBI255s2I", data, "signature altsetting named name " "size elements"
-        )
-        img_prefix["num"] = target_idx
-        if img_prefix["named"]:
-            img_prefix["name"] = cstring(img_prefix["name"])
+        img_prefix, data = consume('<6sBI255s2I', data,
+                                   'signature altsetting named name '
+                                   'size elements')
+        img_prefix['num'] = target_idx
+        if img_prefix['named']:
+            img_prefix['name'] = cstring(img_prefix['name'])
         else:
-            img_prefix["name"] = ""
-        print(
-            "    %(signature)s %(num)d, alt setting: %(altsetting)s, "
-            'name: "%(name)s", size: %(size)d, elements: %(elements)d' % img_prefix
-        )
+            img_prefix['name'] = ''
+        print('    %(signature)s %(num)d, alt setting: %(altsetting)s, '
+              'name: "%(name)s", size: %(size)d, elements: %(elements)d'
+              % img_prefix)
 
-        target_size = img_prefix["size"]
-        target_data = data[:target_size]
-        data = data[target_size:]
-        for elem_idx in range(img_prefix["elements"]):
+        target_size = img_prefix['size']
+        target_data, data = data[:target_size], data[target_size:]
+        for elem_idx in range(img_prefix['elements']):
             # Decode target prefix
-            #
-            # <2I
-            #   <   little endian           Endianness
-            #   I   uint32_t    element     Address
-            #   I   uint32_t    element     Size
-            elem_prefix, target_data = consume("<2I", target_data, "addr size")
-            elem_prefix["num"] = elem_idx
-            print("      %(num)d, address: 0x%(addr)08x, size: %(size)d" % elem_prefix)
-            elem_size = elem_prefix["size"]
+            #   <   little endian
+            #   I   uint32_t    element address
+            #   I   uint32_t    element size
+            elem_prefix, target_data = consume('<2I', target_data, 'addr size')
+            elem_prefix['num'] = elem_idx
+            print('      %(num)d, address: 0x%(addr)08x, size: %(size)d'
+                  % elem_prefix)
+            elem_size = elem_prefix['size']
             elem_data = target_data[:elem_size]
             target_data = target_data[elem_size:]
-            elem_prefix["data"] = elem_data
+            elem_prefix['data'] = elem_data
             elements.append(elem_prefix)
 
         if len(target_data):
             print("target %d PARSE ERROR" % target_idx)
 
     # Decode DFU Suffix
-    #
-    # <4H3sBI
-    #   <   little endian           Endianness
-    #   H   uint16_t    device      Firmware version
+    #   <   little endian
+    #   H   uint16_t    device  Firmware version
     #   H   uint16_t    product
     #   H   uint16_t    vendor
-    #   H   uint16_t    dfu         0x11a   (DFU file format version)
-    #   3s  char[3]     ufd         "UFD"
-    #   B   uint8_t     len         16
-    #   I   uint32_t    crc32       Checksum
-    dfu_suffix = named(
-        struct.unpack("<4H3sBI", data[:16]), "device product vendor dfu ufd len crc"
-    )
-    print(
-        "    usb: %(vendor)04x:%(product)04x, device: 0x%(device)04x, "
-        "dfu: 0x%(dfu)04x, %(ufd)s, %(len)d, 0x%(crc)08x" % dfu_suffix
-    )
-    if crc != dfu_suffix["crc"]:
+    #   H   uint16_t    dfu     0x11a   (DFU file format version)
+    #   3s  char[3]     ufd     'UFD'
+    #   B   uint8_t     len     16
+    #   I   uint32_t    crc32
+    dfu_suffix = named(struct.unpack('<4H3sBI', data[:16]),
+                       'device product vendor dfu ufd len crc')
+    print ('    usb: %(vendor)04x:%(product)04x, device: 0x%(device)04x, '
+           'dfu: 0x%(dfu)04x, %(ufd)s, %(len)d, 0x%(crc)08x' % dfu_suffix)
+    if crc != dfu_suffix['crc']:
         print("CRC ERROR: computed crc32 is 0x%08x" % crc)
         return
     data = data[16:]
@@ -435,56 +377,51 @@ class FilterDFU(object):
     def __call__(self, device):
         for cfg in device:
             for intf in cfg:
-                return intf.bInterfaceClass == 0xFE and intf.bInterfaceSubClass == 1
+                return (intf.bInterfaceClass == 0xFE and
+                        intf.bInterfaceSubClass == 1)
 
 
 def get_dfu_devices(*args, **kwargs):
-    """Returns a list of USB devices which are currently in DFU mode.
-    Additional filters (like idProduct and idVendor) can be passed in
-    to refine the search.
+    """Returns a list of USB device which are currently in DFU mode.
+    Additional filters (like idProduct and idVendor) can be passed in to
+    refine the search.
     """
-
-    # Convert to list for compatibility with newer PyUSB
-    return list(usb.core.find(*args, find_all=True, custom_match=FilterDFU(), **kwargs))
+    # convert to list for compatibility with newer pyusb
+    return list(usb.core.find(*args, find_all=True,
+                              custom_match=FilterDFU(), **kwargs))
 
 
 def get_memory_layout(device):
     """Returns an array which identifies the memory layout. Each entry
     of the array will contain a dictionary with the following keys:
-        addr        - Address of this memory segment.
+        addr        - Address of this memory segment
         last_addr   - Last address contained within the memory segment.
-        size        - Size of the segment, in bytes.
-        num_pages   - Number of pages in the segment.
-        page_size   - Size of each page, in bytes.
+        size        - size of the segment, in bytes
+        num_pages   - number of pages in the segment
+        page_size   - size of each page, in bytes
     """
-
     cfg = device[0]
     intf = cfg[(0, 0)]
     mem_layout_str = get_string(device, intf.iInterface)
-    mem_layout = mem_layout_str.split("/")
+    mem_layout = mem_layout_str.split('/')
+    addr = int(mem_layout[1], 0)
+    segments = mem_layout[2].split(',')
+    seg_re = re.compile(r'(\d+)\*(\d+)(.)(.)')
     result = []
-    for mem_layout_index in range(1, len(mem_layout), 2):
-        addr = int(mem_layout[mem_layout_index], 0)
-        segments = mem_layout[mem_layout_index + 1].split(",")
-        seg_re = re.compile(r"(\d+)\*(\d+)(.)(.)")
-        for segment in segments:
-            seg_match = seg_re.match(segment)
-            num_pages = int(seg_match.groups()[0], 10)
-            page_size = int(seg_match.groups()[1], 10)
-            multiplier = seg_match.groups()[2]
-            if multiplier == "K":
-                page_size *= 1024
-            if multiplier == "M":
-                page_size *= 1024 * 1024
-            size = num_pages * page_size
-            last_addr = addr + size - 1
-            result.append(
-                named(
-                    (addr, last_addr, size, num_pages, page_size),
-                    "addr last_addr size num_pages page_size",
-                )
-            )
-            addr += size
+    for segment in segments:
+        seg_match = seg_re.match(segment)
+        num_pages = int(seg_match.groups()[0], 10)
+        page_size = int(seg_match.groups()[1], 10)
+        multiplier = seg_match.groups()[2]
+        if multiplier == 'K':
+            page_size *= 1024
+        if multiplier == 'M':
+            page_size *= 1024 * 1024
+        size = num_pages * page_size
+        last_addr = addr + size - 1
+        result.append(named((addr, last_addr, size, num_pages, page_size),
+                      "addr last_addr size num_pages page_size"))
+        addr += size
     return result
 
 
@@ -492,21 +429,18 @@ def list_dfu_devices(*args, **kwargs):
     """Prints a lits of devices detected in DFU mode."""
     devices = get_dfu_devices(*args, **kwargs)
     if not devices:
-        raise SystemExit("No DFU capable devices found")
+        print("No DFU capable devices found")
+        return
     for device in devices:
-        print(
-            "Bus {} Device {:03d}: ID {:04x}:{:04x}".format(
-                device.bus, device.address, device.idVendor, device.idProduct
-            )
-        )
+        print("Bus {} Device {:03d}: ID {:04x}:{:04x}"
+              .format(device.bus, device.address,
+                      device.idVendor, device.idProduct))
         layout = get_memory_layout(device)
         print("Memory Layout")
         for entry in layout:
-            print(
-                "    0x{:x} {:2d} pages of {:3d}K bytes".format(
-                    entry["addr"], entry["num_pages"], entry["page_size"] // 1024
-                )
-            )
+            print("    0x{:x} {:2d} pages of {:3d}K bytes"
+                  .format(entry['addr'], entry['num_pages'],
+                          entry['page_size'] // 1024))
 
 
 def write_elements(elements, mass_erase_used, progress=None):
@@ -516,48 +450,62 @@ def write_elements(elements, mass_erase_used, progress=None):
 
     mem_layout = get_memory_layout(__dev)
     for elem in elements:
-        addr = elem["addr"]
-        size = elem["size"]
-        data = elem["data"]
+        addr = elem['addr']
+        size = elem['size']
+        data = elem['data']
         elem_size = size
         elem_addr = addr
-        if progress and elem_size:
+        if progress:
             progress(elem_addr, 0, elem_size)
         while size > 0:
             write_size = size
             if not mass_erase_used:
                 for segment in mem_layout:
-                    if addr >= segment["addr"] and addr <= segment["last_addr"]:
+                    if addr >= segment['addr'] and \
+                       addr <= segment['last_addr']:
                         # We found the page containing the address we want to
                         # write, erase it
-                        page_size = segment["page_size"]
+                        page_size = segment['page_size']
                         page_addr = addr & ~(page_size - 1)
                         if addr + write_size > page_addr + page_size:
                             write_size = page_addr + page_size - addr
                         page_erase(page_addr)
                         break
-            write_memory(addr, data[:write_size], progress, elem_addr, elem_size)
+            write_memory(addr, data[:write_size], progress,
+                         elem_addr, elem_size)
             data = data[write_size:]
             addr += write_size
             size -= write_size
             if progress:
                 progress(elem_addr, addr - elem_addr, elem_size)
 
+def write_bin(path, progress=None):
+    try:
+        with open(path, 'rb') as f:
+            buf = f.read()
+    except Exception as e:
+        print(e)
+        return               
+    
+    xfer_bytes = 0 
+    xfer_total = len(buf)
+    
+    while xfer_bytes < xfer_total:
+        # Send chunk
+        chunk = min (64, xfer_total-xfer_bytes)
+        write_page(buf[xfer_bytes:xfer_bytes+chunk], xfer_bytes)
+        xfer_bytes += chunk
+        if (progress):
+            progress(0x08000000+xfer_bytes, xfer_bytes, xfer_total)
 
 def cli_progress(addr, offset, size):
     """Prints a progress report suitable for use on the command line."""
     width = 25
     done = offset * width // size
-    print(
-        "\r0x{:08x} {:7d} [{}{}] {:3d}% ".format(
-            addr, size, "=" * done, " " * (width - done), offset * 100 // size
-        ),
-        end="",
-    )
-    try:
-        sys.stdout.flush()
-    except OSError:
-        pass  # Ignore Windows CLI "WinError 87" on Python 3.6
+    print("\r0x{:08x} {:7d} [{}{}] {:3d}% "
+          .format(addr, size, '=' * done, ' ' * (width - done),
+                  offset * 100 // size), end="")
+    sys.stdout.flush()
     if offset == size:
         print("")
 
@@ -565,31 +513,36 @@ def cli_progress(addr, offset, size):
 def main():
     """Test program for verifying this files functionality."""
     global __verbose
-    global __VID
-    global __PID
     # Parse CMD args
-    parser = argparse.ArgumentParser(description="DFU Python Util")
+    parser = argparse.ArgumentParser(description='DFU Python Util')
+    #parser.add_argument("path", help="file path")
     parser.add_argument(
-        "-l", "--list", help="list available DFU devices", action="store_true", default=False
+        "-l", "--list",
+        help="list available DFU devices",
+        action="store_true",
+        default=False
     )
-    parser.add_argument("--vid", help="USB Vendor ID", type=lambda x: int(x, 0), default=__VID)
-    parser.add_argument("--pid", help="USB Product ID", type=lambda x: int(x, 0), default=__PID)
     parser.add_argument(
-        "-m", "--mass-erase", help="mass erase device", action="store_true", default=False
+        "-m", "--mass-erase",
+        help="mass erase device",
+        action="store_true",
+        default=False
     )
     parser.add_argument(
-        "-u", "--upload", help="read file from DFU device", dest="path", default=False
+        "-u", "--upload",
+        help="read file from DFU device",
+        dest="path",
+        default=False
     )
-    parser.add_argument("-x", "--exit", help="Exit DFU", action="store_true", default=False)
     parser.add_argument(
-        "-v", "--verbose", help="increase output verbosity", action="store_true", default=False
+        "-v", "--verbose",
+        help="increase output verbosity",
+        action="store_true",
+        default=False
     )
     args = parser.parse_args()
 
     __verbose = args.verbose
-
-    __VID = args.vid
-    __PID = args.pid
 
     if args.list:
         list_dfu_devices(idVendor=__VID, idProduct=__PID)
@@ -597,34 +550,33 @@ def main():
 
     init()
 
-    command_run = False
     if args.mass_erase:
-        print("Mass erase...")
+        print ("Mass erase...")
         mass_erase()
-        command_run = True
 
     if args.path:
-        elements = read_dfu_file(args.path)
-        if not elements:
-            print("No data in dfu file")
-            return
-        print("Writing memory...")
-        write_elements(elements, args.mass_erase, progress=cli_progress)
+        ext = os.path.splitext(args.path)[1]
+        if ext == ".bin":
+            print("Writing binary...")
+            write_bin(args.path, progress=cli_progress)
 
-        print("Exiting DFU...")
-        exit_dfu()
-        command_run = True
+            print("Exiting DFU...")
+            exit_dfu()
+        elif (ext == '.dfu'):
+            elements = read_dfu_file(args.path)
+            if not elements:
+                return
+            print("Writing memory...")
+            write_elements(elements, args.mass_erase, progress=cli_progress)
 
-    if args.exit:
-        print("Exiting DFU...")
-        exit_dfu()
-        command_run = True
+            print("Exiting DFU...")
+            exit_dfu()
+        else:
+            print("File format not supported!")
 
-    if command_run:
-        print("Finished")
-    else:
-        print("No command specified")
+        return
 
+    print("No command specified")
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
`make pydfu` wraps the crow binary into a dfu package, then uploads using `pydfu.py` from [micropython](https://github.com/micropython/micropython) project.

Amazingly it's the fastest upload i've ever seen to a stm32 chip!

`make dfureset` attempts to send the `^^b` command to a connected crow. assumes port `/dev/ttyACM0` so it will only work on ubuntu right now.

`make dfureset pydfu` will build the firmware, reset to bootloader mode, and upload to memory.

//

@tehn the make recipe for `pydfu` is all it took to get the firmware to flash. it just relies upon `util/pydfu.py`. i'll need to update the git release to build .dfu file.

would be great if you could just try and build & upload the firmware with these new commands!