### PR TITLE
Just intonation support

### DIFF
--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -179,6 +179,30 @@ function delay(action, time, repeats)
     return d
 end
 
+--- Just Intonation helpers
+-- convert a single fraction, or table of fractions to just intonation
+-- optional 'offset' is itself a just ratio
+-- justvolts converts to volts-per-octave
+-- just12 converts to 12TET representation (for *.scale libs)
+-- just12 will convert a fraction or table of fractions into 12tet 'semitones'
+local JIVOLT = 1 / math.log(2)
+local JI12TET = 12 * JIVOLT
+local function _jiv(f) return math.log(f) * JIVOLT end
+local function _ji12(f) return math.log(f) * JI12TET end
+function justvolts(f, off) return _justint(_jiv, f, off) end
+function just12(f, off) return _justint(_ji12, f, off) end
+local function _justint(fn, f, off)
+    off = off and fn(off) or 0 -- optional offset is a just ratio
+    if type(f) == 'table' then
+        for k,v in ipairs(f) do
+            f[k] = fn(v) + off
+        end
+        return f
+    else -- assume number
+        return fn(f) + off
+    end
+end
+
 -- empty init function in case userscript doesn't define it
 function init() end
 

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -188,10 +188,11 @@ end
 function _justint(fn, f, off)
     off = off and fn(off) or 0 -- optional offset is a just ratio
     if type(f) == 'table' then
+        local t = {}
         for k,v in ipairs(f) do
-            f[k] = fn(v) + off
+            t[k] = fn(v) + off
         end
-        return f
+        return t
     else -- assume number
         return fn(f) + off
     end

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -185,13 +185,7 @@ end
 -- justvolts converts to volts-per-octave
 -- just12 converts to 12TET representation (for *.scale libs)
 -- just12 will convert a fraction or table of fractions into 12tet 'semitones'
-local JIVOLT = 1 / math.log(2)
-local JI12TET = 12 * JIVOLT
-local function _jiv(f) return math.log(f) * JIVOLT end
-local function _ji12(f) return math.log(f) * JI12TET end
-function justvolts(f, off) return _justint(_jiv, f, off) end
-function just12(f, off) return _justint(_ji12, f, off) end
-local function _justint(fn, f, off)
+function _justint(fn, f, off)
     off = off and fn(off) or 0 -- optional offset is a just ratio
     if type(f) == 'table' then
         for k,v in ipairs(f) do
@@ -202,6 +196,13 @@ local function _justint(fn, f, off)
         return fn(f) + off
     end
 end
+JIVOLT = 1 / math.log(2)
+JI12TET = 12 * JIVOLT
+function _jiv(f) return math.log(f) * JIVOLT end
+function _ji12(f) return math.log(f) * JI12TET end
+-- public functions
+function justvolts(f, off) return _justint(_jiv, f, off) end
+function just12(f, off) return _justint(_ji12, f, off) end
 
 -- empty init function in case userscript doesn't define it
 function init() end

--- a/lua/input.lua
+++ b/lua/input.lua
@@ -66,12 +66,18 @@ function Input:set_mode( mode, ... )
         self.hysteresis = args[2] or self.hysteresis
         set_input_window( self.channel, self.windows, self.hysteresis )
     elseif mode == 'scale' then
-        self.notes   = args[1] or self.notes
-        self.temp    = args[2] or self.temp
+        self.temp = args[2] or self.temp
+        local temp = self.temp
+        if type(self.temp) == 'string' then -- assume just intonation
+            self.notes = just12(args[1]) -- assume args[1] is valid
+            temp = 12
+        else
+            self.notes = args[1] or self.notes
+        end
         self.scaling = args[3] or self.scaling
         set_input_scale( self.channel
                        , self.notes
-                       , self.temp
+                       , temp -- use local as may be coerced to 12 by ji
                        , self.scaling
                        )
     elseif mode == 'volume' then

--- a/lua/output.lua
+++ b/lua/output.lua
@@ -45,14 +45,14 @@ Output.__index = function(self, ix)
     elseif ix == 'volts'   then return LL_get_state(self.channel)
     elseif ix == 'running' then return self.asl.running
     elseif ix == 'scale'   then return
-        function(ns,t,s)
-            local temp = t
-            if type(t) == 'string' then
+        function(...)
+            local args = {...}
+            if type(args[2]) == 'string' then
                 self.ji = true
-                temp = 12 -- fake 12TET with floating point just notes
-                ns = just12(ns)
+                args[2] = 12 -- fake 12TET with floating point just notes
+                args[1] = just12(args[1])
             else self.ji = false end
-            set_output_scale(self.channel, ns, temp, s) -- we close over .channel
+            set_output_scale(self.channel, table.unpack(args)) -- close over .channel
         end
     end
 end

--- a/lua/output.lua
+++ b/lua/output.lua
@@ -6,7 +6,8 @@ function Output.new( chan )
               , rate    = 1/chan
               , shape   = 'linear'
               , slew    = 0.0
-              , _scale   = 'none'
+              , _scale  = 'none'
+              , ji      = false -- mark if .scale is in just intonation mode
               , asl     = asl.new( chan )
 --              , trig    = { asl      = asl.new(k)
 --                          , polarity = 1
@@ -34,7 +35,7 @@ Output.__newindex = function(self, ix, val)
     elseif ix == 'done' then
         self.asl.done = val
     elseif ix == 'scale' then
-        set_output_scale(self.channel, val)
+        set_output_scale(self.channel, self.ji and just12(val) or val)
     end
 end
 
@@ -44,7 +45,15 @@ Output.__index = function(self, ix)
     elseif ix == 'volts'   then return LL_get_state(self.channel)
     elseif ix == 'running' then return self.asl.running
     elseif ix == 'scale'   then return
-        function(...) set_output_scale(self.channel, ...) end
+        function(ns,t,s)
+            local temp = t
+            if type(t) == 'string' then
+                self.ji = true
+                temp = 12 -- fake 12TET with floating point just notes
+                ns = just12(ns)
+            else self.ji = false end
+            set_output_scale(self.channel, ns, temp, s) -- we close over .channel
+        end
     end
 end
 


### PR DESCRIPTION
Fixes #310 

Adds general support for just intonation, as well as dedicated support inside of input & output 'scale' modes.

2 new global functions `justvolts` and `just12` for converting from fractions (ie floats) to their volts, or 12TET representation.
They have the same signature `justX( notex, offset)`. `notex` can be a single fraction which returns a converted value, or it can be a table of fractions which will return a new table with each element converted. `offset` is an optional arg which expects a single fraction acting as a just-transposition to `notex`. From my reading this seems like the way to handle key-modulation (open to other ideas here).

```lua
justvolts(1/1) -> 0.0
justvolts(3/2) -> 0.5849625
justvolts(1/4) -> -2.0 -- notes can be outside the 1/1 .. 2/1 range

just12(1/1) -> 0.0
just12(3/2) -> 7.019549
just12(3/2, 9/8) -> 9.058649 is 3/2 offset by 9/8

just12{1/1,3/2,7/4} -> {0.0, 7.019549, 9.688259} -- table call returns a new table
```
Originally I was only going to have `justvolts`, but `just12` made the input/output scalers easier, and it turns out to be way more human-readable. Exploring with `print(just12(...))` is a nice way of quickly seeing how different just ratios diverge from 12-tet. I think most crow users are probably familiar with the (0..12) semitonal representation of notes.

---

Output scale is used like so:

`output[1].scale({1/1,3/2,11/8}, 'ji')` -- a third optional arg sets volts/octave, so you can still use 1v2/octave if you want

Note the use of `ji` where you normally put the temperament. This calls `just12` under the hood, but is slightly better than doing it manually bc it enforces some default-ing behaviour.

---

Input scale is similar to output, but uses the `mode` function call (like normal input quantizers):

`input[1].mode('scale', {3/2, 9/8, 5/4}, 'ji')` -- again last arg (v/8 scaling) is optional & omitted in this example

---

All tests fine, but any suggestions on naming / calling conventions are welcome. Specifically `justvolts` and `just12`, and the `'ji'` param to scale.