### PR TITLE
add version.txt

### DIFF
--- a/version.txt
+++ b/version.txt
@@ -1,0 +1,1 @@
+2.1.2 https://github.com/monome/crow/releases/download/v2.1.2/crow-v2.1.2.zip


### PR DESCRIPTION
for automatic checking of current version by druid

opting to it this way (manually "activating" a release) vs. scraping the github release filename