### PR TITLE
Allow 16kB userscripts

### DIFF
--- a/lib/flash.h
+++ b/lib/flash.h
@@ -11,7 +11,8 @@
 #define USER_SCRIPT_LOCATION 0x08010000
 #define USER_SCRIPT_SECTOR   FLASH_SECTOR_4
 //#define USER_SCRIPT_SIZE     (0x10000 - 4)
-#define USER_SCRIPT_SIZE     (0x2000 - 4)
+// #define USER_SCRIPT_SIZE     (0x2000 - 4) // 8kB up to v2.1
+#define USER_SCRIPT_SIZE     (0x4000 - 4) // 16kB v3.0+
 
 typedef enum { FLASH_Status_Init  = 0
              , FLASH_Status_Saved = 1


### PR DESCRIPTION
Up from 8kB in v2.1

The limit is ultimately arbitrary. The restriction is that while the user is uploading their script (between `^^s` and `^^e` or `^^w`) the maximum sized script is allocated, so we can't just go 'unlimited'.

I think 16kB is the real-world limit of what we should expect. Especially because we don't have support for `include` or `require` (ie a script is one long file). 16kB should be 700 lines or something stupid like that.

I have not stress-tested it with giant scripts, but it works fine with some bowery scripts (eg boids)