### PR TITLE
Oscillate asllib fn

### DIFF
--- a/lua/asllib.lua
+++ b/lua/asllib.lua
@@ -16,7 +16,7 @@ function lfo(time, level, shape)
 end
 
 function oscillate(freq, level, shape)
-    lfo(1/freq, level, shape)
+    return lfo(1/freq, level, shape)
 end
 
 function pulse(time, level, polarity)

--- a/lua/asllib.lua
+++ b/lua/asllib.lua
@@ -15,6 +15,16 @@ function lfo(time, level, shape)
                }
 end
 
+function oscillate(freq, level, shape)
+    freq = freq or 1
+    level = level or 5
+    shape = shape or 'sine'
+
+    return loop{ to( level, 0.5/freq, shape)
+               , to(-level, 0.5/freq, shape)
+               }
+end
+
 function pulse(time, level, polarity)
     time = time or 0.01
     level = level or 5

--- a/lua/asllib.lua
+++ b/lua/asllib.lua
@@ -16,13 +16,7 @@ function lfo(time, level, shape)
 end
 
 function oscillate(freq, level, shape)
-    freq = freq or 1
-    level = level or 5
-    shape = shape or 'sine'
-
-    return loop{ to( level, 0.5/freq, shape)
-               , to(-level, 0.5/freq, shape)
-               }
+    lfo(1/freq, level, shape)
 end
 
 function pulse(time, level, polarity)


### PR DESCRIPTION
Fixes #402 

A simple inversion of `lfo` so that it's clear that an output is being assigned as an audiorate oscillator.