### PR TITLE
ASL `done` event

### DIFF
--- a/lib/casl.c
+++ b/lib/casl.c
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#include "lualink.h" // L_queue_asl_done for raising a sequence-complete event
+
 // TODO
 // add sequins data type
 // add random math operator
@@ -324,36 +326,40 @@ static void next_action( int index )
     if(index < 0 || index >= SELVES_COUNT){ return; }
     Casl* self = _selves[index];
 
-    To* t = seq_advance(self);
-    if(t){ // To is valid
-        switch(t->ctrl){
-            case ToLiteral:{
-                float ms = resolve(self, &t->b).f * 1000.0;
-                S_toward( index
-                        , resolve(self, &t->a).f
-                        , ms
-                        , resolve(self, &t->c).shape
-                        , &next_action // recur upon breakpoint
-                        );
-                if(ms > 0.0){ return; } // wait for DSP callback before proceeding
-                break;}
+    while(true){ // repeat until halt
+        To* t = seq_advance(self);
+        if(t){ // To is valid
+            switch(t->ctrl){
+                case ToLiteral:{
+                    float ms = resolve(self, &t->b).f * 1000.0;
+                    S_toward( index
+                            , resolve(self, &t->a).f
+                            , ms
+                            , resolve(self, &t->c).shape
+                            , &next_action // recur upon breakpoint
+                            );
+                    if(ms > 0.0){ return; } // wait for DSP callback before proceeding
+                    break;}
 
-            case ToIf:{
-                if( resolve(self, &t->a).f <= 0.0 ){ // pred is false
-                    if( !seq_up(self) ){ return; } // step up & return if nothing to do
-                }
-                break;}
+                case ToIf:{
+                    if( resolve(self, &t->a).f <= 0.0 ){ // pred is false
+                        if( !seq_up(self) ){ return; } // step up & return if nothing to do
+                    }
+                    break;}
 
-            case ToRecur:{  self->seq_current->pc = 0;    break;}
-            case ToEnter:   seq_down(self, t->a.obj.seq); break;
-            case ToHeld:{   self->holding = true;         break;}
-            case ToWait:    /* halt execution */    return;
-            case ToUnheld:{ self->holding = false;        break;} // this is never executed, but here for reference
-            case ToLock:{   self->locked = true;          break;}
-            case ToOpen:{   self->locked = false;         break;}
+                case ToRecur:{  self->seq_current->pc = 0;    break;}
+                case ToEnter:   seq_down(self, t->a.obj.seq); break;
+                case ToHeld:{   self->holding = true;         break;}
+                case ToWait:    /* halt execution */    return;
+                case ToUnheld:{ self->holding = false;        break;} // this is never executed, but here for reference
+                case ToLock:{   self->locked = true;          break;}
+                case ToOpen:{   self->locked = false;         break;}
+            }
+        } else if( !seq_up(self) ){ // To invalid. Jump up. return if nothing left to do
+            L_queue_asl_done(index); // trigger a lua event when sequence is complete
+            return;
         }
-    } else if( !seq_up(self) ){ return; } // To invalid. Jump up. return if nothing left to do
-    next_action(index); // tail call recur as we haven't halted yet
+    }
 }
 
 static bool find_control( Casl* self, ToControl ctrl, bool full_search )

--- a/lib/casl.c
+++ b/lib/casl.c
@@ -343,8 +343,7 @@ static void next_action( int index )
 
                 case ToIf:{
                     if( resolve(self, &t->a).f <= 0.0 ){ // pred is false
-                        goto STEPUP; // WARNING! ensuring only 1 path to asl_done event
-                        if( !seq_up(self) ){ return; } // step up & return if nothing to do
+                        goto stepup; // WARNING! ensuring only 1 path to asl_done event
                     }
                     break;}
 
@@ -357,7 +356,7 @@ static void next_action( int index )
                 case ToOpen:{   self->locked = false;         break;}
             }
         } else {
-STEPUP:
+stepup:
             if( !seq_up(self) ){ // To invalid. Jump up. return if nothing left to do
                 L_queue_asl_done(index); // trigger a lua event when sequence is complete
                 return;

--- a/lib/casl.c
+++ b/lib/casl.c
@@ -343,6 +343,7 @@ static void next_action( int index )
 
                 case ToIf:{
                     if( resolve(self, &t->a).f <= 0.0 ){ // pred is false
+                        goto STEPUP; // WARNING! ensuring only 1 path to asl_done event
                         if( !seq_up(self) ){ return; } // step up & return if nothing to do
                     }
                     break;}
@@ -355,9 +356,12 @@ static void next_action( int index )
                 case ToLock:{   self->locked = true;          break;}
                 case ToOpen:{   self->locked = false;         break;}
             }
-        } else if( !seq_up(self) ){ // To invalid. Jump up. return if nothing left to do
-            L_queue_asl_done(index); // trigger a lua event when sequence is complete
-            return;
+        } else {
+STEPUP:
+            if( !seq_up(self) ){ // To invalid. Jump up. return if nothing left to do
+                L_queue_asl_done(index); // trigger a lua event when sequence is complete
+                return;
+            }
         }
     }
 }

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -75,7 +75,7 @@ static int Lua_handle_error( lua_State* L );
 static void timeouthook( lua_State* L, lua_Debug* ar );
 
 // Handler prototypes
-void L_handle_toward( event_t* e );
+void L_handle_asl_done( event_t* e );
 void L_handle_metro( event_t* e );
 void L_handle_stream( event_t* e );
 void L_handle_change( event_t* e );
@@ -313,18 +313,6 @@ static int _cpu_time( lua_State *L )
     // returns count of background loops for the last 8ms
     lua_pushinteger(L, CPU_GetCount());
     return 1;
-}
-static int _go_toward( lua_State *L )
-{
-    S_toward( luaL_checkinteger(L, 1)-1 // C is zero-based
-            , luaL_checknumber(L, 2)
-            , luaL_checknumber(L, 3) * 1000.0
-            , S_str_to_shape( luaL_checkstring(L, 4) )
-            , L_queue_toward
-            );
-    lua_pop( L, 4 );
-    lua_settop(L, 0);
-    return 0;
 }
 static int _get_state( lua_State *L )
 {
@@ -903,7 +891,6 @@ static const struct luaL_Reg libCrow[]=
     , { "cputime"          , _cpu_time         }
     //, { "sys_cpu_load"     , _sys_cpu          }
         // io
-    , { "go_toward"        , _go_toward        }
     , { "get_state"        , _get_state        }
     , { "set_output_scale" , _set_scale        }
     , { "io_get_input"     , _io_get_input     }
@@ -1069,16 +1056,16 @@ static int Lua_call_usercode( lua_State* L, int nargs, int nresults )
 
 
 // Public Callbacks from C to Lua
-void L_queue_toward( int id )
+void L_queue_asl_done( int id )
 {
-    event_t e = { .handler = L_handle_toward
+    event_t e = { .handler = L_handle_asl_done
                 , .index.i = id
                 };
     event_post(&e);
 }
-void L_handle_toward( event_t* e )
+void L_handle_asl_done( event_t* e )
 {
-    lua_getglobal(L, "toward_handler");
+    lua_getglobal(L, "asl_done_handler");
     lua_pushinteger(L, e->index.i + 1); // 1-ix'd
     if( Lua_call_usercode(L, 1, 0) != LUA_OK ){
         lua_pop( L, 1 );

--- a/lib/lualink.h
+++ b/lib/lualink.h
@@ -23,7 +23,7 @@ uint8_t Lua_eval( lua_State*     L
 void Lua_load_default_script( void );
 
 // Event enqueue wrappers
-extern void L_queue_toward( int id );
+extern void L_queue_asl_done( int id );
 extern void L_queue_metro( int id, int state );
 extern void L_queue_stream( int id, float state );
 extern void L_queue_change( int id, float state );

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -24,6 +24,7 @@ function C.reset()
         output[n].slew = 0
         output[n].volts = 0
         output[n].scale('none')
+        output[n].done = function() end
     end
     ii.reset_events(ii.self)
     ii_follow_reset() -- resets forwarding to output libs
@@ -65,15 +66,8 @@ end
 
 
 --- asl
-toward_handler = function(id)
-    output[id].asl:step()
-end
--- special wrapper should really be in the ASL lib itself?
-function LL_toward( id, d, t, s )
-    while type(d) == 'function' do d = d() end
-    while type(t) == 'function' do t = t() end
-    while type(s) == 'function' do s = s() end
-    go_toward( id, d, t, s )
+asl_done_handler = function(id)
+    output[id].done()
 end
 
 function LL_get_state( id )

--- a/lua/output.lua
+++ b/lua/output.lua
@@ -9,6 +9,7 @@ function Output.new( chan )
               , _scale  = 'none'
               , ji      = false -- mark if .scale is in just intonation mode
               , asl     = asl.new( chan )
+              , done    = function() end -- customizable event called on asl completion
               , clock_div = 1
               , ckcoro  = false -- clock coroutine
               }


### PR DESCRIPTION
returns the `done` user-definable event which was removed with ASL2.

this allows the scripter to trigger some event when their ASL construct has completed by redefining the `output[n].done` function. this is particularly useful now that ASL runs asynchronously from the Lua environment.

```lua
output[1].done = function()
  print 'hey the ASL is done!'
end

output[1].slew = 1
output[1].volts = 2

-- <wait 1 second>
--> "hey the ASL is done!"
```

///

previously there was also a state variable `output[n].running` which would return a boolean stating whether ASL was active on a channel. i'm unconvinced this is really useful, and also *very* easy to manage directly by using the above `done` event.

///

reference note: this PR also removes the deprecated `go_toward` and `LL_toward` which are no longer used since ASL2. additionally it optimizes stack usage inside of Casl, by switching a recursive call to a while loop.