### PR TITLE
Fix `adsr` in asllib (and false directive handling)

### DIFF
--- a/lua/asl.lua
+++ b/lua/asl.lua
@@ -43,11 +43,11 @@ function Asl.set_held(self, b)
     end
 end
 
--- direc(tive) can take 0/1 of false/true. ONLY has effect if there is a held{} construct
+-- direc(tive) can take 0/1 or false/true. ONLY has effect if there is a held{} construct
 -- truthy always restarts
 -- falsey means 'release'
 function Asl:action(direc)
-    if not direc then -- no arg is always 'restart'
+    if direc == nil then -- no arg is always 'restart'
         casl_action(self.id, 1)
     elseif direc == 'unlock' then casl_action(self.id, 2) -- release lock construct
     else -- set `held` dyn if it exists. call action unless no `held` and direc is falsey


### PR DESCRIPTION
when sending directives to ASL (eg: `output[n](false)`), a value of `false` would be treated as if there was no argument present.

As a result, typical `adsr` usage -- sending true/false for attack/release -- was broken. this PR fixes this issue.

//

@dndrks after a little feedback here, but i *think* this makes sense for adsr (and the `held` ASL construct in general), but let me know if this breaks vs previous version.

when you first assign `adsr` to an output, the `held` state is `false` meaning that simply banging the output (`output[n]()`) will seem like it does nothing. this is because it's triggering the 'release' stage, which will fade from the current state (likely 0) to 0 -- hence 'does nothing'.

my thinking is when using an ASL that includes a `held` construct, the scripter *must* be explicit about when one enters/exits the `held` sub-sequence. this means the empty call `output[1]()` will restart the ASL, but it *won't* set the held state. if `held` is set, the empty call will retrigger the attack portion & rest at sustain, but if `held` is unset it will re-trigger the release portion (likely doing nothing).