### PR TITLE
Add quote.lua library

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -42,6 +42,7 @@
 #include "build/iihelp.lua.h"    // generated lua stub for loading i2c modules
 #include "lua/calibrate.lua.h"
 #include "lua/sequins.lua.h"
+#include "lua/quote.lua.h"
 
 #include "build/ii_lualink.h" // generated C header for linking to lua
 
@@ -61,6 +62,7 @@ const struct lua_lib_locator Lua_libs[] =
     , { "build_iihelp"  , build_iihelp  }
     , { "lua_calibrate" , lua_calibrate }
     , { "lua_sequins"   , lua_sequins   }
+    , { "lua_quote"     , lua_quote     }
     , { NULL            , NULL          }
     };
 

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -13,6 +13,7 @@ cal    = dofile('lua/calibrate.lua')
 public = dofile('lua/public.lua')
 clock  = dofile('lua/clock.lua')
 sequins= dofile('lua/sequins.lua')
+quote  = dofile('lua/quote.lua')
 
 
 function C.reset()
@@ -151,8 +152,6 @@ function delay(action, time, repeats)
     if d then d:start() end
     return d
 end
-
-function quotes(s) return string.format('%q',s) end
 
 --- Just Intonation helpers
 -- convert a single fraction, or table of fractions to just intonation

--- a/lua/public.lua
+++ b/lua/public.lua
@@ -91,14 +91,15 @@ P.clear = function()
     P._names = {}
     P._params = {}
     P.view.all(false)
-    _c.tell('pub',quotes'_clear')
+    _c.tell('pub',quote'_clear')
 end
 
 local function quoteptab(p)
+    -- TODO optimize this to leverage quote library
     local t = {}
     local i = 1 -- manual iteration to enable table or sequins (ipairs won't work with sequins)
     while p.v[i] ~= nil do
-        if type(p.v[i] == 'string') then t[i] = quotes(p.v[i])
+        if type(p.v[i] == 'string') then t[i] = quote(p.v[i])
         else t[i] = p.v[i] end
         i = i + 1
     end
@@ -108,7 +109,7 @@ end
 
 local function dval(p)
     local tv = type(p.v)
-    if tv == 'string' then return quotes(p.v)
+    if tv == 'string' then return quote(p.v)
     elseif tv == 'table' then return quoteptab(p)
     else return p.v
     end
@@ -119,22 +120,21 @@ local function dtype(p)
     if p.option then
         t = {string.format('%q', 'option')}
         for i=1,#p.option do
-            t[#t+1] = quotes(p.option[i])
+            t[#t+1] = quote(p.option[i])
         end
     else
-        -- TODO update to use quote() instead of string.format
-        if p.min then table.insert(t, string.format('%g', p.min)) end
-        if p.max then table.insert(t, string.format('%g', p.max)) end
-        if p.tipe then table.insert(t, string.format('%q', p.tipe)) end
+        if p.min then table.insert(t, quote(p.min)) end
+        if p.max then table.insert(t, quote(p.max)) end
+        if p.tipe then table.insert(t, quote(p.tipe)) end
     end
     return table.concat(t,',')
 end
 
 P.discover = function()
     for _,p in ipairs(P._params) do
-        _c.tell('pub', quotes(p.k), dval(p), string.format('{%s}',dtype(p)))
+        _c.tell('pub', quote(p.k), dval(p), string.format('{%s}',dtype(p)))
     end
-    _c.tell('pub',quotes'_end')
+    _c.tell('pub',quote'_end')
 end
 
 P.doact = function(p, v)
@@ -164,12 +164,12 @@ end
 
 P.broadcast = function(k, v, kk)
     local tv = type(v)
-    if tv == 'string' then v = quotes(v)
+    if tv == 'string' then v = quote(v)
     elseif tv == 'table' then v = quoteptab(v) end
     -- else v = v
     if kk then
-        _c.tell('pupdate', quotes(k), v, quotes(kk))
-    else _c.tell('pupdate', quotes(k), v) end
+        _c.tell('pupdate', quote(k), v, quote(kk))
+    else _c.tell('pupdate', quote(k), v) end
 end
 
 -- NOTE: To only be called by remote device

--- a/lua/quote.lua
+++ b/lua/quote.lua
@@ -1,0 +1,57 @@
+--- Quote sub-library
+-- fns for stringifying data-structures
+-- output is a string that can be read back as lua code with call()
+
+local Q = {
+  OPTIMIZE_LENGTH = false -- true reduces tx-length of strings, but takes longer to calc
+}
+
+
+function Q.key(ix)
+    -- stringify a table key with explicit [] style
+    local fstr = (type(ix)=='number') and '[%g]' or '[%q]'
+    return string.format(fstr, ix)
+end
+
+function Q.quote(val, ...)
+    -- stringify any data so lua can load() it
+    if ... ~= nil then
+        local t = {Q.quote(val)} -- capture 1st arg
+        for _,v in ipairs{...} do -- capture varargs
+            table.insert(t, Q.quote(v))
+        end
+        return table.concat(t, ',')
+    elseif type(val) == 'string' then return string.format('%q',val)
+    elseif type(val) == 'number' then return string.format('%.6g',val) -- 6 sig figures
+    elseif type(val) ~= 'table' then return tostring(val)
+    else -- recur per table element
+        local t = {}
+        if Q.OPTIMIZE_LENGTH then
+            local max = 0
+            -- add array-style keys for reduced string length
+            for k,v in ipairs(val) do
+                table.insert(t, Q.quote(v))
+                max = k -- save highest ipair key
+            end
+            for k,v in pairs(val) do
+                -- match on any key that wasn't caught by ipairs (without needing to copy the table)
+                    -- not a number, is a float, is a sparse int key, is a zero or less int key
+                if type(k) ~= 'number' or k ~= math.floor(k) or k > max or k < 1 then
+                    table.insert(t, Q.key(k) .. '=' .. Q.quote(v))
+                end
+            end
+        else -- faster to build, but transmission is longer
+            for k,v in pairs(val) do
+                table.insert(t, Q.key(k) .. '=' .. Q.quote(v))
+            end
+        end
+        return string.format('{%s}', table.concat(t, ','))
+    end
+end
+
+setmetatable(Q,{
+  __call = function(self, ...) return Q.quote(...) end
+})
+
+return Q
+


### PR DESCRIPTION
pulls the 'quote' library from norns (built for crow/public) into the crow firmware.

it's a powerful function global function `quote(...)` that captures any object(s) as argument and returns a string that represents that object. it's primarily useful for when you have a table, or a bunch of arguments of unknown type, and you need to send them over the serial port as a string.

this means you can serialize an object & load it in a different VM:
`reconstructed_object = load(quote(original_object))`

this is required to fix a bug in the new norns-crow-namespace PR https://github.com/monome/norns/pull/1362