### PR TITLE
Asl2 dynamic mutation syntax update

### DIFF
--- a/lib/casl.c
+++ b/lib/casl.c
@@ -261,6 +261,7 @@ static void capture_elem( Casl* self, Elem* e, lua_State* L, int ix )
                 case '*': allocating_capture(self, e, L, ElemT_Mul, 2); break;
                 case '/': allocating_capture(self, e, L, ElemT_Div, 2); break;
                 case '%': allocating_capture(self, e, L, ElemT_Mod, 2); break;
+                case '#': allocating_capture(self, e, L, ElemT_Mutate, 1); break;
 
                 default:
                     printf("ERROR composite To char '%c'not found\n",index);
@@ -425,6 +426,13 @@ static ElemO _resolve( Casl* self, Elem* e )
             float wrap = RESOLVE_VAR(self,e,1); // 0.1
             float mul = floorf(val/wrap); // -0.01 -> -1
             return (ElemO){val - (wrap * mul)};} // -0.001 - (0.1 * -1) => 0.099
+        case ElemT_Mutate:{
+            ElemO mutated = (ElemO){RESOLVE_VAR(self,e,0)};
+            if(resolving_mutable < DYN_COUNT){
+                self->dynamics[resolving_mutable].obj = mutated; // update value
+                resolving_mutable = DYN_COUNT; // mutation resolved!
+            }
+            return mutated;} // return the resultant value
         default: return e->obj;
     }
 }

--- a/lib/casl.c
+++ b/lib/casl.c
@@ -4,6 +4,8 @@
 #include <stdio.h>
 #include <math.h> // floorf
 
+#include "caw.h" // Caw_printf
+
 // TODO
 // add sequins data type
 // add random math operator
@@ -40,7 +42,11 @@ Casl* casl_init( int index )
 
 static void seq_enter( Casl* self )
 {
-    if(self->seq_ix >= SEQ_COUNT){ printf("ERROR: no sequences left!\n"); return; }
+    if(self->seq_ix >= SEQ_COUNT){
+        printf("ERROR: no sequences left!\n");
+        Caw_printf("ERROR: no sequences left!\n");
+        return;
+    }
     Sequence* s = &self->seqs[self->seq_ix];
     self->seq_current = s; // save as 'active' Sequence
 
@@ -61,7 +67,10 @@ static void seq_exit( Casl* self )
 static void seq_append( Casl* self, To* t )
 {
     Sequence* s = self->seq_current;
-    if(s->length >= SEQ_LENGTH){ printf("ERROR: no stages left!\n"); }
+    if(s->length >= SEQ_LENGTH){
+        printf("ERROR: no stages left!\n");
+        Caw_printf("ERROR: no stages left!\n");
+    }
     s->stage[s->length] = t; // append To* to end of Sequence
     s->length++;
 }
@@ -145,7 +154,11 @@ static void parse_table( Casl* self, lua_State* L )
 
         case LUA_TSTRING: { // TO, RECUR
             To* t = to_alloc(self);
-            if(t == NULL){ printf("ERROR: not enough To slots left\n"); return; }
+            if(t == NULL){
+                printf("ERROR: not enough To slots left\n");
+                Caw_printf("ERROR: not enough To slots left\n");
+                return;
+            }
             seq_append(self, t);
             switch( ix_char(L, 1) ){
                 case 'T': read_to(self, t, L); break; // standard To
@@ -159,7 +172,10 @@ static void parse_table( Casl* self, lua_State* L )
                 case 'U':{ t->ctrl = ToUnheld; break; }
                 case 'L':{ t->ctrl = ToLock; break; }
                 case 'O':{ t->ctrl = ToOpen; break; }
-                default: printf("ERROR char not found\n"); break;
+                default:
+                    printf("ERROR char not found\n");
+                    Caw_printf("ERROR char not found\n");
+                    break;
             }
             break;}
 
@@ -179,7 +195,10 @@ static void parse_table( Casl* self, lua_State* L )
             seq_exit(self);
             break;}
 
-        default: printf("ERROR unhandled parse type\n"); break;
+        default:
+            printf("ERROR unhandled parse type\n");
+            Caw_printf("ERROR unhandled parse type\n");
+            break;
     }
 }
 
@@ -243,12 +262,18 @@ static void capture_elem( Casl* self, Elem* e, lua_State* L, int ix )
                 case '/': allocating_capture(self, e, L, ElemT_Div, 2); break;
                 case '%': allocating_capture(self, e, L, ElemT_Mod, 2); break;
 
-                default: printf("ERROR composite To char '%c'not found\n",index); break;
+                default:
+                    printf("ERROR composite To char '%c'not found\n",index);
+                    Caw_printf("ERROR composite To char '%c'not found\n",index);
+                    break;
             }
             lua_pop(L, 1);
             break;
 
-        default: printf("ERROR unknown To type\n"); break;
+        default:
+            printf("ERROR unknown To type\n");
+            Caw_printf("ERROR unknown To type\n");
+            break;
     }
 }
 
@@ -428,7 +453,11 @@ int casl_defdynamic( int index )
 
 int casl_defdynamicP( Casl* self )
 {
-    if(self->dyn_ix >= DYN_COUNT){ printf("ERROR: no dynamic slots remain\n"); return -1; }
+    if(self->dyn_ix >= DYN_COUNT){
+        printf("ERROR: no dynamic slots remain\n");
+        Caw_printf("ERROR: no dynamic slots remain\n");
+        return -1;
+    }
     int ix = self->dyn_ix; self->dyn_ix++;
     return ix;
 }
@@ -458,6 +487,9 @@ float casl_getdynamic( int index, int dynamic_ix )
     switch(self->dynamics[dynamic_ix].type){
         case ElemT_Float:
             return self->dynamics[dynamic_ix].obj.f;
-        default: printf("getdynamic! wrong type\n"); return 0.0;
+        default:
+            printf("getdynamic! wrong type\n");
+            Caw_printf("getdynamic! wrong type\n");
+            return 0.0;
     }
 }

--- a/lib/casl.c
+++ b/lib/casl.c
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <math.h> // floorf
 
 // TODO
 // add sequins data type
@@ -395,10 +396,10 @@ static ElemO _resolve( Casl* self, Elem* e )
         case ElemT_Mod:{
             // this is just fmodf(val, wrap), but we need to handle negative numerators
             // FIXME negative values shoud wrap to 'wrap' value
-            float val  = RESOLVE_VAR(self,e,0);
-            float wrap = RESOLVE_VAR(self,e,1);
-            int mul = (int)(val/wrap);
-            return (ElemO){val - (wrap * mul)};}
+            float val  = RESOLVE_VAR(self,e,0); // -0.001
+            float wrap = RESOLVE_VAR(self,e,1); // 0.1
+            float mul = floorf(val/wrap); // -0.01 -> -1
+            return (ElemO){val - (wrap * mul)};} // -0.001 - (0.1 * -1) => 0.099
         default: return e->obj;
     }
 }

--- a/lib/casl.h
+++ b/lib/casl.h
@@ -9,10 +9,10 @@
 
 #include "slopes.h" // S_toward
 
-#define TO_COUNT   16
-#define SEQ_COUNT  8
-#define SEQ_LENGTH 8
-#define DYN_COUNT  32
+#define TO_COUNT   16   // 28bytes
+#define SEQ_COUNT  8    // 16bytes
+#define SEQ_LENGTH 8    // 4bytes
+#define DYN_COUNT  40   // 8bytes
 
 typedef enum{ ToLiteral
             , ToRecur
@@ -44,6 +44,7 @@ typedef enum{ ElemT_Float
             , ElemT_Mul
             , ElemT_Div
             , ElemT_Mod
+            , ElemT_Mutate
 } ElemT;
 
 typedef struct{

--- a/lib/casl.h
+++ b/lib/casl.h
@@ -12,7 +12,7 @@
 #define TO_COUNT   16
 #define SEQ_COUNT  8
 #define SEQ_LENGTH 8
-#define DYN_COUNT  16
+#define DYN_COUNT  32
 
 typedef enum{ ToLiteral
             , ToRecur
@@ -31,7 +31,7 @@ typedef union{
     uint16_t var[2]; // 2 indexes into dynamic table
     int     seq; // reference to a Sequence object
     Shape_t shape;
-} ElemO;
+} ElemO; // 4bytes
 
 typedef enum{ ElemT_Float
             , ElemT_Shape

--- a/lua/asl.lua
+++ b/lua/asl.lua
@@ -8,7 +8,6 @@ local Dynmt = {
 function Asl.new(id)
     local c = {id = id or 1}
     c.dyn = setmetatable({_names={}, id=c.id}, Dynmt) -- needs link to `id`
-    c.mutable = c.dyn -- alias mutable to dyn for more natural manipulation of named mutables
     setmetatable(c, Asl)
     return c
 end
@@ -112,6 +111,16 @@ end
 --- behavioural types
 -- available for dynamics so exposed variables can be musician-centric
 -- and mutables, where operations are destructive to the value for iteration
+
+local Matheds = {
+    step = function(t, inc) return t + inc end,
+    mul  = function(t, mul) return t * mul end,
+    wrap = function(t, min, max)
+        if min == 0 then return t % max
+        else return (t - min) % (max - min) + min end
+    end,
+}
+
 local Mathmt = {
     __unm = function(a)   return Asl.math{'~', a} end,
     __add = function(a,b) return Asl.math{'+', a, b} end,
@@ -119,6 +128,20 @@ local Mathmt = {
     __mul = function(a,b) return Asl.math{'*', a, b} end,
     __div = function(a,b) return Asl.math{'/', a, b} end,
     __mod = function(a,b) return Asl.math{'%', a, b} end, -- % is used to wrap to a range
+    __len = function(a)   return Asl.math{'#', a} end, -- freeze operator for mutables
+    __index = function(t, ix)
+        local fn = Matheds[ix]
+        if fn then
+            if t[1] == '#' then -- if parent is #(freeze), peel it off
+                t = t[2] -- NOTE this doesn't change the self table, must close over
+            else -- ==first method ==parent is DYN. convert it to NMUT
+                t[2] = {'NMUT', t[2]}
+            end
+            return function(nop, ...) -- ignore self, instead close over above 't'
+                return Asl.math{'#', fn(t, ...)}
+            end
+        end
+    end, -- enable method-chain on dynamics
 }
 function Asl.math(tab) return setmetatable(tab, Mathmt) end -- overload table with arithmetic semantics
 

--- a/lua/output.lua
+++ b/lua/output.lua
@@ -60,7 +60,6 @@ Output.__index = function(self, ix)
             set_output_scale(self.channel, table.unpack(args))
         end
     elseif ix == 'dyn' then return self.asl.dyn
-    elseif ix == 'mutable' then return self.asl.dyn -- forward mutable to dyn as they share named vars
     end
 end
 


### PR DESCRIPTION
Changes the syntax for dynamic values in ASL2, allowing for more precise control over how parameters will be varied per-breakpoint.

The concept of `mutable` values is removed (or hidden from userspace at least), instead allowing `dyn` values to have mutation-descriptions method-chained onto them.

```lua
-- dynamic variables are same as before
dyn{time = 3} -- create a dynamic variable

-- mutation-chains can be added to change the dyn value
dyn{time = 3}:step(1) -- step will add or subtract it's argument on each usage
  -- each time dyn.time is accessed, the value will increase by 1

-- multiplication is also available for exponential changes
dyn{freq = 1}:mul(2) -- freq will double every time dyn.freq is used

-- multiple mutations can be chained for complex effects
-- these results can be wrapped into a range, for cycling effects
dyn{volts = 0}:step(1):wrap(-5,5)
  -- step up in increments of 1V, wrapping into the (-5 .. +5) range

-- parameters to the mutations can also by dynamic variables
dyn{x = 1}:mul(dyn{growth = 0.99}) -- value of 1 decreasing exponentially toward 0

-- eg: apply inside an ASL and demonstrate dynamic updates
-- the dynamic chain updates the voltage the ramp-lfo will rise to
output[1](
  loop{ to( dyn{height = 1}:mul( dyn{growth = 0.99}), 0.1 )
      , to(0, 0)
      })

output[1].dyn.height = 2 -- force the lfo height to 2V
output[1].dyn.growth = 1.1 -- increase height by 10% at each call

-- note that wrap can be used without a step or mul
-- this is useful for avoiding invalid values when setting via `dyn.*`
output[1]( loop{ to( 5, dyn{rate=1}:wrap(0.1, 10) )
               , to( 0, 0)
               }
output[1].dyn.rate = 2 -- updates LFO rate to 2seconds
output[1].dyn.rate = 11 -- wraps LFO rate to 1second
```

This last concept will make more sense when other range-behaviours are ready. I'll be adding `clamp` to limit to fixed range without the roll-over of wrap. And also adding `bounce` which will invert the operation step/mul operation when reaching the wrap point -- allowing for triangular modulations.