### PR TITLE
fix dofile when called from a coroutine

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -50,20 +50,20 @@
 #define WATCHDOG_COUNT     2        // how many watchdogs before 'frozen'
 
 const struct lua_lib_locator Lua_libs[] =
-    { { "lua_crowlib"   , lua_crowlib   }
-    , { "lua_asl"       , lua_asl       }
-    , { "lua_asllib"    , lua_asllib    }
-    , { "lua_clock"     , lua_clock     }
-    , { "lua_metro"     , lua_metro     }
-    , { "lua_input"     , lua_input     }
-    , { "lua_output"    , lua_output    }
-    , { "lua_public"    , lua_public    }
-    , { "lua_ii"        , lua_ii        }
-    , { "build_iihelp"  , build_iihelp  }
-    , { "lua_calibrate" , lua_calibrate }
-    , { "lua_sequins"   , lua_sequins   }
-    , { "lua_quote"     , lua_quote     }
-    , { NULL            , NULL          }
+    { { "lua_crowlib"   , lua_crowlib   , true}
+    , { "lua_asl"       , lua_asl       , true}
+    , { "lua_asllib"    , lua_asllib    , true}
+    , { "lua_clock"     , lua_clock     , false}
+    , { "lua_metro"     , lua_metro     , true}
+    , { "lua_input"     , lua_input     , true}
+    , { "lua_output"    , lua_output    , true}
+    , { "lua_public"    , lua_public    , true}
+    , { "lua_ii"        , lua_ii        , false}
+    , { "build_iihelp"  , build_iihelp  , false}
+    , { "lua_calibrate" , lua_calibrate , true}
+    , { "lua_sequins"   , lua_sequins   , true}
+    , { "lua_quote"     , lua_quote     , true}
+    , { NULL            , NULL          , true}
     };
 
 // Basic crow script
@@ -190,25 +190,19 @@ close_LL:
     return retval;
 }
 
-// STRIPPED removes debug info from crow libs to reduce RAM usage
-// TODO could flag this per file if we need debug info in some files
-#define STRIPPED 1
-static int _open_lib( const struct lua_lib_locator* lib, const char* name )
+static int _open_lib( lua_State *L, const struct lua_lib_locator* lib, const char* name )
 {
     uint8_t i = 0;
     while( lib[i].addr_of_luacode != NULL ){
         if( !strcmp( name, lib[i].name ) ){ // if the strings match
-            if( _load_chunk(L, lib[i].addr_of_luacode, STRIPPED) ){
-            // if( luaL_loadstring(L, lib[i].addr_of_luacode) ){ // old version. same as STRIPPED == 0
-                 printf("can't load library: %s\n", (char*)lib[i].name );
-                // lua error
+            if( _load_chunk(L, lib[i].addr_of_luacode, lib[i].stripped) ){
+                printf("can't load library: %s\n", (char*)lib[i].name );
                 printf( "%s\n", (char*)lua_tostring( L, -1 ) );
                 lua_pop( L, 1 );
                 return -1; // error
             }
             if( lua_pcall(L, 0, LUA_MULTRET, 0) ){
                 printf("can't exec library: %s\n", (char*)lib[i].name );
-                // lua error
                 printf( "%s\n", (char*)lua_tostring( L, -1 ) );
                 lua_pop( L, 1 );
                 return -1; // error
@@ -224,12 +218,12 @@ static int _dofile( lua_State *L )
 {
     const char* l_name = luaL_checkstring(L, 1);
     lua_pop( L, 1 );
-    switch( _open_lib( Lua_libs, l_name ) ){
+    switch( _open_lib( L, Lua_libs, l_name ) ){
         case -1: goto fail;
         case 1: return 1;
         default: break;
     }
-    switch( _open_lib( Lua_ii_libs, l_name ) ){
+    switch( _open_lib( L, Lua_ii_libs, l_name ) ){
         case -1: goto fail;
         case 1: return 1;
         default: break;

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -49,17 +49,18 @@
 #define WATCHDOG_FREQ      0x100000 // ~1s how often we run the watchdog
 #define WATCHDOG_COUNT     2        // how many watchdogs before 'frozen'
 
+// mark the 3rd arg 'false' if you need to debug that library
 const struct lua_lib_locator Lua_libs[] =
     { { "lua_crowlib"   , lua_crowlib   , true}
     , { "lua_asl"       , lua_asl       , true}
     , { "lua_asllib"    , lua_asllib    , true}
-    , { "lua_clock"     , lua_clock     , false}
+    , { "lua_clock"     , lua_clock     , true}
     , { "lua_metro"     , lua_metro     , true}
     , { "lua_input"     , lua_input     , true}
     , { "lua_output"    , lua_output    , true}
     , { "lua_public"    , lua_public    , true}
-    , { "lua_ii"        , lua_ii        , false}
-    , { "build_iihelp"  , build_iihelp  , false}
+    , { "lua_ii"        , lua_ii        , true}
+    , { "build_iihelp"  , build_iihelp  , true}
     , { "lua_calibrate" , lua_calibrate , true}
     , { "lua_sequins"   , lua_sequins   , true}
     , { "lua_quote"     , lua_quote     , true}

--- a/lib/lualink.h
+++ b/lib/lualink.h
@@ -1,12 +1,17 @@
 #pragma once
 
 #include <stdint.h>
+#include <stdbool.h>
 
 // Lua itself
 #include "../submodules/lua/src/lua.h" // lua_State*
 
 typedef void (*ErrorHandler_t)(char* error_message);
-struct lua_lib_locator{ const char* name; const char* addr_of_luacode; };
+struct lua_lib_locator{
+    const char* name;
+    const char* addr_of_luacode;
+    const bool stripped;
+};
 
 extern volatile int CPU_count; // count from main.c
 

--- a/util/ii_lualinker.lua
+++ b/util/ii_lualinker.lua
@@ -9,7 +9,7 @@ function make_lualink(files)
     ll = ll .. '\n'
             .. 'const struct lua_lib_locator Lua_ii_libs[] = {\n'
     for _,f in ipairs(files) do
-        ll = ll .. '\t{ \"build_ii_' .. f.lua_name .. '\", build_ii_' .. f.lua_name .. ' },\n'
+        ll = ll .. '\t{ \"build_ii_' .. f.lua_name .. '\", build_ii_' .. f.lua_name .. ', true },\n'
     end
     ll = ll .. '\t{ NULL, NULL } };\n'
     return ll


### PR DESCRIPTION
Fixes #419 

When calling an `ii` function for the first time from within a `clock` coroutine, it would load the file but fail to return the table to the coroutine, abandoning it to the GC.

This was caused by the custom `dofile` implementation using a global pointer to the `lua_State`, rather than the received pointer from the VM. This breaks when called from a coroutine because a lua coroutine is essentially a `lua_State` object wrapped in a 'LUA_TTHREAD' object. Thus we would push the loaded table into the main thread's stack, rather than the coroutine's stack.

---

Additionally, a new 'strip_debug' flag is added per lua-library in `lib/lualink.c`. If you are debugging an issue in any of the on-board lua libraries, set the flag to `false` for that file so you get accurate line-numbers when errors arise.