### PR TITLE
Fixes docker run command for bash shell in dev docs

### DIFF
--- a/readme-development.md
+++ b/readme-development.md
@@ -34,7 +34,7 @@ container.
 git clone --recursive --config core.autocrlf=input https://github.com/monome/crow
 cd crow
 docker build . -t crow-dev
-docker run --rm -it -v "$(pwd)":/target crow-dev bash
+docker run --rm -it -v "$(pwd)":/target --entrypoint /bin/bash crow-dev
 ```
 
 and then `make` to build, or use `docker run --rm -it -v


### PR DESCRIPTION
This change updates the documentation to reflect that the `ENTRYPOINT` needs to be explicitly set to `bash`, otherwise the container execution will interpret "bash" as an argument.

I believe this could also be resolved via changes to the Dockerfile: changing `ENTRYPOINT` to `CMD` will allow the behavior you describe in the doc. I'm not sure of the exact use case (i.e. where else this container is run...), but [if you're trying to set the _default_ but overridable execution flow](https://docs.docker.com/engine/reference/builder/#cmd) then `CMD` might be a better fit.