### PR TITLE
Re-init I2C HAL layer when setting address

### DIFF
--- a/lib/ii.c
+++ b/lib/ii.c
@@ -115,6 +115,8 @@ void ii_set_address( uint8_t index ){
         default: break;
     }
     I2C_SetAddress( i2c );
+    ii_deinit();
+    ii_init(i2c);
 }
 
 


### PR DESCRIPTION
Proposed fix for #430.

Confirmed to enable Teletype `CROW.SEL 2` and `CROW2: ...` when `ii.set_address(2)` is run on crow.  But is this the right way to solve the problem?