### PR TITLE
Clock fix for more accurate internal timebase counter

### DIFF
--- a/lib/clock.c
+++ b/lib/clock.c
@@ -268,6 +268,7 @@ void clock_internal_start( float new_beat, bool transport_start )
 
 void clock_internal_stop(void)
 {
+    internal.running = false; // actually stop the sync clock
     clock_stop_from( CLOCK_SOURCE_INTERNAL ); // user callback
 }
 

--- a/lib/clock.c
+++ b/lib/clock.c
@@ -248,7 +248,7 @@ void clock_internal_init(void)
 
 void clock_internal_set_tempo( float bpm )
 {
-    internal_interval_seconds = 60.0 / bpm;
+    internal_interval_seconds = (double)60.0 / (double)bpm;
     clock_internal_start( internal_beat, false );
 }
 


### PR DESCRIPTION
Fixes #437 

Previously the quantization of the 1ms timebase of the clock system was causing the internal clock to drag. This manifested in double-triggers as clocks (using `clock.sync()`) would resume slightly before their intended time. Or more accurately, the clocks would resume at the right time, but the internal clock would have not quite got there in time.

This PR does 2 things to fix the problem:
1) internal clock resumes (0.0 .. 1.0) ms early, to ensure the 'beat' is advanced before any other resuming clocks.
2) the quantization error between clock calls is accumulated & offsets the clock pulse time when it exits (0 .. 1.0) range.

This solves the double-triggering problem in #437 and makes the internal clock more accurate relative to `metro` and `asl`.

Additionally this PR:
* Fixes behaviour of `clock.stop()` which would previously do nothing other than trigger `clock.internal.stop()`
* Refactors the C implementation of clock_sync (i had a hard time grokking it, when i went to fix this)
* Abstracts a few new functions for calculating timings