### PR TITLE
add seeded random option

### DIFF
--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -95,6 +95,12 @@ end
 ii_follow_reset()
 
 
+--- Pseudo RNG
+-- use s prefix for seeded random
+math.srandom = math.random
+math.srandomseed = math.randomseed
+
+
 --- True Random Number Generator
 -- redefine library function to use stm native rng
 math.random = function(a,b)


### PR DESCRIPTION
previously we overwrote the built-in random function in Lua with the true RNG in the STM32.

this just aliases 'normal' (pseudo) RNG with a leading `s` (for seeded).

usage:
```lua
-- print some seeded random numbers
print(math.srandom()) --> 0.690001
print(math.srandom()) --> 0.5054184

-- reset crow
^^r

-- printing srandom again will produce the same sequence
print(math.srandom()) --> 0.690001
print(math.srandom()) --> 0.5054184

-- you can seed the PRNG yourself
math.srandomseed(314)
print(math.srandom()) --> 0.7310537
-- re-seeding to the same number always produces the same sequence
math.srandomseed(314)
print(math.srandom()) --> 0.7310537
```