### PR TITLE
Caw module can now stream a const char bigger than the TX buffer

### DIFF
--- a/lib/caw.c
+++ b/lib/caw.c
@@ -8,6 +8,7 @@
 #define USB_RX_BUFFER 2048
 static char reader[USB_RX_BUFFER];
 static int16_t pReader = 0;
+static const char* queued_ptr = NULL;
 
 void Caw_Init( int timer_index )
 {

--- a/lib/caw.c
+++ b/lib/caw.c
@@ -54,11 +54,6 @@ void Caw_send_luachunk( char* text )
     );
 }
 
-static void queue_stream( const char* ptr )
-{
-    queued_ptr = ptr;
-}
-
 void Caw_stream_constchar( const char* stream )
 {
     size_t len = strlen(stream);
@@ -70,7 +65,7 @@ void Caw_stream_constchar( const char* stream )
         Caw_send_raw( (uint8_t*)stream, space ); // fill the buffer
 
         // here's the remainder that didn't fit
-        queue_stream( stream + space );
+        queued_ptr = stream + space;
     }
 }
 

--- a/lib/caw.c
+++ b/lib/caw.c
@@ -23,10 +23,9 @@ void Caw_DeInit( void )
 
 void Caw_send_raw( uint8_t* buf, uint32_t len )
 {
-uint32_t old_primask = __get_PRIMASK();
-__disable_irq();
-    USB_tx_enqueue( buf, len );
-__set_PRIMASK( old_primask );
+    BLOCK_IRQS(
+        USB_tx_enqueue( buf, len );
+    );
 }
 
 void Caw_printf( char* text, ... )
@@ -49,23 +48,51 @@ void Caw_printf( char* text, ... )
 void Caw_send_luachunk( char* text )
 {
     const uint8_t newline[] = "\n\r";
-uint32_t old_primask = __get_PRIMASK();
-__disable_irq();
-    USB_tx_enqueue( (uint8_t*)text, strlen(text) );
-    USB_tx_enqueue( (uint8_t*)newline, 2 );
-__set_PRIMASK( old_primask );
+    BLOCK_IRQS(
+        USB_tx_enqueue( (uint8_t*)text, strlen(text) );
+        USB_tx_enqueue( (uint8_t*)newline, 2 );
+    );
+}
+
+static void queue_stream( const char* ptr )
+{
+    queued_ptr = ptr;
+}
+
+void Caw_stream_constchar( const char* stream )
+{
+    size_t len = strlen(stream);
+    size_t space = USB_tx_space();
+    if( len < (space-2) ){ // leave space for newline
+        Caw_send_luachunk( (char*)stream ); // send it normally
+    } else {
+        // break up the stream into chunks
+        Caw_send_raw( (uint8_t*)stream, space ); // fill the buffer
+
+        // here's the remainder that didn't fit
+        queue_stream( stream + space );
+    }
+}
+
+void Caw_send_queued( void )
+{
+    if( queued_ptr != NULL
+     && USB_tx_is_ready() ){
+        const char* p = queued_ptr; // copy
+        queued_ptr = NULL; // clear before calling
+        Caw_stream_constchar( p ); // may reinstate queued_ptr
+    }
 }
 
 void Caw_send_luaerror( char* error_msg )
 {
     const uint8_t leader[] = "\\";
     const uint8_t newline[] = "\n\r";
-uint32_t old_primask = __get_PRIMASK();
-__disable_irq();
-    USB_tx_enqueue( (uint8_t*)leader, 1 );
-    USB_tx_enqueue( (uint8_t*)error_msg, strlen(error_msg) );
-    USB_tx_enqueue( (uint8_t*)newline, 2 );
-__set_PRIMASK( old_primask );
+    BLOCK_IRQS(
+        USB_tx_enqueue( (uint8_t*)leader, 1 );
+        USB_tx_enqueue( (uint8_t*)error_msg, strlen(error_msg) );
+        USB_tx_enqueue( (uint8_t*)newline, 2 );
+    );
 }
 
 void Caw_send_value( uint8_t type, float value )

--- a/lib/caw.h
+++ b/lib/caw.h
@@ -26,6 +26,8 @@ void Caw_printf( char* text, ... );
 void Caw_send_luachunk( char* text );
 void Caw_send_luaerror( char* error_msg );
 void Caw_send_value( uint8_t type, float value ); // enum the type
+void Caw_stream_constchar( const char* stream );
+void Caw_send_queued( void );
 
 C_cmd_t Caw_try_receive( void );
 char* Caw_get_read( void );

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -609,7 +609,7 @@ static int _ii_list_commands( lua_State *L )
 {
     uint8_t address = luaL_checkinteger(L, 1);
     printf("i2c help %i\n", address);
-    Caw_send_luachunk( (char*)ii_list_cmds(address) );
+    Caw_stream_constchar( ii_list_cmds(address) );
     lua_pop(L, 1);
     return 0;
 }

--- a/main.c
+++ b/main.c
@@ -70,5 +70,6 @@ int main(void)
         clock_update();
         event_next(); // check/execute single event
         ii_leader_process();
+        Caw_send_queued();
     }
 }

--- a/usbd/usbd_cdc_interface.c
+++ b/usbd/usbd_cdc_interface.c
@@ -191,11 +191,9 @@ size_t USB_tx_space( void )
 }
 int USB_tx_is_ready( void )
 {
-    // ensure the bufer is empty
-    // and the CDC driver has finished any active transfer
     USBD_CDC_HandleTypeDef *hcdc = USBD_Device.pClassData;
-    return (UserTxDataLen == 0)
-        && (hcdc->TxState == 0);
+    return (UserTxDataLen == 0)  // ensure the bufer is empty
+        && (hcdc->TxState == 0); // CDC has finished active tx
 }
 
 // interrupt sends out any queued data

--- a/usbd/usbd_cdc_interface.c
+++ b/usbd/usbd_cdc_interface.c
@@ -166,6 +166,11 @@ static int8_t CDC_Itf_Control (uint8_t cmd, uint8_t* pbuf, uint16_t length)
 // user call copies the data to the tx queue
 void USB_tx_enqueue( uint8_t* buf, uint32_t len )
 {
+    // WARNING: UserTxDataLen having room doesn't necessarily mean
+    // the buffer is junk data. There can still be an ongoing transfer
+    // using the end of the buffer (usually just the last few bytes).
+    // Check USB_tx_is_ready()==1 if you need to be sure no data is lost.
+    // especially if *streaming* data to the CDC.
     if( (UserTxDataLen + len) >= APP_TX_DATA_SIZE ){
         len = APP_TX_DATA_SIZE - UserTxDataLen; // stop buffer overflow
     }
@@ -178,6 +183,19 @@ void USB_tx_enqueue( uint8_t* buf, uint32_t len )
           , len
           );
     UserTxDataLen += len;
+}
+
+size_t USB_tx_space( void )
+{
+    return (size_t)(APP_TX_DATA_SIZE - UserTxDataLen);
+}
+int USB_tx_is_ready( void )
+{
+    // ensure the bufer is empty
+    // and the CDC driver has finished any active transfer
+    USBD_CDC_HandleTypeDef *hcdc = USBD_Device.pClassData;
+    return (UserTxDataLen == 0)
+        && (hcdc->TxState == 0);
 }
 
 // interrupt sends out any queued data

--- a/usbd/usbd_cdc_interface.h
+++ b/usbd/usbd_cdc_interface.h
@@ -66,6 +66,8 @@ extern int timer_index;
 void CDC_clear_buffers();
 
 void USB_tx_enqueue( uint8_t* buf, uint32_t len );
+size_t USB_tx_space( void );
+int USB_tx_is_ready( void );
 uint8_t USB_rx_dequeue_LOCK( uint8_t** buf, uint32_t* len );
 void USB_rx_dequeue_UNLOCK( void );
 


### PR DESCRIPTION
Fixes #264 

Specifically solves usage of `ii.<module>.help()` for modules with a lot of commands (kria, jf, txo, disting etc).

Previously, only the first 1024 bytes would be sent, after which the USB TX buffer would be full & discard the rest of a message. This PR adds a queue system so that longer blocks of chars will be broken up across multiple USB frames.

Note, this solution only works with `const char*` strings as we don't need to copy the data anywhere. It cannot be applied to scripts that generate giant strings.

//

While fixing this i discovered that the code that marks the TX buffer as empty doesn't guarantee that the buffer has been fully consumed. In practice I was able to trample the last dozen characters or so, when spamming the USB port. Making a note here so it can be searched, but not opening an issue as i don't think it's pertinent to fix for crow's usage.

If someone needs to fix it, look at the new `USB_tx_is_ready()` fn in `usbd/usbd_cdc_interface.c` for how to check if the buffer should be released.