### PR TITLE
reset i2c driver so change of address takes effect

### DIFF
--- a/ll/i2c.c
+++ b/ll/i2c.c
@@ -180,6 +180,15 @@ uint8_t I2C_GetAddress( void )
 void I2C_SetAddress( uint8_t address )
 {
     i2c_handle.Init.OwnAddress1 = address << 1;
+    I2C_DeInit();
+    if( lead_response != NULL ){
+        I2C_Init( address
+                , lead_response
+                , follow_action
+                , follow_request
+                , error_action
+                );
+    }
 }
 
 


### PR DESCRIPTION
Fixes #430 

Special thanks to @beels for the outline & hardwork digging through the source.

This change causes the `i2c` drive to be reinitialized when changing address as it seems to be the only way to have the address change take effect.