### PR TITLE
Sequins strings + other goodies

### DIFF
--- a/lua/sequins.lua
+++ b/lua/sequins.lua
@@ -1,7 +1,4 @@
 --- sequins
--- nestable tables with sequencing behaviours & control flow
--- TODO i think ASL can be defined in terms of a sequins...
-
 
 local S = {}
 
@@ -19,21 +16,28 @@ function S.new(t)
     t = totable(t) -- convert a string to a table of chars
     -- wrap a table in a sequins with defaults
     local s = { data   = t
-              , length = #t -- memoize table length for speed
-              , set_ix = 1 -- force first stage to start at elem 1
-              , ix     = 1 -- current val
-              , n      = 1 -- can be a sequin
+              , length = #t -- memoize for efficiency
+              , ix     = 1
+              , qix    = 1 -- force 1st value to 1st step
+              , n      = 1 -- store the step val (can be a sequins)
+              , flw    = {} -- store any applied flow modifiers
+              , fn     = {} -- store a transformer function & any additional arguments
               }
-    s.action = {up = s}
-    setmetatable(s, S)
-    return s
+    return setmetatable(s, S)
 end
 
 local function wrap_index(s, ix) return ((ix - 1) % s.length) + 1 end
 
--- TODO generalize to cover every/count/times etc
-function S.setdata(self, t)
-    if S.is_sequins(t) then t = t.data end -- handle sequins as input
+function S:is_sequins() return getmetatable(self) == S end
+
+function S:setdata(t)
+    if S.is_sequins(t) then
+        t = t.data -- handle sequins as input
+
+        -- FIXME generalize to cover flow-mods & transforms
+        -- only need to worry about it in here
+        -- otherwise it's just a raw table (hence untouched)
+    end
 
     t = totable(t) -- convert a string to a table of chars
 
@@ -50,18 +54,7 @@ function S.setdata(self, t)
     self.ix = wrap_index(self, self.ix)
 end
 
-function S.is_sequins(t) return getmetatable(t) == S end
-
-local function turtle(t, fn)
-    -- apply fn to all nested sequins. default to 'next'
-    if S.is_sequins(t) then
-        if fn then
-            return fn(t)
-        else return S.next(t) end
-    end
-    return t
-end
-
+-- nb: 2nd arg 'cp' is for internal recursive use only
 function S.copy(og, cp)
     cp = cp or {}
     local og_type = type(og)
@@ -76,131 +69,108 @@ function S.copy(og, cp)
             end
             setmetatable(copy, S.copy(getmetatable(og), cp))
         end
-    else -- literal value
-        copy = og
-    end
+    else copy = og end -- literal value
     return copy
 end
+
+function S:peek() return self.data[self.ix] end
 
 
 ------------------------------
 --- control flow execution
 
-function S.next(self)
-    local act = self.action
-    if act.action then
-        return S.do_ctrl(act)
-    else return S.do_step(act) end
+local function turtle(t, fn)
+    -- apply fn to all nested sequins
+    fn = fn or S.next -- default to S.next
+    if S.is_sequins(t) then return fn(t) end -- unwrap
+    return t -- literal value
 end
 
-function S.select(self, ix)
-    rawset(self, 'set_ix', ix)
+local function do_step(s)
+    -- if .qix is set, it will be used, rather than incrementing by s.n
+    local newix = wrap_index(s, s.qix or s.ix + turtle(s.n))
+    -- pull data from new index (unwrap if it's a sequins)
+    local retval, exec = turtle(s.data[newix])
+    -- handle messaging from child sequins
+    if exec ~= 'again' then s.ix = newix; s.qix = nil end
+    -- FIXME add protection for list of dead sequins. for now we just recur, hoping for a live sequin in nest
+    if retval == 'skip' or retval == 'dead' then return S.next(s) end
+    return retval, exec
+end
+
+S.flows = {
+    every = function(f,n) return (f.ix % n) ~= 0 end,
+    times = function(f,n) return f.ix > n end,
+    count = function(f,n)
+        if f.ix < n then return 'again'
+        else f.ix = 0 end
+    end
+}
+
+function do_flow(s, k)
+    local f = s.flw[k] -- check if times exists
+    if f then
+        f.ix = f.ix + 1
+        return S.flows[k](f, turtle(f.n))
+    end
+end
+
+function S.next(s)
+    if do_flow(s, 'every') then return 'skip' end
+    if do_flow(s, 'times') then return 'dead' end
+    local again = do_flow(s, 'count')
+    if again then
+        local e = s.flw.every
+        if e then e.ix = e.ix - 1 end -- undo every advance
+    end
+    return do_step(s), again
+end
+
+function S:step(n) self.n = n; return self end
+
+function S.flow(s, k, n) s.flw[k] = {n=n, ix=0}; return s end
+function S:every(n) return self:flow('every',n) end
+function S:count(n) return self:flow('count',n) end
+function S:times(n) return self:flow('times',n) end
+function S:all() return self:flow('count',#self) end
+
+function S:select(ix)
+    rawset(self, 'qix', ix) -- qix may be nil, hence rawset
     return self
 end
 
-function S.do_step(act)
-    local s = act.up
-    -- if .set_ix is set, it will be used, rather than incrementing by s.n
-    local newix = wrap_index(s, s.set_ix or s.ix + turtle(s.n))
-    local retval, exec = turtle(s.data[newix])
-    if exec ~= 'again' then s.ix = newix; s.set_ix = nil end
-    -- FIXME add protection for list of dead sequins. for now we just recur, hoping for a live sequin in nest
-    if exec == 'skip' then return S.next(s) end
-    return retval, exec
+function S:reset()
+    self:select(1)
+    for _,v in ipairs(self.data) do turtle(v, S.reset) end
+    for _,v in pairs(self.flw) do
+        v.ix = 0
+        turtle(v.n, S.reset)
+    end
 end
 
 
 ------------------------------
---- control flow manipulation
-
-function S.do_ctrl(act)
-    act.ix = act.ix + 1
-    if not act.cond or act.cond(act) then
-        retval, exec = S.next(act)
-        if exec then act.ix = act.ix - 1 end -- undo increment
-    else
-        retval, exec = {}, 'skip'
-    end
-    if act.rcond then
-        if act.rcond(act) then
-            if exec == 'skip' then retval, exec = S.next(act)
-            else exec = 'again' end
-        end
-    end
-    return retval, exec
-end
-
-function S.reset(self)
-    self.ix = self.length
-    for _,v in ipairs(self.data) do turtle(v, S.reset) end
-    local a = self.action
-    while a.ix do
-        a.ix = 0
-        turtle(a.n, S.reset)
-        a = a.action
-    end
-end
-
---- behaviour modifiers
-function S.step(self, s) self.n = s; return self end
-
-
-function S.extend(self, t)
-    self.action = { up     = self -- containing sequins
-                  , action = self.action -- wrap nested actions
-                  , ix     = 0
-                  }
-    for k,v in pairs(t) do self.action[k] = v end
-    return self
-end
-
-function S._every(self)
-    return (self.ix % turtle(self.n)) == 0
-end
-
-function S._times(self)
-    return self.ix <= turtle(self.n)
-end
-
-function S._count(self)
-    if self.ix < turtle(self.n) then return true
-    else self.ix = 0 end -- reset
-end
-
-function S.cond(self, p) return S.extend(self, {cond = p}) end
-function S.condr(self, p) return S.extend(self, {cond = p, rcond = p}) end
-function S.every(self, n) return S.extend(self, {cond = S._every, n = n}) end
-function S.times(self, n) return S.extend(self, {cond = S._times, n = n}) end
-function S.count(self, n) return S.extend(self, {rcond = S._count, n = n}) end
-
---- helpers in terms of core
-function S.all(self) return self:count(self.length) end
-function S.once(self) return self:times(1) end
-function S.peek(self) return self.data[self.ix] end
-
-
 --- metamethods
 
+-- calling the sequins library will create a new sequins object (S:new)
+-- calling a sequins object will produce a new value (S:next)
 S.__call = function(self, ...)
     return (self == S) and S.new(...) or S.next(self)
 end
 
 S.metaix = { settable = S.setdata
            , step     = S.step
-           , cond     = S.cond
-           , condr    = S.condr
+           , flow     = S.flow
            , every    = S.every
            , times    = S.times
            , count    = S.count
            , all      = S.all
-           , once     = S.once
            , reset    = S.reset
            , select   = S.select
            , peek     = S.peek
            , copy     = S.copy
            }
 S.__index = function(self, ix)
-    -- runtime calls to step() and select() should return values, not functions
     if type(ix) == 'number' then return self.data[ix]
     else
         return S.metaix[ix]
@@ -214,15 +184,23 @@ S.__newindex = function(self, ix, v)
 end
 
 S.__tostring = function(t)
-    -- will recursively call for other sequins
+    -- data
     local st = {}
     for i=1,t.length do
         st[i] = tostring(t.data[i])
     end
-    local s = string.format('s[%i]{%s}', t.ix, table.concat(st,','))
+    local s = string.format('s[%i]{%s}', t.qix or t.ix, table.concat(st,','))
 
-    -- TODO modifiers: need to add metadata to modifiers so they can be introspected
-    -- TODO transforms: not sure what the structure is yet
+    -- modifiers
+    for k,v in pairs(t.flw) do
+        -- TODO do we need to print current counters?
+        s = string.format('%s:%s(%s)',s, k:sub(1,1), tostring(v.n))
+    end
+
+    -- transformer
+    if #t.fn > 0 then
+        s = string.format('%s:fn(%s)',s, k:sub(1,1), tostring(t.fn[1]))
+    end
 
     return s
 end
@@ -231,6 +209,4 @@ end
 S.__len = function(t) return t.length end
 
 
-setmetatable(S, S)
-
-return S
+return setmetatable(S, S)

--- a/lua/sequins.lua
+++ b/lua/sequins.lua
@@ -31,11 +31,21 @@ end
 
 local function wrap_index(s, ix) return ((ix - 1) % s.length) + 1 end
 
--- can this be generalized to cover every/count/times etc
+-- TODO generalize to cover every/count/times etc
 function S.setdata(self, t)
+    if S.is_sequins(t) then t = t.data end -- handle sequins as input
+
     t = totable(t) -- convert a string to a table of chars
 
-    self.data   = t
+    for i=1,#t do
+        if S.is_sequins(t[i]) and S.is_sequins(self.data[i]) then
+            self.data[i]:settable(t[i]) -- recurse nested sequins
+        else
+            self.data[i] = t[i] -- copy table piecemeal
+        end
+    end
+    self.data[#t+1] = nil -- disregard any surplus data
+
     self.length = #t
     self.ix = wrap_index(self, self.ix)
 end

--- a/lua/sequins.lua
+++ b/lua/sequins.lua
@@ -196,6 +196,10 @@ S.__tostring = function(t)
     return s
 end
 
+-- use memoized data length, aka #(t.data)
+S.__len = function(t) return t.length end
+
+
 setmetatable(S, S)
 
 return S

--- a/lua/sequins.lua
+++ b/lua/sequins.lua
@@ -52,6 +52,26 @@ local function turtle(t, fn)
     return t
 end
 
+function S.copy(og, cp)
+    cp = cp or {}
+    local og_type = type(og)
+    local copy = {}
+    if og_type == 'table' then
+        if cp[og] then -- handle duplicate refs to an internal table
+            copy = cp[og]
+        else
+            cp[og] = copy
+            for og_k, og_v in next, og, nil do
+                copy[S.copy(og_k, cp)] = S.copy(og_v, cp)
+            end
+            setmetatable(copy, S.copy(getmetatable(og), cp))
+        end
+    else -- literal value
+        copy = og
+    end
+    return copy
+end
+
 
 ------------------------------
 --- control flow execution
@@ -167,6 +187,7 @@ S.metaix = { settable = S.setdata
            , reset    = S.reset
            , select   = S.select
            , peek     = S.peek
+           , copy     = S.copy
            }
 S.__index = function(self, ix)
     -- runtime calls to step() and select() should return values, not functions

--- a/lua/sequins.lua
+++ b/lua/sequins.lua
@@ -5,7 +5,18 @@
 
 local S = {}
 
+-- convert a string to a table of chars
+function totable(t)
+    if type(t) == 'string' then
+        local tmp = {}
+        t:gsub('.', function(c) table.insert(tmp,c) end)
+        return tmp
+    end
+    return t
+end
+
 function S.new(t)
+    t = totable(t) -- convert a string to a table of chars
     -- wrap a table in a sequins with defaults
     local s = { data   = t
               , length = #t -- memoize table length for speed
@@ -22,6 +33,8 @@ local function wrap_index(s, ix) return ((ix - 1) % s.length) + 1 end
 
 -- can this be generalized to cover every/count/times etc
 function S.setdata(self, t)
+    t = totable(t) -- convert a string to a table of chars
+
     self.data   = t
     self.length = #t
     self.ix = wrap_index(self, self.ix)

--- a/lua/sequins.lua
+++ b/lua/sequins.lua
@@ -182,6 +182,19 @@ S.__newindex = function(self, ix, v)
     end
 end
 
+S.__tostring = function(t)
+    -- will recursively call for other sequins
+    local st = {}
+    for i=1,t.length do
+        st[i] = tostring(t.data[i])
+    end
+    local s = string.format('s[%i]{%s}', t.ix, table.concat(st,','))
+
+    -- TODO modifiers: need to add metadata to modifiers so they can be introspected
+    -- TODO transforms: not sure what the structure is yet
+
+    return s
+end
 
 setmetatable(S, S)
 


### PR DESCRIPTION
a set of new features, shortcuts & nice-to-haves in the sequins library:

a sequins of a string is converted into a sequins of a table of characters, eg:
```lua
sequins"abc" --> sequins{'a', 'b', 'c'}
```

printing a sequins, now prints a representation of the execution state & data. should be very helpful in terms of debugging and being able to introspect the current status of a sequins.
```lua
s1 = sequins{1, 2, sequins{3, 4}}
s1(); s1() -- advance 2 steps
print(s1) --> s[2]{1,2,s[1]{3,4}}
```

the `#` length operator is now meaningfully supported on sequins. it will return the count of items in the top-level table (ie nested tables are treated as length-of-1:
```lua
s2 = sequins{1, 2, sequins{3, 4}}
print(#s2) -- 3
```

add a new `:copy()` method so that sequins can be duplicated. this is useful if you want to have 2 duplicate sequins (or to make permutations) but maintain their table counters separately:
```lua
s1 = sequins{1,2,3}
s2 = s1:copy()
s1() --> 1
s2() --> 1
```

the `:settable(t)` method is extended to handle nested sequins. if your sequins has the same structure (eg. element 3 is a sequins in both old & new tables) the execution state of the old table will be carried across. this means you can replace more complex sequences without restarting any nested elements. NB: does not copy flow-modifiers yet (eg. `every`, `count` etc).

additionally, the 'table' argument to settable can now be a table *or* a sequins (to make the syntax a little more flexible):
```lua
s1 = sequins{1,2,sequins{3,4}
for i=1,5 do s1() end -- step forward 5 steps
print(s1) --> s[2]{1,2,s[2]{3,4}}

s1:settable{5,6,sequins{7,8,9}}
print(s1) --> s[2]{5,6,s[2]{7,8,9}} -- table-length can change too!

s2 = sequins{'a','b',sequins{'c','d'}
s1:settable(s2) -- switch to another set of data, but maintain state
print(s1) --> s[2]{'a','b',s[2]{'c','d'}} -- table-length can change too!
```