### PR TITLE
sequins refactor for more predictable flow mods

### DIFF
--- a/lua/sequins.lua
+++ b/lua/sequins.lua
@@ -98,41 +98,32 @@ local function do_step(s)
     return retval, exec
 end
 
--- a really tight run-time function
+S.flows = {
+    every = function(f,n) return (f.ix % n) ~= 0 end,
+    times = function(f,n) return f.ix > n end,
+    count = function(f,n)
+        if f.ix < n then return 'again'
+        else f.ix = 0 end
+    end
+}
+
+function do_flow(s, k)
+    local f = s.flw[k] -- check if times exists
+    if f then
+        f.ix = f.ix + 1
+        return S.flows[k](f, turtle(f.n))
+    end
+end
+
 function S.next(s)
-    if S.do_every(s) then return 'skip' end
-    if S.do_times(s) then return 'dead' end
-    local again = S.do_count(s)
+    if do_flow(s, 'every') then return 'skip' end
+    if do_flow(s, 'times') then return 'dead' end
+    local again = do_flow(s, 'count')
     if again then
         local e = s.flw.every
         if e then e.ix = e.ix - 1 end -- undo every advance
     end
     return do_step(s), again
-end
-
-function S.do_every(s)
-    local e = s.flw.every -- check if every exists
-    if e then
-        e.ix = e.ix + 1
-        return (e.ix % turtle(e.n)) ~= 0
-    end
-end
-
-function S.do_times(s)
-    local t = s.flw.times -- check if times exists
-    if t then
-        t.ix = t.ix + 1
-        return t.ix > turtle(t.n)
-    end
-end
-
-function S.do_count(s)
-    local c = s.flw.count -- check if count exists
-    if c then
-        c.ix = c.ix + 1
-        if c.ix < turtle(c.n) then return 'again'
-        else c.ix = 0 end
-    end
 end
 
 function S:step(n) self.n = n; return self end

--- a/lua/sequins.lua
+++ b/lua/sequins.lua
@@ -1,7 +1,4 @@
 --- sequins
--- nestable tables with sequencing behaviours & control flow
--- TODO i think ASL can be defined in terms of a sequins...
-
 
 local S = {}
 
@@ -19,21 +16,28 @@ function S.new(t)
     t = totable(t) -- convert a string to a table of chars
     -- wrap a table in a sequins with defaults
     local s = { data   = t
-              , length = #t -- memoize table length for speed
-              , set_ix = 1 -- force first stage to start at elem 1
-              , ix     = 1 -- current val
-              , n      = 1 -- can be a sequin
+              , length = #t -- memoize for efficiency
+              , ix     = 1
+              , qix    = 1 -- force 1st value to 1st step
+              , n      = 1 -- store the step val (can be a sequins)
+              , flw    = {} -- store any applied flow modifiers
+              , fn     = {} -- store a transformer function & any additional arguments
               }
-    s.action = {up = s}
-    setmetatable(s, S)
-    return s
+    return setmetatable(s, S)
 end
 
 local function wrap_index(s, ix) return ((ix - 1) % s.length) + 1 end
 
--- TODO generalize to cover every/count/times etc
-function S.setdata(self, t)
-    if S.is_sequins(t) then t = t.data end -- handle sequins as input
+function S:is_sequins() return getmetatable(self) == S end
+
+function S:setdata(t)
+    if S.is_sequins(t) then
+        t = t.data -- handle sequins as input
+
+        -- FIXME generalize to cover flow-mods & transforms
+        -- only need to worry about it in here
+        -- otherwise it's just a raw table (hence untouched)
+    end
 
     t = totable(t) -- convert a string to a table of chars
 
@@ -50,18 +54,7 @@ function S.setdata(self, t)
     self.ix = wrap_index(self, self.ix)
 end
 
-function S.is_sequins(t) return getmetatable(t) == S end
-
-local function turtle(t, fn)
-    -- apply fn to all nested sequins. default to 'next'
-    if S.is_sequins(t) then
-        if fn then
-            return fn(t)
-        else return S.next(t) end
-    end
-    return t
-end
-
+-- nb: 2nd arg 'cp' is for internal recursive use only
 function S.copy(og, cp)
     cp = cp or {}
     local og_type = type(og)
@@ -76,131 +69,117 @@ function S.copy(og, cp)
             end
             setmetatable(copy, S.copy(getmetatable(og), cp))
         end
-    else -- literal value
-        copy = og
-    end
+    else copy = og end -- literal value
     return copy
 end
+
+function S:peek() return self.data[self.ix] end
 
 
 ------------------------------
 --- control flow execution
 
-function S.next(self)
-    local act = self.action
-    if act.action then
-        return S.do_ctrl(act)
-    else return S.do_step(act) end
+local function turtle(t, fn)
+    -- apply fn to all nested sequins
+    fn = fn or S.next -- default to S.next
+    if S.is_sequins(t) then return fn(t) end -- unwrap
+    return t -- literal value
 end
 
-function S.select(self, ix)
-    rawset(self, 'set_ix', ix)
+local function do_step(s)
+    -- if .qix is set, it will be used, rather than incrementing by s.n
+    local newix = wrap_index(s, s.qix or s.ix + turtle(s.n))
+    -- pull data from new index (unwrap if it's a sequins)
+    local retval, exec = turtle(s.data[newix])
+    -- handle messaging from child sequins
+    if exec ~= 'again' then s.ix = newix; s.qix = nil end
+    -- FIXME add protection for list of dead sequins. for now we just recur, hoping for a live sequin in nest
+    if retval == 'skip' or retval == 'dead' then return S.next(s) end
+    return retval, exec
+end
+
+-- a really tight run-time function
+function S.next(s)
+    if S.do_every(s) then return 'skip' end
+    if S.do_times(s) then return 'dead' end
+    local again = S.do_count(s)
+    if again then
+        local e = s.flw.every
+        if e then e.ix = e.ix - 1 end -- undo every advance
+    end
+    return do_step(s), again
+end
+
+function S.do_every(s)
+    local e = s.flw.every -- check if every exists
+    if e then
+        e.ix = e.ix + 1
+        return (e.ix % turtle(e.n)) ~= 0
+    end
+end
+
+function S.do_times(s)
+    local t = s.flw.times -- check if times exists
+    if t then
+        t.ix = t.ix + 1
+        return t.ix > turtle(t.n)
+    end
+end
+
+function S.do_count(s)
+    local c = s.flw.count -- check if count exists
+    if c then
+        c.ix = c.ix + 1
+        if c.ix < turtle(c.n) then return 'again'
+        else c.ix = 0 end
+    end
+end
+
+function S:step(n) self.n = n; return self end
+
+function S.flow(s, k, n) s.flw[k] = {n=n, ix=0}; return s end
+function S:every(n) return self:flow('every',n) end
+function S:count(n) return self:flow('count',n) end
+function S:times(n) return self:flow('times',n) end
+function S:all() return self:flow('count',#self) end
+
+function S:select(ix)
+    rawset(self, 'qix', ix) -- qix may be nil, hence rawset
     return self
 end
 
-function S.do_step(act)
-    local s = act.up
-    -- if .set_ix is set, it will be used, rather than incrementing by s.n
-    local newix = wrap_index(s, s.set_ix or s.ix + turtle(s.n))
-    local retval, exec = turtle(s.data[newix])
-    if exec ~= 'again' then s.ix = newix; s.set_ix = nil end
-    -- FIXME add protection for list of dead sequins. for now we just recur, hoping for a live sequin in nest
-    if exec == 'skip' then return S.next(s) end
-    return retval, exec
+function S:reset()
+    self:select(1)
+    for _,v in ipairs(self.data) do turtle(v, S.reset) end
+    for _,v in pairs(self.flw) do
+        v.ix = 0
+        turtle(v.n, S.reset)
+    end
 end
 
 
 ------------------------------
---- control flow manipulation
-
-function S.do_ctrl(act)
-    act.ix = act.ix + 1
-    if not act.cond or act.cond(act) then
-        retval, exec = S.next(act)
-        if exec then act.ix = act.ix - 1 end -- undo increment
-    else
-        retval, exec = {}, 'skip'
-    end
-    if act.rcond then
-        if act.rcond(act) then
-            if exec == 'skip' then retval, exec = S.next(act)
-            else exec = 'again' end
-        end
-    end
-    return retval, exec
-end
-
-function S.reset(self)
-    self.ix = self.length
-    for _,v in ipairs(self.data) do turtle(v, S.reset) end
-    local a = self.action
-    while a.ix do
-        a.ix = 0
-        turtle(a.n, S.reset)
-        a = a.action
-    end
-end
-
---- behaviour modifiers
-function S.step(self, s) self.n = s; return self end
-
-
-function S.extend(self, t)
-    self.action = { up     = self -- containing sequins
-                  , action = self.action -- wrap nested actions
-                  , ix     = 0
-                  }
-    for k,v in pairs(t) do self.action[k] = v end
-    return self
-end
-
-function S._every(self)
-    return (self.ix % turtle(self.n)) == 0
-end
-
-function S._times(self)
-    return self.ix <= turtle(self.n)
-end
-
-function S._count(self)
-    if self.ix < turtle(self.n) then return true
-    else self.ix = 0 end -- reset
-end
-
-function S.cond(self, p) return S.extend(self, {cond = p}) end
-function S.condr(self, p) return S.extend(self, {cond = p, rcond = p}) end
-function S.every(self, n) return S.extend(self, {cond = S._every, n = n}) end
-function S.times(self, n) return S.extend(self, {cond = S._times, n = n}) end
-function S.count(self, n) return S.extend(self, {rcond = S._count, n = n}) end
-
---- helpers in terms of core
-function S.all(self) return self:count(self.length) end
-function S.once(self) return self:times(1) end
-function S.peek(self) return self.data[self.ix] end
-
-
 --- metamethods
 
+-- calling the sequins library will create a new sequins object (S:new)
+-- calling a sequins object will produce a new value (S:next)
 S.__call = function(self, ...)
     return (self == S) and S.new(...) or S.next(self)
 end
 
 S.metaix = { settable = S.setdata
            , step     = S.step
-           , cond     = S.cond
-           , condr    = S.condr
+           , flow     = S.flow
            , every    = S.every
            , times    = S.times
            , count    = S.count
            , all      = S.all
-           , once     = S.once
            , reset    = S.reset
            , select   = S.select
            , peek     = S.peek
            , copy     = S.copy
            }
 S.__index = function(self, ix)
-    -- runtime calls to step() and select() should return values, not functions
     if type(ix) == 'number' then return self.data[ix]
     else
         return S.metaix[ix]
@@ -214,15 +193,23 @@ S.__newindex = function(self, ix, v)
 end
 
 S.__tostring = function(t)
-    -- will recursively call for other sequins
+    -- data
     local st = {}
     for i=1,t.length do
         st[i] = tostring(t.data[i])
     end
-    local s = string.format('s[%i]{%s}', t.ix, table.concat(st,','))
+    local s = string.format('s[%i]{%s}', t.qix or t.ix, table.concat(st,','))
 
-    -- TODO modifiers: need to add metadata to modifiers so they can be introspected
-    -- TODO transforms: not sure what the structure is yet
+    -- modifiers
+    for k,v in pairs(t.flw) do
+        -- TODO do we need to print current counters?
+        s = string.format('%s:%s(%s)',s, k:sub(1,1), tostring(v.n))
+    end
+
+    -- transformer
+    if #t.fn > 0 then
+        s = string.format('%s:fn(%s)',s, k:sub(1,1), tostring(t.fn[1]))
+    end
 
     return s
 end
@@ -231,6 +218,4 @@ end
 S.__len = function(t) return t.length end
 
 
-setmetatable(S, S)
-
-return S
+return setmetatable(S, S)

--- a/tests/sequins.lua
+++ b/tests/sequins.lua
@@ -1,15 +1,14 @@
 --- sequins.lua tester
 
 
-s = dofile("lua/sequins.lua")
+s = dofile("../lua/sequins_alt.lua")
 
 --- make a table of notes, with default next() behaviour
 local s1 = s{0,4,7,11}
 assert(s1() == 0)
 assert(s1() == 4)
 assert(s1() == 7)
-assert(s1() == 11)
-assert(s1() == 0) -- wraps
+assert(s1() == 11) -- assert(s1() == 0) -- wraps
 
 -- custom behaviour: steps backward by 1
 -- local s2 = s({0,3,6,9}, s.step(-1))
@@ -20,16 +19,16 @@ assert(s2() == 6)
 assert(s2() == 3)
 
 --- default behaviour, demonstrate select for direct setting
--- local s3 = s{1,2,3,4,5}
--- -- for i=1,5 do print(s2()) end
--- assert(s3() == 1)
--- assert(s3() == 2)
--- assert(s3:select(4)() == 4) -- select() is 1-based like the rest of lua
--- assert(s3() == 5)
--- assert(s3() == 1)
+local s3 = s{1,2,3,4,5}
+-- for i=1,5 do print(s2()) end
+assert(s3() == 1)
+assert(s3() == 2)
+assert(s3:select(4)() == 4) -- select() is 1-based like the rest of lua
+assert(s3() == 5)
+assert(s3() == 1)
 
---[[
 --- explicit behaviours (any datatype!)
+--- FIXME: unsure if this usge of :select & :step is supported / documented?
 -- local s4 = s{'a','b','c','d'}
 -- assert(s4:select(1) == 'a')
 -- assert(s4:select(1) == 'a')
@@ -44,7 +43,6 @@ assert(s2() == 3)
 -- assert(s6() == 2)
 -- assert(s6() == 3)
 
-]]
 
 
 
@@ -166,56 +164,31 @@ assert(s15() == 4)
 assert(s15() == 5)
 
 
---- wrapped iteration should multiply calls like nested loops
-local s16 = s{1, s{2}:count(2):count(2)}
+--- wrapped iteration should overwrite
+local s16 = s{1, s{2}:count(3):count(2)}
 assert(s16() == 1)
 assert(s16() == 2)
 assert(s16() == 2)
-assert(s16() == 2)
-assert(s16() == 2)
 assert(s16() == 1)
+assert(s16() == 2)
+assert(s16() == 2)
 
--- FIXME broken- current result is (1,2,1,3,1,2,1,3)
 --- reverse nested every/count
--- local s17 = s{1, s{2,3}:every(2):count(3)}
--- for i=1,8 do print(); print(s17()) end
--- assert(s17() == 1)
--- assert(s17() == 2)
--- assert(s17() == 3)
--- assert(s17() == 2)
--- assert(s17() == 1)
--- assert(s17() == 3)
--- assert(s17() == 2)
--- assert(s17() == 3)
--- assert(s17() == 1)
+-- re-ordered so every always happens first
+local s17 = s{1, s{2,3}:every(2):count(3)}
+assert(s17() == 1)
+assert(s17() == 1)
+assert(s17() == 2)
+assert(s17() == 3)
+assert(s17() == 2)
+assert(s17() == 1)
+assert(s17() == 1)
+assert(s17() == 3)
+assert(s17() == 2)
+assert(s17() == 3)
+assert(s17() == 1)
 
--- --- every+every composition divides timing
--- FIXME disabled bc i can't tell what the desired behaviour is
--- local s17 = s{1, s{2,3}:every(2):every(2)}
--- for i=1,8 do print(); print(s17()) end
--- assert(s17() == 1)
--- assert(s17() == 1)
--- assert(s17() == 1)
--- assert(s17() == 1)
--- assert(s17() == 2)
--- assert(s17() == 1)
--- assert(s17() == 1)
--- assert(s17() == 1)
--- assert(s17() == 1)
--- assert(s17() == 3)
--- assert(s17() == 1)
-
-local s18 = s{ 1, s{2,3}:all():count(2)}
-assert(s18() == 1)
-assert(s18() == 2)
-assert(s18() == 3)
-assert(s18() == 2)
-assert(s18() == 3)
-assert(s18() == 1)
-assert(s18() == 2)
-assert(s18() == 3)
-assert(s18() == 2)
-
+-- times
 local s19 = s{ 1, s{2,3}:times(3)}
 assert(s19() == 1)
 assert(s19() == 2)
@@ -235,30 +208,42 @@ s5:step(-1)
 assert(s5() == 1)
 assert(s5() == 4) -- wraps
 
-
--- generic cond function
-STATE = true
-local s1 = s{1, s{2}:cond(function() return STATE end)}
-assert(s1() == 1)
-assert(s1() == 2)
-assert(s1() == 1)
-assert(s1() == 2)
-STATE = false
-assert(s1() == 1)
-assert(s1() == 1)
-assert(s1() == 1)
-
-
 -- test reset
-local s18 = s{ 1, s{2,3}:all():count(2)}
+local s18 = s{ 1, s{2,3}:count(2)}
 assert(s18() == 1)
-assert(s18() == 2)
-assert(s18() == 3)
 assert(s18() == 2)
 s18:reset()
 assert(s18() == 1)
 assert(s18() == 2)
 assert(s18() == 3)
-assert(s18() == 2)
-assert(s18() == 3)
 assert(s18() == 1)
+assert(s18() == 2)
+
+-- string tests
+local s1 = s"cba"
+assert(s1() == 'c')
+assert(s1() == 'b')
+assert(s1() == 'a')
+assert(s1() == 'c') -- assert(s1() == 0) -- wraps
+
+-- __len test
+local s1 = s{1,2,3}
+assert(#s1 == 3)
+
+local s1 = s"cba"
+assert(#s1 == 3)
+
+local s1 = s{1,2,s{2,3}} -- nests only count as one
+assert(#s1 == 3)
+
+
+--[[
+-- TODO copy test
+
+-- TODO setdata tests
+
+-- TODO transformer tests
+
+-- TODO bake tests
+
+]]

--- a/tests/sequins.lua
+++ b/tests/sequins.lua
@@ -1,7 +1,7 @@
 --- sequins.lua tester
 
 
-s = dofile("../lua/sequins_alt.lua")
+s = dofile("../lua/sequins.lua")
 
 --- make a table of notes, with default next() behaviour
 local s1 = s{0,4,7,11}


### PR DESCRIPTION
aggressive refactor based around solving some non-determinism & confusing behaviour in the flow-modifier system.

basically now there is only 1 of each `every` / `count` (and `all`) / `times` in each sequins. nested sequins have their own set as well.

this is in contrast to original version which had a recursive stack of modifiers that could have n-instances of each. the issue was that people wanted to *change* the value of the modifiers, but attempting to do so would append an additional modifier.

furthermore, there was previously a confusing difference in execution when you stacked `:count(n):every(m)` versus `:every(m):count(n)`. this order-of-operations has been removed, and instead we have a fixed order of operation: first we process `every`, skipping non-matched elements. then process `count`, which freezes the `every` state until the `count` is complete.

so you can say "every 3 times you call this nested sequins, i will produce 4 values in a row, before yielding back to the parent sequins". meanwhile "times" is the number of actual values returned, thus ignoring 'every' and counting once per value, regardless if it's part of a 'count'.

////

note:
* `sequins.cond` and `sequins.rcond` are removed
* `sequins.once` is removed (use `sequins.times(1)`)
* `tostring(s{1}:every(3))` and similar will now stringify any active flow-modifiers