### PR TITLE
Sequins transformers

### DIFF
--- a/lua/sequins.lua
+++ b/lua/sequins.lua
@@ -200,7 +200,7 @@ S.metaix = { settable = S.setdata
            , select   = S.select
            , peek     = S.peek
            , copy     = S.copy
-           , fn       = S.func
+           , map      = S.func
            }
 S.__index = function(self, ix)
     if type(ix) == 'number' then return self.data[ix]
@@ -231,7 +231,7 @@ S.__tostring = function(t)
 
     -- transformer
     if #t.fun > 0 then
-        s = string.format('%s:fn(%s)',s, k:sub(1,1), tostring(t.fun[1]))
+        s = string.format('%s:map(%s)',s, k:sub(1,1), tostring(t.fun[1]))
     end
 
     return s

--- a/lua/sequins.lua
+++ b/lua/sequins.lua
@@ -75,6 +75,15 @@ end
 
 function S:peek() return self.data[self.ix] end
 
+function S:bake(n)
+    n = n or #self -- void call creates a table of length == the parent sequins
+    local t = {}
+    for i=1,n do
+        t[i] = self()
+    end
+    return S.new(t)
+end
+
 local function turtle(t, fn)
     -- apply fn to all nested sequins
     fn = fn or S.next -- default to S.next
@@ -201,6 +210,7 @@ S.metaix = { settable = S.setdata
            , peek     = S.peek
            , copy     = S.copy
            , map      = S.func
+           , bake     = S.bake
            }
 S.__index = function(self, ix)
     if type(ix) == 'number' then return self.data[ix]

--- a/lua/sequins.lua
+++ b/lua/sequins.lua
@@ -186,6 +186,11 @@ function S:reset()
         v.ix = 0
         turtle(v.n, S.reset)
     end
+    if self.fun[1] and #self.fun[2] > 0 then
+        for _,v in pairs(self.fun[2]) do
+            turtle(v, S.reset)
+        end
+    end
 end
 
 

--- a/lua/sequins.lua
+++ b/lua/sequins.lua
@@ -54,23 +54,14 @@ function S:setdata(t)
     self.ix = wrap_index(self, self.ix)
 end
 
--- nb: 2nd arg 'cp' is for internal recursive use only
-function S.copy(og, cp)
-    cp = cp or {}
-    local og_type = type(og)
-    local copy = {}
-    if og_type == 'table' then
-        if cp[og] then -- handle duplicate refs to an internal table
-            copy = cp[og]
-        else
-            cp[og] = copy
-            for og_k, og_v in next, og, nil do
-                copy[S.copy(og_k, cp)] = S.copy(og_v, cp)
-            end
-            setmetatable(copy, S.copy(getmetatable(og), cp))
+function S:copy()
+    if type(self) == 'table' then
+        local cp = {}
+        for k,v in pairs(self) do
+            cp[k] = S.copy(v)
         end
-    else copy = og end -- literal value
-    return copy
+        return setmetatable(cp, getmetatable(self))
+    else return self end
 end
 
 function S:peek() return self.data[self.ix] end

--- a/lua/sequins.lua
+++ b/lua/sequins.lua
@@ -75,6 +75,12 @@ end
 
 function S:peek() return self.data[self.ix] end
 
+local function turtle(t, fn)
+    -- apply fn to all nested sequins
+    fn = fn or S.next -- default to S.next
+    if S.is_sequins(t) then return fn(t) end -- unwrap
+    return t -- literal value
+end
 
 ------------------------------
 --- transformers
@@ -92,15 +98,24 @@ local function do_transform(s, v)
     else return v end
 end
 
+-- support arithmetic via math operators
+S._fns = {
+    add = function(n,b) return n+turtle(b) end,
+    sub = function(n,b) return n-turtle(b) end,
+    mul = function(n,b) return n*turtle(b) end,
+    div = function(n,b) return n/turtle(b) end,
+    mod = function(n,b) return n%turtle(b) end,
+}
+
+-- assume 'a' is self of a sequins
+S.__add = function(a,b) return S.func(a, S._fns.add, b) end
+S.__sub = function(a,b) return S.func(a, S._fns.sub, b) end
+S.__mul = function(a,b) return S.func(a, S._fns.mul, b) end
+S.__div = function(a,b) return S.func(a, S._fns.div, b) end
+S.__mod = function(a,b) return S.func(a, S._fns.mod, b) end
+
 ------------------------------
 --- control flow execution
-
-local function turtle(t, fn)
-    -- apply fn to all nested sequins
-    fn = fn or S.next -- default to S.next
-    if S.is_sequins(t) then return fn(t) end -- unwrap
-    return t -- literal value
-end
 
 local function do_step(s)
     -- if .qix is set, it will be used, rather than incrementing by s.n

--- a/tests/sequins.lua
+++ b/tests/sequins.lua
@@ -357,7 +357,6 @@ eq(sfn(), sbaked())
 eq(#sbaked, 7)
 
 -- test :reset on a sequins transformer map
-print':reset'
 local sfn = s{1}+s{0,1}
 eq(sfn(), 1)
 sfn:reset()
@@ -365,23 +364,8 @@ eq(sfn(), 1)
 
 
 
--- eq(sfn(), 2)
--- eq(sfn(), 2)
--- eq(sfn(), 2)
--- eq(sfn(), 1)
--- eq(sfn(), 3)
-
--- eq(sfn(), 1)
--- eq(sfn(), 2)
--- eq(sfn(), 2)
--- eq(sfn(), 2)
-
-
 --[[
 -- TODO copy test
 
 -- TODO setdata tests
-
-
-
 ]]

--- a/tests/sequins.lua
+++ b/tests/sequins.lua
@@ -322,6 +322,59 @@ assert(sfn() == 0)
 assert(sfn() == 1)
 assert(sfn() == 0)
 
+-- dumb equality assertion shim to print values if assertion fails
+function eq(testcase,expect)
+    if testcase ~= expect then
+        print('failed: got '..testcase)
+        print('   expected '..expect)
+    end
+end
+
+-- bake tests
+-- default bake length  == length of parent sequins
+local sfn = s{1,2}+s{0,0,1}
+local sbaked = sfn:bake() -- will produce list of length 2
+local sfn = s{1,2}+s{0,0,1} -- reset to ensure we're phase aligned
+-- FIXME transformer is not reset with :reset()
+-- sfn:reset() -- reset to ensure we're phase aligned
+eq(sfn(), sbaked())
+eq(sfn(), sbaked())
+eq(#sfn, #sbaked)
+
+-- explicit bake length
+local sfn = s{1,2}+s{0,0,1}
+local sbaked = sfn:bake(7)
+local sfn = s{1,2}+s{0,0,1} -- reset to ensure we're phase aligned
+-- FIXME transformer is not reset with :reset()
+-- sfn:reset() -- reset to ensure we're phase aligned
+eq(sfn(), sbaked())
+eq(sfn(), sbaked())
+eq(sfn(), sbaked())
+eq(sfn(), sbaked())
+eq(sfn(), sbaked())
+eq(sfn(), sbaked())
+eq(sfn(), sbaked())
+eq(#sbaked, 7)
+
+-- test :reset on a sequins transformer map
+print':reset'
+local sfn = s{1}+s{0,1}
+eq(sfn(), 1)
+sfn:reset()
+eq(sfn(), 1)
+
+
+
+-- eq(sfn(), 2)
+-- eq(sfn(), 2)
+-- eq(sfn(), 2)
+-- eq(sfn(), 1)
+-- eq(sfn(), 3)
+
+-- eq(sfn(), 1)
+-- eq(sfn(), 2)
+-- eq(sfn(), 2)
+-- eq(sfn(), 2)
 
 
 --[[
@@ -330,6 +383,5 @@ assert(sfn() == 0)
 -- TODO setdata tests
 
 
--- TODO bake tests
 
 ]]

--- a/tests/sequins.lua
+++ b/tests/sequins.lua
@@ -383,6 +383,52 @@ local sog = s{1,2,3}+1
 local scp = sog:copy()
 for i=1,10 do eq(sog(), scp()) end
 
---[[
--- TODO setdata tests
-]]
+
+-- setdata tests
+-- swap data, maintain index
+local sd = s{1,2}
+sd(); sd()
+eq(tostring(sd), 's[2]{1,2}')
+ix = sd.ix
+sd:settable{3,4}
+eq(ix, sd.ix)
+eq(tostring(sd), 's[2]{3,4}')
+
+-- swap data, maintain index, sequins input
+local sd = s{1,2}
+sd(); sd()
+eq(tostring(sd), 's[2]{1,2}')
+ix = sd.ix
+sd:settable(s{3,4})
+eq(ix, sd.ix)
+eq(tostring(sd), 's[2]{3,4}')
+
+-- swap nested data, maintain index
+local sd = s{1,s{2,3}}
+sd(); sd(); sd(); sd()
+eq(tostring(sd), 's[2]{1,s[2]{2,3}}')
+ix = sd.ix
+sd:settable{2,s{3,4}}
+eq(ix, sd.ix)
+eq(tostring(sd), 's[2]{2,s[2]{3,4}}')
+
+-- swap nested flow-mod (same type), maintain flow-index
+local sd = s{1,s{2,3}:every(2)}
+sd(); sd(); sd(); sd()
+eq(tostring(sd), 's[1]{1,s[1]{2,3}:e[2](2)}')
+sd:settable{1,s{2,3}:every(5)}
+eq(tostring(sd), 's[1]{1,s[1]{2,3}:e[2](5)}')
+
+-- swap nested flow-mod (new type), maintain flow-index
+local sd = s{1,s{2,3}:every(2)}
+sd(); sd(); sd(); sd()
+eq(tostring(sd), 's[1]{1,s[1]{2,3}:e[2](2)}')
+sd:settable{1,s{2,3}:count(5)}
+eq(tostring(sd), 's[1]{1,s[1]{2,3}:c[0](5)}')
+
+-- swap seq w/ transformer
+local sd = s{1}+s{2,3}
+sd(); sd();
+eq(tostring(sd), 's[1]{1}:map(fn,s[2]{2,3})')
+sd:settable(s{1}+s{3,4})
+eq(tostring(sd), 's[1]{1}:map(fn,s[2]{3,4})')

--- a/tests/sequins.lua
+++ b/tests/sequins.lua
@@ -238,25 +238,25 @@ assert(#s1 == 3)
 
 --- transformer tests
 -- simple function
-local sfn = s{1,2}:fn(function(n) return n+1 end)
+local sfn = s{1,2}:map(function(n) return n+1 end)
 -- for i=1,4 do print(sfn()) end
 assert(sfn() == 2)
 assert(sfn() == 3)
 assert(sfn() == 2)
-sfn:fn() -- remove the transformer
+sfn:map() -- remove the transformer
 assert(sfn() == 2)
 assert(sfn() == 1)
 assert(sfn() == 2)
 
 -- function with captured args
-local sfn = s{1,2}:fn(function(n,arg) return n*arg end, 2)
+local sfn = s{1,2}:map(function(n,arg) return n*arg end, 2)
 assert(sfn() == 2)
 assert(sfn() == 4)
 assert(sfn() == 2)
 assert(sfn() == 4)
 
 -- function with captured sequins
-local sfn = s{0,3,6}:fn(function(n,sq)
+local sfn = s{0,3,6}:map(function(n,sq)
         return n+sq()
     end, s{0,12})
 assert(sfn() == 0)

--- a/tests/sequins.lua
+++ b/tests/sequins.lua
@@ -264,6 +264,63 @@ assert(sfn() == 15)
 assert(sfn() == 6)
 assert(sfn() == 12)
 
+-- divide operator
+local sfn = s{0,12}/12
+-- for i=1,4 do print(sfn()) end
+assert(sfn() == 0)
+assert(sfn() == 1)
+assert(sfn() == 0)
+
+-- divide operator sequins
+local sfn = s{1,2}/s{1,2,3}
+-- for i=1,4 do print(sfn()) end
+assert(sfn() == 1)
+assert(sfn() == 1)
+assert(sfn() == 1/3)
+assert(sfn() == 2)
+assert(sfn() == 1/2)
+assert(sfn() == 2/3)
+assert(sfn() == 1)
+
+local sfn = s{1,2}+1
+assert(sfn() == 2)
+assert(sfn() == 3)
+assert(sfn() == 2)
+
+local sfn = s{1,2}-1
+assert(sfn() == 0)
+assert(sfn() == 1)
+assert(sfn() == 0)
+
+local sfn = s{1,2}*2
+assert(sfn() == 2)
+assert(sfn() == 4)
+assert(sfn() == 2)
+
+local sfn = s{0,3,4}%3
+assert(sfn() == 0)
+assert(sfn() == 0)
+assert(sfn() == 1)
+
+local sfn = s{1}+s{0,1}
+assert(sfn() == 1)
+assert(sfn() == 2)
+assert(sfn() == 1)
+
+local sfn = s{1}-s{0,1}
+assert(sfn() == 1)
+assert(sfn() == 0)
+assert(sfn() == 1)
+
+local sfn = s{1}*s{1,2}
+assert(sfn() == 1)
+assert(sfn() == 2)
+assert(sfn() == 1)
+
+local sfn = s{3}%s{1,2,3}
+assert(sfn() == 0)
+assert(sfn() == 1)
+assert(sfn() == 0)
 
 
 

--- a/tests/sequins.lua
+++ b/tests/sequins.lua
@@ -236,13 +236,42 @@ assert(#s1 == 3)
 local s1 = s{1,2,s{2,3}} -- nests only count as one
 assert(#s1 == 3)
 
+--- transformer tests
+-- simple function
+local sfn = s{1,2}:fn(function(n) return n+1 end)
+-- for i=1,4 do print(sfn()) end
+assert(sfn() == 2)
+assert(sfn() == 3)
+assert(sfn() == 2)
+sfn:fn() -- remove the transformer
+assert(sfn() == 2)
+assert(sfn() == 1)
+assert(sfn() == 2)
+
+-- function with captured args
+local sfn = s{1,2}:fn(function(n,arg) return n*arg end, 2)
+assert(sfn() == 2)
+assert(sfn() == 4)
+assert(sfn() == 2)
+assert(sfn() == 4)
+
+-- function with captured sequins
+local sfn = s{0,3,6}:fn(function(n,sq)
+        return n+sq()
+    end, s{0,12})
+assert(sfn() == 0)
+assert(sfn() == 15)
+assert(sfn() == 6)
+assert(sfn() == 12)
+
+
+
 
 --[[
 -- TODO copy test
 
 -- TODO setdata tests
 
--- TODO transformer tests
 
 -- TODO bake tests
 

--- a/tests/sequins.lua
+++ b/tests/sequins.lua
@@ -356,16 +356,33 @@ eq(sfn(), sbaked())
 eq(sfn(), sbaked())
 eq(#sbaked, 7)
 
--- test :reset on a sequins transformer map
+-- :reset() on a sequins transformer map
 local sfn = s{1}+s{0,1}
 eq(sfn(), 1)
 sfn:reset()
 eq(sfn(), 1)
 
+-- copy tests
+-- plain sequins
+local sog = s{1,2,3}
+local scp = sog:copy()
+for i=1,10 do eq(sog(), scp()) end
 
+-- nested sequins
+local sog = s{1,2,s{3,4}}
+local scp = sog:copy()
+for i=1,3 do eq(sog(), scp()) end
+
+-- nested sequins with flow-mod
+local sog = s{1,2,s{3,4}:every(2)}
+local scp = sog:copy()
+for i=1,10 do eq(sog(), scp()) end
+
+-- sequins with transformer
+local sog = s{1,2,3}+1
+local scp = sog:copy()
+for i=1,10 do eq(sog(), scp()) end
 
 --[[
--- TODO copy test
-
 -- TODO setdata tests
 ]]


### PR DESCRIPTION
## sequins transformer maps

this new feature for sequins allows a value transformation function to be attached to a sequins. whenever a sequins object is called, the value it produces is passed through the transformer function before being returned.

this enables rapid pattern permutation with the full power of lua, while the interface to produce that value is left untouched. it is another tool for describing a sequence of values that will be produced in the future.

usage is with the method `:map` which takes its name from the functional programming technique of 'mapping' a function over a collection. here we map our transformer over the output values of the sequins. one key difference is that our `map` transformation is a non-destructive effect that happens whenever a new value is taken from the sequins.

because a lua function can have non-determinism (eg. `math.random()`), this can create infinitely long sequences, or at least stochastic sequences.

transformers can also use sequins, which you pass in as additional arguments to `:map`. this gets into 'pattern synthesis' (thanks @dndrks) territory, enabling complex interactions to unfold, especially when using sequins of differing lengths.

while any lua action is allowed, we suggest using transformers exclusively to manipulate the data in a pure fashion. if you want each value to be sent to an IO (read: real-world) function, call the sequins in a `timeline` or event handler.

```lua
s = sequins

-- create a major scale where each note is randomly set to root octave, or up once octave
sfn = s{0,4,7,11}:map(function(n) return n + (math.random() > 0.5 and 12 or 0) end)

-- use a transformer to limit the range
sfn1 = s{0,4,7}:map(function(n) return n>5 and n-12 or n end)
sfn1() ... --> 0,4,-5,0 repeats

-- cyclically add octaves
sfn2 = s{0,3,6,9}:map(function(n, sq)
        return n + sq()
    end, s{-12,0,12})
sfn2() ... --> -12,3,18,-3,0,15,-6,9,-12 repeats

-- you can of course pre-define your functions for clarity
dropC = function(n) return n == 0 and -12 or n end -- drop 0 (middle-C) 1 octave
sfn3 = s{0,2,4,s{7,9}}:map(dropC)
sfn3() ... --> -12,2,4,7-12,2,4,9,-12 repeats

-- __ more examples here __
```

additionally there are shortcuts to do a single arithmetic operation, using lua's arithmetic operators. this can make transposition easy (+2), or conversion from notes-numbers to volts (/12).

you can of course apply another sequins as demonstrated above, but with a much tighter syntax. when applying other sequins, remember that the sequins on the left of the operator is the 'primary' sequins that captures the sequins (or literal) on the right hand side. this is true for literals too - the sequins must be on the left (so no, you can't negative a sequins directly, use a little function).

```lua
-- transpose up 2 semitones
sop1 = s{0,2,4,7,9} + 2
sop1() ... --> 2,4,6,9,11,2 repeats

-- convert notes to volts (great for `ii` functions that expect volts)
sop2 = s{0,3,0,2}/12
sop2() ... --> 0, (3/12), 0, (2/12), 0 repeats

-- now we can just use the sequins directly
ii.jf.play_note(sop2(), 2)

-- which is great with timeline, avoiding trivial anonymous functions
melody = s{0,7,s{2,4},9}/12
timeline.loop{ s{3,3,2}, {ii.jf.play_note, melody, 2.5} }

-- or we can use this on 2 sequins to generate complexity from simple elements
-- synthesize a pattern with 2 sequins
sop3 = s{0,7,s{2,4},9} + s{0,0,12,0,12}
sop3() ... --> this would be a nice long pattern in a major pentatonic style


```

## baking sequins
when you start working with transformation maps, you will likely want to work iteratively, building up your transformations gradually. when you land on the right transformation, rather than copying the whole sequins & creating increasingly complex `map` functions, you can `bake` the current transformation into a new sequins.

the `bake` function returns a completely flat sequins (ie, no nested sequins). the default behaviour of `:bake()` with no arguments will create a new sequins of the same length as the original sequins (any nested sequins are treated as only 1 value).

if you want to capture variations built into your original sequins, you can capture an arbitrary number of values from your sequins with `:bake(n)` where `n` is the number of values in the newly baked sequins. this technique is very useful for flattening nested tables, or flattening tables with sequins-enabled transformations.

additionally, the `:bake(n)` method can be super useful for taking sequins of odd-lengths & forcing them into a repeating 8/16/32 (etc) step pattern. under the hood, `:bake(n)` is just calling your sequins `n`-times and making a sequins out of the result, so it's not linked to any of the more complex sequins behaviour.

__ TODO__ pull examples from https://gist.github.com/trentgill/bf930d4cb3f7f9e4a4c981432bf02356 and comments below.