### PR TITLE
Qscale library

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -43,6 +43,7 @@
 #include "lua/calibrate.lua.h"
 #include "lua/sequins.lua.h"
 #include "lua/quote.lua.h"
+#include "lua/scale.lua.h"
 
 #include "build/ii_lualink.h" // generated C header for linking to lua
 
@@ -64,6 +65,7 @@ const struct lua_lib_locator Lua_libs[] =
     , { "lua_calibrate" , lua_calibrate , true}
     , { "lua_sequins"   , lua_sequins   , true}
     , { "lua_quote"     , lua_quote     , true}
+    , { "lua_scale"     , lua_scale     , true}
     , { NULL            , NULL          , true}
     };
 

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -14,6 +14,7 @@ public = dofile('lua/public.lua')
 clock  = dofile('lua/clock.lua')
 sequins= dofile('lua/sequins.lua')
 quote  = dofile('lua/quote.lua')
+qscale = dofile('lua/scale.lua')
 
 
 function C.reset()

--- a/lua/scale.lua
+++ b/lua/scale.lua
@@ -1,0 +1,33 @@
+--- scale quantizer generator library
+-- call the library similarly to input.scale or output.scale
+-- returns a function that will perform the quantization on an input
+
+local Q = {}
+
+Q.ji = function(rs, ins, outs)
+    -- create a 12TET-ified version of rs
+    return Q.__call(S, just12(rs), ins, outs)
+end
+
+local chrom = {0,1,2,3,4,5,6,7,8,9,10,11}
+Q.__call = function(self, ns, ins, outs)
+    -- defaults
+    ins, outs = ins or 12, outs or 1
+    -- chromatic shortcut with empty table or empty call
+    ns = (not ns or #ns == 0) and chrom or ns
+
+    -- optimize by precalculating constants
+    local _INS = 1/ins -- inverse of in-scaling (mul cheaper than div!)
+    local OFF = 0.5 * _INS -- half an input-window of offset
+    local LEN = #ns -- memoize length
+
+
+    return function(n)
+        local norm = (n+OFF) * _INS -- normalize to input scaling
+        local octs = math.floor(norm) -- extract octaves
+        local ix   = math.floor((norm - octs) * LEN)
+        return (ns[ix+1]*_INS + octs) * outs -- scale lookup & reconstruct
+    end
+end
+
+return setmetatable(Q,Q)

--- a/tests/scale.lua
+++ b/tests/scale.lua
@@ -1,0 +1,84 @@
+--- scale library test
+
+sk = dofile("../lua/scale.lua")
+
+
+--- major scale quantizer
+-- input[1].mode('scale',{0,2,4,7,9},12,1.0)
+-- output[1].scale({0,2,4,7,9},12,1.0)
+
+-- myquantizer = scale({0,2,4,7,9}, 12, 1.0) -- convert to volts
+-- myquantizerN = scale({0,2,4,7,9}, 12, 12) -- input/output mapping the same
+
+-- think of the 'divs'/'scaling' as input/output ranges
+-- so if divs == 12, then our table should be in 12TET
+-- if divs == 'ji', then our table should be in just fractions
+-- if scaling == divs, then output matches input
+-- if divs==12 & scaling==1 then convert note table to voltage
+
+-- quantize to octaves, staying in 12TET
+local s1 = sk({0},12,12)
+assert(type(s1) == 'function')
+assert(s1(0) == 0)
+assert(s1(7) == 0)
+assert(s1(11) == 0) -- always round down
+assert(s1(11.99) == 12) -- capture marginally beneath bounds
+assert(s1(12) == 12)
+assert(s1(-12) == -12) -- test negative numbers
+assert(s1(-11) == -12)
+assert(s1(-13) == -24)
+
+-- quantize to octaves, convert to volts
+local s1 = sk({0},12,1)
+assert(s1(0) == 0)
+assert(s1(7) == 0)
+assert(s1(11) == 0) -- always round down
+assert(s1(11.99) == 1) -- capture marginally beneath bounds
+assert(s1(12) == 1)
+assert(s1(-12) == -1) -- test negative numbers
+assert(s1(-11) == -1)
+assert(s1(-13) == -2)
+
+-- quantize to 2 values, splitting the octave evenly
+local s1 = sk({0,1},12,12)
+assert(s1(0) == 0)
+assert(s1(5) == 0) -- round down
+assert(s1(6) == 1) -- round up
+assert(s1(12) == 12) -- round up
+
+-- as above but confirm default in/out is 12,1
+local s1 = sk({0,36})
+assert(s1(0) == 0)
+assert(s1(5) == 0) -- round down
+assert(s1(6) == 3) -- round up (note out-of-octave vals allowed)
+assert(s1(12) == 1) -- round up
+
+-- chromatic n->v scaler
+local s1 = sk()
+assert(s1(0) == 0)
+assert(s1(1) == 1/12)
+assert(s1(11) == 11/12)
+assert(s1(12) == 1)
+
+-- chromatic n->v scaler: table-call syntax
+local s1 = sk{}
+assert(s1(0) == 0)
+assert(s1(1) == 1/12)
+assert(s1(11) == 11/12)
+assert(s1(12) == 1)
+
+-- chromatic n->n scaler
+local s1 = sk({}, 12, 12)
+assert(s1(0) == 0)
+assert(s1(1) == 1)
+assert(s1(11) == 11)
+assert(s1(12) == 12)
+
+-- just intonation support
+-- use a separate function
+local sj1 = sk.ji({1/1, 2/1}, 12, 1)
+assert(sj1(0) == 0)
+assert(sj1(5) == 0) -- round down
+-- note we need to account for floating point inaccuracies here
+assert(sj1(6) >= 0.9999 and sj1(6) <= 1.0001) -- round up
+assert(sj1(12) == 1.0) -- round up


### PR DESCRIPTION
WIP
* what should the naming be?
* need to test it on crow (not just via testing lib)
* confirm it works with a voltage-input (not note-nums)

## Qscale

This is a small scale-quantizer library in a similar style to `input[n].mode('scale',...)` and `output[n].scale = ...`.

it enables the same syntax as the `input` and `output` libs, but decouples the behaviour from hardware.

using `qscale` is a 2-part process:
1) create a qscale function with `qscale(...)` or `qscale.ji(...)`
2) use it by passing your value-to-be-quantized through the generated function.

looks like this:
```lua
myquantizer = qscale{0,2,4,7,9}
print( myquantizer(0.4) ) --> 0
print( myquantizer(15) ) --> 14/12 (1 octave + 2semitones)
```
in the above example, we use a table call which expects the table to be in 12TET note numbers, and will convert the output to a voltage (divides the quantized value by 12).

## in/out scaling

you can provide input & output scaling, similar to the in/out libs
```lua
-- here 12,12 means note table is in 12TET and output should be as well
s1 = qscale({0,3,6,9},12,12)

-- this is the same as the defaults (ie scale output to 1.0 per octave)
s1 = qscale({0,3,6,9},12,1.0)
```

plus there are shortcuts for chromatic scaling if you want that:
```lua
-- uses default scaling 12TET->1V/8ve
s1 = qscale()
-- equivalent to:
s1 = qscale{0,1,2,3,4,5,6,7,8,9,10,11}

-- or provide your own scaling if you want
s1 = qscale({}, 12, 12)
-- equivalent to:
s1 = qscale({0,1,2,3,4,5,6,7,8,9,10,11}, 12, 12)
```

## random access sequencers
the values don't have to be a linear scale! you can (mis)use qscale as a lookup table to build random-access sequencers:
```lua
lut = qscale{0,7,14,9,4,11,6}
```
specifically note here that
1) note-table values can be outside the octave range (eg: 14 above)
2) note-table need not be in order
3) octaves will be added and subtracted based on *input* values.

if you want to define a lookup table that repeats every 2 octaves, you could try:
```lua
lut = qscale({0,7,14,9,4,11,6}, 24, 2.0)
```
^^ this is untested, but it should be something close to what you expect...

## just intonation
just like the input/output libs, you can provide the note table as a series of just ratios, using the special function `qscale.ji`. this differs from the input/output libs where you pass `'ji'` as the 'divisions' value. in our case, we still need divs to represent the scaling of the input (eg. is input from an input channel (1.0) or a note-number generator (12), and output remains the same)
```lua
sj1 = sk.ji({1/1, 10/9, 9/8, 5/4, 4/3, 3/2, 8/5}, 12, 1)
```