### PR TITLE
hotswap library

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -44,6 +44,7 @@
 #include "lua/sequins.lua.h"
 #include "lua/quote.lua.h"
 #include "lua/timeline.lua.h"
+#include "lua/hotswap.lua.h"
 
 #include "build/ii_lualink.h" // generated C header for linking to lua
 
@@ -52,20 +53,23 @@
 
 // mark the 3rd arg 'false' if you need to debug that library
 const struct lua_lib_locator Lua_libs[] =
+    // hardware interactive
     { { "lua_crowlib"   , lua_crowlib   , true}
     , { "lua_asl"       , lua_asl       , true}
-    , { "lua_asllib"    , lua_asllib    , true}
     , { "lua_clock"     , lua_clock     , true}
     , { "lua_metro"     , lua_metro     , true}
     , { "lua_input"     , lua_input     , true}
     , { "lua_output"    , lua_output    , true}
-    , { "lua_public"    , lua_public    , true}
     , { "lua_ii"        , lua_ii        , true}
     , { "build_iihelp"  , build_iihelp  , true}
     , { "lua_calibrate" , lua_calibrate , true}
+    // lua libraries
+    , { "lua_asllib"    , lua_asllib    , true}
+    , { "lua_public"    , lua_public    , true}
     , { "lua_sequins"   , lua_sequins   , true}
     , { "lua_quote"     , lua_quote     , true}
     , { "lua_timeline"  , lua_timeline  , true}
+    , { "lua_hotswap"   , lua_hotswap   , true}
     , { NULL            , NULL          , true}
     };
 

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -15,6 +15,7 @@ clock  = dofile('lua/clock.lua')
 sequins= dofile('lua/sequins.lua')
 quote  = dofile('lua/quote.lua')
 timeline = dofile('lua/timeline.lua')
+hotswap= dofile('lua/hotswap.lua')
 
 
 function C.reset()

--- a/lua/hotswap.lua
+++ b/lua/hotswap.lua
@@ -1,0 +1,46 @@
+--- hotswap library
+
+--- globals are available on crow, otherwise require for norns
+local s = sequins or require 'lib/sequins'
+local tl = timeline or require 'lib/timeline'
+
+local HS = {
+    _reg = {} -- a place to register updateable sequins
+}
+
+-- to add support for a new type you need: 
+-- 1) add an elseif predicate for capturing the type
+-- 2) give the type a single character identifier
+-- 3) add a swap function to HS._swap table
+
+HS._type = function(o)
+    -- return a char representing the type
+    if s.is_sequins(o) then return 's'
+    elseif tl.is_timeline(o) then return 't'
+    else print 'hotswap does not know this type'
+    end
+end
+
+HS._swap = {
+    s = function(t, v) t:settable(v) end,
+    t = function(t, v) t:hotswap(v) end,
+}
+
+
+HS.__index = function(self, ix)
+    return HS._reg[ix][2]
+end
+
+HS.__newindex = function(self, ix, v)
+    local t = HS._type(v)
+    if t then
+        if HS._reg[ix] then -- key already exists
+            -- warning! we assume the new type matches
+            HS._swap[t](HS._reg[ix][2], v)
+        else -- new key
+            HS._reg[ix] = {t,v} -- register with type annotation
+        end
+    end
+end
+
+return setmetatable(HS, HS)


### PR DESCRIPTION
simple library oriented toward live-coding, and specifically addressing the desire to re-run a line of code numerous times to change data piecemeal.

take the following example:
```lua
s = sequins
s1 = s{1,2,3}
print(s1) --> 1
print(s1) --> 2
s1 = s{4,5,6}
print(s1) --> 4
```
see how when we re-assigned `s1`, the sequins is reset to it's first stage. this makes sense as we are creating a new sequins and replacing the old one with the new. sometimes we *want* to keep the index into the sequins, and just modify the data sightly (perhaps 1 note was off, and we're already using the sequins in a metro somewhere):
```lua
s = sequins
-- current solution
s1 = s{1,2,3}
s1:settable{4,5,6} -- requires different syntax

-- or use the hotswap library
hs = hotswap
hs.s1 = s{1,2,3}
hs.s1 = s{4,5,6}
```
behaviour of the 2 above solutions is identical. the difference is that the 2nd version doesn't require changing the syntax at all. `hotswap` is a special table that does some extra checks & balances whenever setting a value in the table. specifically it's for handling objects with internal state. at present that means `sequins` and `timeline`.

take this example of an arpeggiator, where we gradually morph the timeline in various ways, each without missing a beat or resetting any of the scales:
```lua
hs = hotswap
tl = timeline
s = sequins
hs.mytl = tl.loop{ s{3,3,2}, {ii.wsyn.play_note, s{0,4,7,11}, 2.0 }
hs.mytl = tl.loop{ s{3,3,2}, {ii.wsyn.play_note, s{0,4,7,11}, 1.5 } -- reduce volume
hs.mytl = tl.loop{ s{3,3,2}, {ii.jf.play_note, s{0,4,7,11}, 1.5 } -- switch to just friends instead of w/
hs.mytl = tl.loop{ s{3,3,2}, {ii.jf.play_note, s{0,3,7,10}, 1.5 } -- switch to minor 7th
hs.mytl = tl.loop{ s{3,2,3}, {ii.jf.play_note, s{0,3,7,10}, 1.5 } -- reorganize rhythm
hs.mytl = tl.loop{ s{3,2,3}, {ii.jf.play_note, s{0,3,7,s{10,14}}, 1.5 } -- add nested sequins to scale
hs.mytl = tl.loop{ s{3,2,3}, {ii.jf.play_note, s{0,3,7,s{10,15}}, 1.5 } -- change upper harmony
```
while the result is very wordy when written out as a block, this is designed for use in a text editor where you can re-evaluate a line of code at a time (__LINK__ for howto). thus all the changes made above would be iterative modification of the line of text, and then re-running that line.

### implementation

the way the library works is a very basic shim which just captures assignments & forwards everything through the internal `hotswap` and `settable` methods of timeline & sequins respectively. as a result, any bugs that are found are likely not the fault of hotswap, but the implementation of those methods.

the new `sequins-transformer` PR includes a number of fixes & extensions for `sequins.settable`. the `timeline.hotswap` function is only loosely tested currently, and while it works on a basic level, i haven't explored complex nesting of different features (beyond a sequins in an action-table). there is likely some bugs & edge-cases not handled.

### extending

this library is intended to be extended as other stateful data structures ("classes"?) are identified that could benefit from live-piecemeal-modification. there may be a bunch of these on norns that i don't know about. on crow, `ASL` could potentially use this feature, but it's likely a very big undertaking as it'd have to interact with the C-layer.