### PR TITLE
add high-reliability mode for i2c

### DIFF
--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -24,6 +24,7 @@
 #include "../ll/adda.h"     // CAL_*()
 #include "../ll/cal_ll.h"   // CAL_LL_ActiveChannel()
 #include "../ll/system.h"   // getUID_Word()
+#include "../ll/i2c.h"      // I2C_SetTimings(u8)
 #include "lib/events.h"     // event_t event_post()
 #include "stm32f7xx_hal.h"  // HAL_GetTick()
 #include "stm32f7xx_it.h"   // CPU_GetCount()
@@ -873,6 +874,14 @@ static int _pub_view_out( lua_State* L )
     return 0;
 }
 
+// i2c debug control
+static int _i2c_set_timings( lua_State *L )
+{
+    I2C_SetTimings( luaL_checkinteger(L, 1) );
+    lua_pop( L, 1 );
+    return 0;
+}
+
 
 // array of all the available functions
 static const struct luaL_Reg libCrow[]=
@@ -886,6 +895,7 @@ static const struct luaL_Reg libCrow[]=
     , { "unique_id"        , _unique_id        }
     , { "time"             , _time             }
     , { "cputime"          , _cpu_time         }
+    , { "i2c_fastmode"     , _i2c_set_timings  }
     //, { "sys_cpu_load"     , _sys_cpu          }
         // io
     , { "get_state"        , _get_state        }

--- a/ll/i2c.c
+++ b/ll/i2c.c
@@ -43,6 +43,8 @@ I2C_error_callback_t  error_action;
 I2C_State_t buf;
 uint8_t pullup_state = 0;
 
+uint32_t i2c_timings = I2C_TIMING_STABLE; // default timings
+
 
 //////////////////////////////
 // public definitions
@@ -62,7 +64,7 @@ uint8_t I2C_Init( uint8_t               address
     error_action   = error_callback;
 
     i2c_handle.Instance              = I2Cx;
-    i2c_handle.Init.Timing           = I2C_TIMING;
+    i2c_handle.Init.Timing           = i2c_timings;
     i2c_handle.Init.OwnAddress1      = address << 1; // correct MSB justification
     i2c_handle.Init.AddressingMode   = I2C_ADDRESSINGMODE_7BIT;
     i2c_handle.Init.DualAddressMode  = I2C_DUALADDRESS_DISABLE;
@@ -84,6 +86,20 @@ uint8_t I2C_Init( uint8_t               address
 void I2C_DeInit( void )
 {
     HAL_I2C_DeInit( &i2c_handle );
+}
+
+void I2C_SetTimings( uint32_t is_fast )
+{
+    I2C_DeInit();
+    i2c_timings = is_fast ? I2C_TIMING_SPEED : I2C_TIMING_STABLE; // override timings
+    if( lead_response != NULL ){
+        I2C_Init( I2C_GetAddress()
+                , lead_response
+                , follow_action
+                , follow_request
+                , error_action
+                );
+    }
 }
 
 uint8_t I2C_is_boot( void )

--- a/ll/i2c.h
+++ b/ll/i2c.h
@@ -7,7 +7,11 @@
 //////////////////////////////////////////
 // hardware configuration
 
-#define I2C_TIMING  0xB042080B // see nucleof767 project for reasoning ~400kHz
+
+// these are from reference manual (p1232) but they do not give correct values
+// I2C_TIMINGR register
+#define I2C_TIMING_STABLE 0xD0421C0C // runs at 55kHz
+#define I2C_TIMING_SPEED  0xA0420B07 // runs at 320kHz
 
 #define I2Cx                            I2C1
 #define I2Cx_CLK_ENABLE()               __HAL_RCC_I2C1_CLK_ENABLE()
@@ -60,6 +64,8 @@ uint8_t I2C_is_boot( void );
 
 void I2C_SetPullups( uint8_t state );
 uint8_t I2C_GetPullups( void );
+
+void I2C_SetTimings( uint32_t mask );
 
 uint8_t I2C_GetAddress( void );
 void I2C_SetAddress( uint8_t address );

--- a/lua/ii.lua
+++ b/lua/ii.lua
@@ -18,6 +18,11 @@ function ii.pullup( state )
     ii_pullup(state)
 end
 
+function ii.fastmode( state )
+    if state == true then state = 1 else state = 0 end
+    i2c_fastmode(state)
+end
+
 -- aliases to C functions
 ii.set_address = ii_set_add
 ii.get_address = ii_get_add


### PR DESCRIPTION
this adds a new function `ii.fastmode(state)` to crow's lua system. a truthy value will set to fast (ie. the current normal) speed communication. while a falsey value will use slower timings with a much wider window on the rising edge of all clocks. this slow-mode (aka stable-mode) **is now the default selection**.

the motivation here is that a change in version 3.0 slightly increased the speed of communication (closer to the 400kHz limit of i2c fast mode), and we saw some reports of slightly less reliable i2c systems.

i2c communication speed is limited by the rise-time of the i2c lines. this rise time is a function of
1) how much pullup current is supplied to the lines
2) how many devices are attached to the network
3) total length of cables in the network.

Both 2) and 3) increase the effective capacitance of the network. This capacitance forms an effective 1pole lowpass filter with the pullup current resistors. The greater the capacitance, the lower the filter cutoff, and thus the slower the rising of the lines. This filter primarily affects the low-to-high transition of the i2c lines, and the fall-time can be ignored.

My 2 extreme test cases are a best-case, and a worst-case scenario:

best case: 2 crow modules, connected with <1" path, both with 40k pullup resistors to +3v3 and dedicated 2.2k pullup resistors on a busboard. Effective pullup current is ~1.5mA per line.

worst case: 2 crow modules, connected with 35" cable, with pullups disabled on 1 crow, and 40k enabled on the other. Pullup current is ~83uA (roughly 18 times less than the ideal).

In the worst case, the typical values would always fail on the first transmission, but reliably works with stable-mode timings. Communicating at roughly 55kHz clock speed. The lines were measured to reach around 2.3V on each rising edge (this is the 0.7xVdd requirement).

In the best case, either stable or fast mode works fine. Stable mode will reach speeds of 137kHz (nb. how the i2c driver auto-compensates). Fast mode reaches around 350kHz (slightly slower than the 400kHz limit of the spec). While the speed could be increased here, the slightly reduced speed results in higher voltage being reached on each rising edge (~2.5V) which was compromised to get the last 50kHz speed increase.

//

While the above was not tested with a great many other modules (though a White Whale was added to the bus to confirm it didn't dramatically influence capacitance [it didn't]), the observed behaviour suggests this should help with stability of some bus configurations.

A small subset of people who were really pushing the throughput limit of the i2c bus may find their scripts overload the bus now (though this feels incredibly unlikely). In that case they can place `ii.fastmode(true)` in their `init` function. This will almost certainly not be needed by anyone, but is kept here just in case someone wants to really push the maximum rate on the bus.

The key benefit is that setups that have crow as the only device providing pullup current may be able to operate a stable bus with more than 1 other module. Currently, it's hard to guarantee that crow can support more than 1 module because the amount of capacitance added by different implementations of i2c is highly variable. By changing to stable-mode by default, i hope we can dramatically reduce the number of i2c-stability related questions / issues / support requests throughout the eco-system.
