### PR TITLE
i2c reliability

### DIFF
--- a/lib/ii.c
+++ b/lib/ii.c
@@ -170,7 +170,7 @@ uint8_t ii_leader_enqueue_bytes( uint8_t  address
 void ii_leader_process( void )
 {
     if( !I2C_is_ready() ){ return; } // I2C lib is busy
-    int ix = queue_dequeue(l_qix);
+    int ix = queue_front(l_qix);
     if( ix < 0 ){ return; } // queue is empty!
     ii_q_t* q = &l_iq[ix];
 
@@ -185,6 +185,7 @@ void ii_leader_process( void )
                       )) ){
             if( error & 0x6 ){ error_action( 1 ); }
             printf("leadRx failed %i\n",error);
+            return; // EARLY RETURN. DOESN'T POP QUEUE. WILL RETRY
         }
     } else {
         if( (error = I2C_LeadTx( q->address
@@ -193,8 +194,10 @@ void ii_leader_process( void )
                       )) ){
             if( error & 2 ){ error_action( 1 ); }
             printf("leadTx failed %i\n",error);
+            return; // EARLY RETURN. DOESN'T POP QUEUE. WILL RETRY
         }
     }
+    queue_dequeue(l_qix); // pop the value as it was used
 }
 
 

--- a/lib/ii.c
+++ b/lib/ii.c
@@ -322,9 +322,9 @@ static void error_action( int error_code )
             break;
         case 1: // Bus is busy. Could this also be ARLO?
             if( I2C_GetPullups() ){
-                Caw_send_luachunk("ii: lines are low.");
-                Caw_send_luachunk("  check ii devices are connected correctly.");
-                Caw_send_luachunk("  check no ii devices are frozen.");
+                // Caw_send_luachunk("ii: lines are low.");
+                // Caw_send_luachunk("  check ii devices are connected correctly.");
+                // Caw_send_luachunk("  check no ii devices are frozen.");
             } else {
                 Caw_send_luachunk("ii: lines are low. try ii.pullup(true)");
             }

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -24,6 +24,7 @@
 #include "../ll/adda.h"     // CAL_*()
 #include "../ll/cal_ll.h"   // CAL_LL_ActiveChannel()
 #include "../ll/system.h"   // getUID_Word()
+#include "../ll/i2c.h"      // I2C_SetTimings(u8)
 #include "lib/events.h"     // event_t event_post()
 #include "stm32f7xx_hal.h"  // HAL_GetTick()
 #include "stm32f7xx_it.h"   // CPU_GetCount()
@@ -873,6 +874,14 @@ static int _pub_view_out( lua_State* L )
     return 0;
 }
 
+// i2c debug control
+static int _i2c_set_timings( lua_State *L )
+{
+    I2C_SetTimings( luaL_checkinteger(L, 1) );
+    lua_pop( L, 1 );
+    return 0;
+}
+
 
 // array of all the available functions
 static const struct luaL_Reg libCrow[]=
@@ -886,6 +895,7 @@ static const struct luaL_Reg libCrow[]=
     , { "unique_id"        , _unique_id        }
     , { "time"             , _time             }
     , { "cputime"          , _cpu_time         }
+    , { "i2c_fastmode"     , _i2c_set_timings  }
     //, { "sys_cpu_load"     , _sys_cpu          }
         // io
     , { "get_state"        , _get_state        }

--- a/ll/i2c.c
+++ b/ll/i2c.c
@@ -438,6 +438,14 @@ void I2Cx_ER_IRQHandler( void )
 
 void HAL_I2C_ErrorCallback( I2C_HandleTypeDef* h )
 {
+    printf("I2C_ERROR_");
+    switch( h->ErrorCode ){
+        case HAL_I2C_ERROR_BERR: printf("BERR\n"); break;
+        case HAL_I2C_ERROR_OVR:  printf("OVR\n"); break;
+        case HAL_I2C_ERROR_ARLO: printf("ARLO\n"); break;
+        case HAL_I2C_ERROR_AF:   printf("AF\n"); break;
+        default: printf("unknown!\n"); break;
+    }
     if( h->ErrorCode == HAL_I2C_ERROR_AF ){
         (*error_action)( 0 );
     } else {

--- a/ll/i2c.c
+++ b/ll/i2c.c
@@ -43,6 +43,8 @@ I2C_error_callback_t  error_action;
 I2C_State_t buf;
 uint8_t pullup_state = 0;
 
+uint32_t i2c_timings = I2C_TIMING_STABLE; // default timings
+
 
 //////////////////////////////
 // public definitions
@@ -62,7 +64,7 @@ uint8_t I2C_Init( uint8_t               address
     error_action   = error_callback;
 
     i2c_handle.Instance              = I2Cx;
-    i2c_handle.Init.Timing           = I2C_TIMING;
+    i2c_handle.Init.Timing           = i2c_timings;
     i2c_handle.Init.OwnAddress1      = address << 1; // correct MSB justification
     i2c_handle.Init.AddressingMode   = I2C_ADDRESSINGMODE_7BIT;
     i2c_handle.Init.DualAddressMode  = I2C_DUALADDRESS_DISABLE;
@@ -84,6 +86,20 @@ uint8_t I2C_Init( uint8_t               address
 void I2C_DeInit( void )
 {
     HAL_I2C_DeInit( &i2c_handle );
+}
+
+void I2C_SetTimings( uint32_t is_fast )
+{
+    I2C_DeInit();
+    i2c_timings = is_fast ? I2C_TIMING_SPEED : I2C_TIMING_STABLE; // override timings
+    if( lead_response != NULL ){
+        I2C_Init( I2C_GetAddress()
+                , lead_response
+                , follow_action
+                , follow_request
+                , error_action
+                );
+    }
 }
 
 uint8_t I2C_is_boot( void )

--- a/ll/i2c.h
+++ b/ll/i2c.h
@@ -7,7 +7,11 @@
 //////////////////////////////////////////
 // hardware configuration
 
-#define I2C_TIMING  0xB042080B // see nucleof767 project for reasoning ~400kHz
+
+// these are from reference manual (p1232) but they do not give correct values
+// I2C_TIMINGR register
+#define I2C_TIMING_STABLE 0xD0421C0C // runs at 55kHz
+#define I2C_TIMING_SPEED  0xA0420B07 // runs at 320kHz
 
 #define I2Cx                            I2C1
 #define I2Cx_CLK_ENABLE()               __HAL_RCC_I2C1_CLK_ENABLE()
@@ -60,6 +64,8 @@ uint8_t I2C_is_boot( void );
 
 void I2C_SetPullups( uint8_t state );
 uint8_t I2C_GetPullups( void );
+
+void I2C_SetTimings( uint32_t mask );
 
 uint8_t I2C_GetAddress( void );
 void I2C_SetAddress( uint8_t address );

--- a/lua/ii.lua
+++ b/lua/ii.lua
@@ -18,6 +18,11 @@ function ii.pullup( state )
     ii_pullup(state)
 end
 
+function ii.fastmode( state )
+    if state == true then state = 1 else state = 0 end
+    i2c_fastmode(state)
+end
+
 -- aliases to C functions
 ii.set_address = ii_set_add
 ii.get_address = ii_get_add


### PR DESCRIPTION
Unrelated to the pullup-centric PR, this is a (WIP) set of improvements to the i2c driver & ii layer to better handle errors.

especially when a message fails to send on an otherwise ok bus (due to another device taking control) we now retry sending that message. there is no timeout or limit, and this does mean the "ii lines are low" message is no longer sent if pullups are already enabled.

__more to come__