### PR TITLE
query calls currently registered stream_handler, not default stream

### DIFF
--- a/lua/input.lua
+++ b/lua/input.lua
@@ -119,7 +119,7 @@ Input.__index = function(self, ix)
     if     ix == 'volts' then
         return Input.get_value(self)
     elseif ix == 'query' then
-        return function() _c.tell('stream',self.channel,Input.get_value(self)) end
+        return function() stream_handler(self.channel,Input.get_value(self)) end
     elseif ix == 'mode'  then
         return function(...) Input.set_mode( self, ...) end
     elseif ix == 'reset_events' then


### PR DESCRIPTION
@dndrks this should solve the issue in the norns `.query` request: https://github.com/monome/norns/issues/1555

issue is that the new norns handling doesn't use the old 'named' convention (eg. `^^stream`) but instead allocates a dynamic name under the hood. the change was made such that future API changes on crow wouldn't require a co-edit to the norns system (ie. it would 'just work').