### PR TITLE
Ceify some of the lua libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,8 @@ OBJS += $(addprefix $(LUAS)/,$(LUACORE_OBJS) $(LUALIB_OBJS) )
 OBJS += Startup.o
 
 # specific objects that require built dependencies (ii)
-$(OBJDIR)/lib/lualink.o: $(LUA_PP) $(BUILD_DIR)/ii_lualink.h
+$(OBJDIR)/lib/l_bootstrap.o: $(LUA_PP) $(BUILD_DIR)/ii_lualink.h
+# $(OBJDIR)/lib/lualink.o: $(LUA_PP) $(BUILD_DIR)/ii_lualink.h
 $(OBJDIR)/lib/ii.o: $(BUILD_DIR)/ii_c_layer.h
 
 # generate the build directory

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,20 @@ $(BUILD_DIR)/ii_lualink.h: $(II_SRC) util/ii_lualinker.lua | $(BUILD_DIR)
 ### destination sources
 
 # lua srcs: these get converted to bytecode strings wrapped in c-headers
-LUA_SRC  = $(wildcard lua/*.lua)
+# LUA_SRC  = $(wildcard lua/*.lua)
+LUA_SRC += lua/asl.lua
+LUA_SRC += lua/asllib.lua
+LUA_SRC += lua/calibrate.lua
+LUA_SRC += lua/clock.lua
+LUA_SRC += lua/crowlib.lua
+LUA_SRC += lua/First.lua
+LUA_SRC += lua/ii.lua
+LUA_SRC += lua/input.lua
+LUA_SRC += lua/metro.lua
+LUA_SRC += lua/output.lua
+LUA_SRC += lua/public.lua
+LUA_SRC += lua/quote.lua
+LUA_SRC += lua/sequins.lua
 LUA_SRC += $(BUILD_DIR)/iihelp.lua
 LUA_SRC += $(II_TARGET)
 

--- a/lib/l_bootstrap.c
+++ b/lib/l_bootstrap.c
@@ -44,30 +44,30 @@ const struct lua_lib_locator Lua_libs[] =
 
 
 void l_bootstrap_init(lua_State* L){
-	// collectgarbage('setpause', 55)
-	lua_gc(L, LUA_GCSETPAUSE, 55);
-	lua_gc(L, LUA_GCSETSTEPMUL, 260);
+    // collectgarbage('setpause', 55)
+    lua_gc(L, LUA_GCSETPAUSE, 55);
+    lua_gc(L, LUA_GCSETSTEPMUL, 260);
 
-	// dofile just calls c_dofile
-	lua_getglobal(L, "c_dofile");
-	lua_setglobal(L, "dofile");
+    // dofile just calls c_dofile
+    lua_getglobal(L, "c_dofile");
+    lua_setglobal(L, "dofile");
 
-	// TODO collect & implement much of crowlib here directly
-	// _c = dofile('lua/crowlib.lua')
-	lua_pushliteral(L, "lua/crowlib.lua");
-	l_bootstrap_dofile(L); // hotrod without l_call
-	lua_setglobal(L, "_c");
+    // TODO collect & implement much of crowlib here directly
+    // _c = dofile('lua/crowlib.lua')
+    lua_pushliteral(L, "lua/crowlib.lua");
+    l_bootstrap_dofile(L); // hotrod without l_call
+    lua_setglobal(L, "_c");
 
-	// crow = _c
-	lua_getglobal(L, "_c");
-	lua_setglobal(L, "crow");
+    // crow = _c
+    lua_getglobal(L, "_c");
+    lua_setglobal(L, "crow");
 
     // crowlib C extensions
     l_crowlib_init(L);
 
-	// perform two full garbage collection cycles for full cleanup
-	lua_gc(L, LUA_GCCOLLECT, 1);
-	lua_gc(L, LUA_GCCOLLECT, 1);
+    // perform two full garbage collection cycles for full cleanup
+    lua_gc(L, LUA_GCCOLLECT, 1);
+    lua_gc(L, LUA_GCCOLLECT, 1);
 }
 
 
@@ -82,11 +82,11 @@ int l_bootstrap_dofile(lua_State* L)
     char cname[32]; // 32bytes is more than enough for any path
     int p=0; // pointer into cname
     for(int i=0; i<l_len; i++){
-    	switch(l_name[i]){
-    		case '/':{ cname[p++] = '_'; } break;
-    		case '.':{ cname[p++] = 0; } goto strcomplete;
-    		default:{ cname[p++] = l_name[i]; } break;
-    	}
+        switch(l_name[i]){
+            case '/':{ cname[p++] = '_'; } break;
+            case '.':{ cname[p++] = 0; } goto strcomplete;
+            default:{ cname[p++] = l_name[i]; } break;
+        }
     }
 strcomplete:
     lua_pop( L, 1 );

--- a/lib/l_bootstrap.c
+++ b/lib/l_bootstrap.c
@@ -1,0 +1,179 @@
+#include "l_bootstrap.h"
+
+#include <string.h>
+
+//#include "lualink.h"
+
+#include "lua/crowlib.lua.h"
+#include "lua/asl.lua.h"
+#include "lua/asllib.lua.h"
+#include "lua/clock.lua.h"
+#include "lua/metro.lua.h"
+#include "lua/public.lua.h"
+#include "lua/input.lua.h"
+#include "lua/output.lua.h"
+#include "lua/ii.lua.h"
+#include "build/iihelp.lua.h"    // generated lua stub for loading i2c modules
+#include "lua/calibrate.lua.h"
+#include "lua/sequins.lua.h"
+#include "lua/quote.lua.h"
+
+#include "build/ii_lualink.h" // generated C header for linking to lua
+
+static int _writer(lua_State *L, const void *p, size_t sz, void *ud);
+static int _load_chunk(lua_State* L, const char* code, int strip);
+static int _open_lib( lua_State *L, const struct lua_lib_locator* lib, const char* name );
+
+// mark the 3rd arg 'false' if you need to debug that library
+const struct lua_lib_locator Lua_libs[] =
+    { { "lua_crowlib"   , lua_crowlib   , true}
+    , { "lua_asl"       , lua_asl       , true}
+    , { "lua_asllib"    , lua_asllib    , true}
+    , { "lua_clock"     , lua_clock     , true}
+    , { "lua_metro"     , lua_metro     , true}
+    , { "lua_input"     , lua_input     , true}
+    , { "lua_output"    , lua_output    , true}
+    , { "lua_public"    , lua_public    , true}
+    , { "lua_ii"        , lua_ii        , true}
+    , { "build_iihelp"  , build_iihelp  , true}
+    , { "lua_calibrate" , lua_calibrate , true}
+    , { "lua_sequins"   , lua_sequins   , true}
+    , { "lua_quote"     , lua_quote     , true}
+    , { NULL            , NULL          , true}
+    };
+
+void l_bootstrap_init(lua_State* L){
+	// collectgarbage('setpause', 55)
+	lua_gc(L, LUA_GCSETPAUSE, 55);
+	lua_gc(L, LUA_GCSETSTEPMUL, 260);
+
+	// // print -> print_serial
+	// lua_pushcfunction(L,lcf1_print);
+	// lua_setfield(L,LUA_ENVIRONINDEX,"print");
+	// assert(lua_gettop(L) - lc_nextra == 0);
+
+	// dofile just calls c_dofile
+	lua_getglobal(L, "c_dofile");
+	lua_setglobal(L, "dofile");
+
+	// TODO collect & implement much of crowlib here directly
+	// _c = dofile('lua/crowlib.lua')
+	lua_pushliteral(L, "lua/crowlib.lua");
+	l_bootstrap_dofile(L); // hotrod without l_call
+	lua_setglobal(L, "_c");
+
+	// crow = _c
+	lua_getglobal(L, "_c");
+	lua_setglobal(L, "crow");
+
+	// perform two full garbage collection cycles for full cleanup
+	lua_gc(L, LUA_GCCOLLECT, 1);
+	lua_gc(L, LUA_GCCOLLECT, 1);
+}
+
+int l_bootstrap_dofile(lua_State* L)
+{
+    const char* l_name = luaL_checkstring(L, 1);
+    int l_len = strlen(l_name);
+    if(l_len > 32) printf("FIXME bootstrap: filepath >32bytes!\n\r");
+
+    // simple C version of "luapath_to_cpath"
+    // l_name is a lua native path: "lua/asl.lua"
+    char cname[32]; // 32bytes is more than enough for any path
+    int p=0; // pointer into cname
+    for(int i=0; i<l_len; i++){
+    	switch(l_name[i]){
+    		case '/':{ cname[p++] = '_'; } break;
+    		case '.':{ cname[p++] = 0; } goto strcomplete;
+    		default:{ cname[p++] = l_name[i]; } break;
+    	}
+    }
+strcomplete:
+    lua_pop( L, 1 );
+    switch( _open_lib( L, Lua_libs, cname ) ){
+        case -1: goto fail;
+        case 1: return 1;
+        default: break;
+    }
+    switch( _open_lib( L, Lua_ii_libs, cname ) ){
+        case -1: goto fail;
+        case 1: return 1;
+        default: break;
+    }
+    printf("can't open library: %s\n", (char*)cname);
+fail:
+    lua_pushnil(L);
+    return 1;
+}
+
+/////////// private defns
+
+// this is a somewhat arbitrary size. must be big enough for the biggest library. 8kB was too small
+#define SIZED_STRING_LEN 0x4000 // (16kB)
+struct sized_string{
+    char data[SIZED_STRING_LEN];
+    int  len;
+};
+
+#define UNUSED(x) (void)(sizeof(x))
+static int _writer(lua_State *L, const void *p, size_t sz, void *ud)
+{
+    UNUSED(L);
+    struct sized_string* chunkstr = ud; /// need explicit cast?
+    if(chunkstr->len + sz >= SIZED_STRING_LEN){
+        printf("chunkstr too small.\n");
+        return 1;
+    }
+    memcpy(&chunkstr->data[chunkstr->len], p, sz);
+    chunkstr->len += sz;
+    return 0;
+}
+#undef UNUSED
+
+static int _load_chunk(lua_State* L, const char* code, int strip)
+{
+    int retval = 0;
+    struct sized_string chunkstr = {.len = 0};
+    { // scope lua_State to destroy it asap
+        lua_State* LL=luaL_newstate();
+        if( !LL ){ printf("luaL_newstate failed\n"); return 1; }
+        if( luaL_loadstring(LL, code) ){
+            printf("loadstring error\n");
+            retval = 1;
+            goto close_LL;
+        }
+        if( lua_dump(LL, _writer, &chunkstr, strip) ){
+            printf("dump error\n");
+            retval = 1;
+            goto close_LL;
+        }
+close_LL:
+        lua_close(LL);
+    }
+    luaL_loadbuffer(L, chunkstr.data, chunkstr.len, chunkstr.data); // load our compiled chunk
+    return retval;
+}
+
+static int _open_lib( lua_State *L, const struct lua_lib_locator* lib, const char* name )
+{
+    uint8_t i = 0;
+    while( lib[i].addr_of_luacode != NULL ){
+        if( !strcmp( name, lib[i].name ) ){ // if the strings match
+            if( _load_chunk(L, lib[i].addr_of_luacode, lib[i].stripped) ){
+                printf("can't load library: %s\n", (char*)lib[i].name );
+                printf( "%s\n", (char*)lua_tostring( L, -1 ) );
+                lua_pop( L, 1 );
+                return -1; // error
+            }
+            if( lua_pcall(L, 0, LUA_MULTRET, 0) ){
+                printf("can't exec library: %s\n", (char*)lib[i].name );
+                printf( "%s\n", (char*)lua_tostring( L, -1 ) );
+                lua_pop( L, 1 );
+                return -1; // error
+            }
+            return 1; // table is left on the stack as retval
+        }
+        i++;
+    }
+    return 0; // not found
+}

--- a/lib/l_bootstrap.c
+++ b/lib/l_bootstrap.c
@@ -2,7 +2,7 @@
 
 #include <string.h>
 
-//#include "lualink.h"
+#include "l_crowlib.h"
 
 #include "lua/crowlib.lua.h"
 #include "lua/asl.lua.h"
@@ -42,15 +42,11 @@ const struct lua_lib_locator Lua_libs[] =
     , { NULL            , NULL          , true}
     };
 
+
 void l_bootstrap_init(lua_State* L){
 	// collectgarbage('setpause', 55)
 	lua_gc(L, LUA_GCSETPAUSE, 55);
 	lua_gc(L, LUA_GCSETSTEPMUL, 260);
-
-	// // print -> print_serial
-	// lua_pushcfunction(L,lcf1_print);
-	// lua_setfield(L,LUA_ENVIRONINDEX,"print");
-	// assert(lua_gettop(L) - lc_nextra == 0);
 
 	// dofile just calls c_dofile
 	lua_getglobal(L, "c_dofile");
@@ -66,10 +62,14 @@ void l_bootstrap_init(lua_State* L){
 	lua_getglobal(L, "_c");
 	lua_setglobal(L, "crow");
 
+    // crowlib C extensions
+    l_crowlib_init(L);
+
 	// perform two full garbage collection cycles for full cleanup
 	lua_gc(L, LUA_GCCOLLECT, 1);
 	lua_gc(L, LUA_GCCOLLECT, 1);
 }
+
 
 int l_bootstrap_dofile(lua_State* L)
 {
@@ -105,6 +105,11 @@ fail:
     lua_pushnil(L);
     return 1;
 }
+
+
+
+
+
 
 /////////// private defns
 

--- a/lib/l_bootstrap.h
+++ b/lib/l_bootstrap.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "../submodules/lua/src/lua.h" // in header
+#include "../submodules/lua/src/lauxlib.h"
+#include "../submodules/lua/src/lualib.h"
+
+void l_bootstrap_init(lua_State* L);
+int l_bootstrap_dofile(lua_State* L);

--- a/lib/l_crowlib.c
+++ b/lib/l_crowlib.c
@@ -1,0 +1,98 @@
+#include "l_crowlib.h"
+
+#include <math.h>
+
+#define L_CL_MIDDLEC 		(261.63f)
+#define L_CL_MIDDLEC_INV 	(1.0f/L_CL_MIDDLEC)
+#define L_CL_JIVOLT 		(1.0f/logf(2.f))
+
+
+// called after crowlib lua file is loaded
+// here we add any additional globals and such
+void l_crowlib_init(lua_State* L){}
+
+
+// Just Intonation calculators
+
+static int justvolts(lua_State* L, float mul);
+
+int l_crowlib_justvolts(lua_State* L){
+	return justvolts(L, 1.f);
+}
+
+int l_crowlib_just12(lua_State *L){
+	return justvolts(L, 12.f);
+}
+
+int l_crowlib_hztovolts(lua_State *L){
+	// assume numbers, not tables
+	float retval = 0.f;
+	switch(lua_gettop(L)){
+		case 1: // use default middleC reference
+			// note we 
+			retval = log2f(luaL_checknumber(L, 1) * L_CL_MIDDLEC_INV);
+			break;
+		case 2: // use provided reference
+			retval = log2f(luaL_checknumber(L, 1)/luaL_checknumber(L, 2));
+			break;
+		default:
+			lua_pushliteral(L, "need 1 or 2 args");
+			lua_error(L);
+			break;
+	}
+    lua_settop(L, 0);
+	lua_pushnumber(L, retval);
+	return 1;
+}
+
+static int justvolts(lua_State* L, float mul){
+	// apply optional offset
+	float offset = 0.f;
+	switch(lua_gettop(L)){
+		case 1: break;
+		case 2: {offset = log2f(luaL_checknumber(L, 2))*mul;} break;
+		default:
+			lua_pushliteral(L, "need 1 or 2 args");
+			lua_error(L);
+			break;
+	}
+
+	// now do the conversion
+	int nresults = 0;
+	switch(lua_type(L, 1)){
+		case LUA_TNUMBER:{
+			float result = log2f(lua_tonumber(L, 1))*mul + offset;
+			lua_settop(L, 0);
+			lua_pushnumber(L, result);
+			nresults = 1;
+			break;}
+		case LUA_TTABLE:{
+			// get length of table to convert
+			lua_len(L, 1);
+			int telems = lua_tonumber(L, -1);
+			lua_pop(L, 1);
+
+			// build the new table in C (a copy)
+			float newtab[telems+1]; // bottom element is unused
+			for(int i=1; i<=telems; i++){
+				lua_geti(L, 1, i);
+				newtab[i] = log2f(luaL_checknumber(L, -1))*mul + offset;
+				lua_pop(L, 1); // pops the number from the stack
+			}
+
+			// push the C table into the lua table
+			lua_settop(L, 0);
+			lua_createtable(L, telems, 0);
+			for(int i=1; i<=telems; i++){
+				lua_pushnumber(L, newtab[i]);
+				lua_seti(L, 1, i);
+			}
+			nresults = 1;
+			break;}
+		default:
+			lua_pushliteral(L, "unknown voltage type");
+			lua_error(L);
+			break;
+	}
+	return nresults;
+}

--- a/lib/l_crowlib.h
+++ b/lib/l_crowlib.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "../submodules/lua/src/lua.h" // in header
+#include "../submodules/lua/src/lauxlib.h"
+#include "../submodules/lua/src/lualib.h"
+
+void l_crowlib_init(lua_State* L);
+
+int l_crowlib_justvolts(lua_State *L);
+int l_crowlib_just12(lua_State *L);
+int l_crowlib_hztovolts(lua_State *L);

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -29,8 +29,11 @@
 #include "stm32f7xx_hal.h"  // HAL_GetTick()
 #include "stm32f7xx_it.h"   // CPU_GetCount()
 
-// Lua libs wrapped in C-headers: Note the extra '.h'
-#include "l_bootstrap.h" // MUST LOAD THIS MANUALLY FIRST
+// Lua lib C implementations
+// as much low-level functionality is in here as possible
+// thus keeping the lua VM as free as possible
+#include "l_bootstrap.h"
+#include "l_crowlib.h"
 
 
 #define WATCHDOG_FREQ      0x100000 // ~1s how often we run the watchdog
@@ -776,6 +779,10 @@ static const struct luaL_Reg libCrow[]=
     , { "print_serial"     , _print_serial     }
     , { "tell"             , _print_tell       }
         // system
+    , { "justvolts"        , l_crowlib_justvolts }
+    , { "just12"           , l_crowlib_just12    }
+    , { "hztovolts"        , l_crowlib_hztovolts }
+        // crowlib
     , { "sys_bootloader"   , _bootloader       }
     , { "unique_id"        , _unique_id        }
     , { "time"             , _time             }

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -30,43 +30,12 @@
 #include "stm32f7xx_it.h"   // CPU_GetCount()
 
 // Lua libs wrapped in C-headers: Note the extra '.h'
-#include "lua/bootstrap.lua.h" // MUST LOAD THIS MANUALLY FIRST
-#include "lua/crowlib.lua.h"
-#include "lua/asl.lua.h"
-#include "lua/asllib.lua.h"
-#include "lua/clock.lua.h"
-#include "lua/metro.lua.h"
-#include "lua/public.lua.h"
-#include "lua/input.lua.h"
-#include "lua/output.lua.h"
-#include "lua/ii.lua.h"
-#include "build/iihelp.lua.h"    // generated lua stub for loading i2c modules
-#include "lua/calibrate.lua.h"
-#include "lua/sequins.lua.h"
-#include "lua/quote.lua.h"
+#include "l_bootstrap.h" // MUST LOAD THIS MANUALLY FIRST
 
-#include "build/ii_lualink.h" // generated C header for linking to lua
 
 #define WATCHDOG_FREQ      0x100000 // ~1s how often we run the watchdog
 #define WATCHDOG_COUNT     2        // how many watchdogs before 'frozen'
 
-// mark the 3rd arg 'false' if you need to debug that library
-const struct lua_lib_locator Lua_libs[] =
-    { { "lua_crowlib"   , lua_crowlib   , true}
-    , { "lua_asl"       , lua_asl       , true}
-    , { "lua_asllib"    , lua_asllib    , true}
-    , { "lua_clock"     , lua_clock     , true}
-    , { "lua_metro"     , lua_metro     , true}
-    , { "lua_input"     , lua_input     , true}
-    , { "lua_output"    , lua_output    , true}
-    , { "lua_public"    , lua_public    , true}
-    , { "lua_ii"        , lua_ii        , true}
-    , { "build_iihelp"  , build_iihelp  , true}
-    , { "lua_calibrate" , lua_calibrate , true}
-    , { "lua_sequins"   , lua_sequins   , true}
-    , { "lua_quote"     , lua_quote     , true}
-    , { NULL            , NULL          , true}
-    };
 
 // Basic crow script
 #include "lua/First.lua.h"
@@ -108,10 +77,11 @@ lua_State* Lua_Init(void)
     L = luaL_newstate();
     luaL_openlibs(L);
     Lua_linkctolua(L);
-    Lua_eval(L, lua_bootstrap
-              , strlen(lua_bootstrap)
-              , "=lib"
-              ); // redefine dofile(), print(), load crowlib
+    l_bootstrap_init(L); // redefine dofile(), print(), load crowlib
+    // Lua_eval(L, lua_bootstrap
+    //           , strlen(lua_bootstrap)
+    //           , "=lib"
+    //           ); 
     return L;
 }
 
@@ -150,91 +120,6 @@ void Lua_DeInit(void)
 // to avoid shadowing similar-named extern functions in other modules
 // and also to distinguish from extern 'L_' functions.
 
-// this is a somewhat arbitrary size. must be big enough for the biggest library. 8kB was too small
-#define SIZED_STRING_LEN 0x4000 // (16kB)
-struct sized_string{
-    char data[SIZED_STRING_LEN];
-    int  len;
-};
-static int _writer(lua_State *L, const void *p, size_t sz, void *ud)
-{
-    UNUSED(L);
-    struct sized_string* chunkstr = ud; /// need explicit cast?
-    if(chunkstr->len + sz >= SIZED_STRING_LEN){
-        printf("chunkstr too small.\n");
-        return 1;
-    }
-    memcpy(&chunkstr->data[chunkstr->len], p, sz);
-    chunkstr->len += sz;
-    return 0;
-}
-static int _load_chunk(lua_State* L, const char* code, int strip)
-{
-    int retval = 0;
-    struct sized_string chunkstr = {.len = 0};
-    { // scope lua_State to destroy it asap
-        lua_State* LL=luaL_newstate();
-        if( !LL ){ printf("luaL_newstate failed\n"); return 1; }
-        if( luaL_loadstring(LL, code) ){
-            printf("loadstring error\n");
-            retval = 1;
-            goto close_LL;
-        }
-        if( lua_dump(LL, _writer, &chunkstr, strip) ){
-            printf("dump error\n");
-            retval = 1;
-            goto close_LL;
-        }
-close_LL:
-        lua_close(LL);
-    }
-    luaL_loadbuffer(L, chunkstr.data, chunkstr.len, chunkstr.data); // load our compiled chunk
-    return retval;
-}
-
-static int _open_lib( lua_State *L, const struct lua_lib_locator* lib, const char* name )
-{
-    uint8_t i = 0;
-    while( lib[i].addr_of_luacode != NULL ){
-        if( !strcmp( name, lib[i].name ) ){ // if the strings match
-            if( _load_chunk(L, lib[i].addr_of_luacode, lib[i].stripped) ){
-                printf("can't load library: %s\n", (char*)lib[i].name );
-                printf( "%s\n", (char*)lua_tostring( L, -1 ) );
-                lua_pop( L, 1 );
-                return -1; // error
-            }
-            if( lua_pcall(L, 0, LUA_MULTRET, 0) ){
-                printf("can't exec library: %s\n", (char*)lib[i].name );
-                printf( "%s\n", (char*)lua_tostring( L, -1 ) );
-                lua_pop( L, 1 );
-                return -1; // error
-            }
-            return 1; // table is left on the stack as retval
-        }
-        i++;
-    }
-    return 0; // not found
-}
-
-static int _dofile( lua_State *L )
-{
-    const char* l_name = luaL_checkstring(L, 1);
-    lua_pop( L, 1 );
-    switch( _open_lib( L, Lua_libs, l_name ) ){
-        case -1: goto fail;
-        case 1: return 1;
-        default: break;
-    }
-    switch( _open_lib( L, Lua_ii_libs, l_name ) ){
-        case -1: goto fail;
-        case 1: return 1;
-        default: break;
-    }
-    printf("can't open library: %s\n", (char*)l_name);
-fail:
-    lua_pushnil(L);
-    return 1;
-}
 static int _debug( lua_State *L )
 {
     const char* msg = luaL_checkstring(L, 1);
@@ -886,7 +771,7 @@ static int _i2c_set_timings( lua_State *L )
 // array of all the available functions
 static const struct luaL_Reg libCrow[]=
         // bootstrap
-    { { "c_dofile"         , _dofile           }
+    { { "c_dofile"         , l_bootstrap_dofile }
     , { "debug_usart"      , _debug            }
     , { "print_serial"     , _print_serial     }
     , { "tell"             , _print_tell       }

--- a/lua/bootstrap.lua
+++ b/lua/bootstrap.lua
@@ -1,3 +1,11 @@
+--- DEPRECATED!!
+--- NOT INCLUDED IN BINARY
+
+
+
+
+
+
 --- Bootstrap Lua by redefining standard library functions
 -- dofile() and print() need hardware specific implementations
 -- call this before any other lua code

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -1,3 +1,17 @@
+-- temp placing print redef here to complete bootstrap elimination
+print = function(...)
+    local args = {...}
+    local arg_len = #args
+    local printResult = args[1]
+    if arg_len > 1 then
+        for i=2,arg_len do
+            printResult = printResult .. '\t' .. tostring(args[i])
+        end
+    end
+    print_serial(tostring(printResult))
+end
+
+
 --- Crow standard library
 
 local C = {}

--- a/lua/crowlib.lua
+++ b/lua/crowlib.lua
@@ -162,42 +162,37 @@ function delay(action, time, repeats)
         end)
 end
 
---- Just Intonation helpers
--- convert a single fraction, or table of fractions to just intonation
--- optional 'offset' is itself a just ratio
--- justvolts converts to volts-per-octave
--- just12 converts to 12TET representation (for *.scale libs)
--- just12 will convert a fraction or table of fractions into 12tet 'semitones'
-function _justint(fn, f, off)
-    off = off and fn(off) or 0 -- optional offset is a just ratio
-    if type(f) == 'table' then
-        local t = {}
-        for k,v in ipairs(f) do
-            t[k] = fn(v) + off
-        end
-        return t
-    else -- assume number
-        return fn(f) + off
-    end
-end
-JIVOLT = 1 / math.log(2)
-JI12TET = 12 * JIVOLT
-function _jiv(f) return math.log(f) * JIVOLT end
-function _ji12(f) return math.log(f) * JI12TET end
--- public functions
-function justvolts(f, off) return _justint(_jiv, f, off) end
-function just12(f, off) return _justint(_ji12, f, off) end
-function hztovolts(hz, ref)
-    ref = ref or 261.63 -- optional. defaults to middle-C
-    return justvolts(hz/ref)
-end
+-- --- Just Intonation helpers
+-- -- convert a single fraction, or table of fractions to just intonation
+-- -- optional 'offset' is itself a just ratio
+-- -- justvolts converts to volts-per-octave
+-- -- just12 converts to 12TET representation (for *.scale libs)
+-- -- just12 will convert a fraction or table of fractions into 12tet 'semitones'
+-- function _justint(fn, f, off)
+--     off = off and fn(off) or 0 -- optional offset is a just ratio
+--     if type(f) == 'table' then
+--         local t = {}
+--         for k,v in ipairs(f) do
+--             t[k] = fn(v) + off
+--         end
+--         return t
+--     else -- assume number
+--         return fn(f) + off
+--     end
+-- end
+-- JIVOLT = 1 / math.log(2)
+-- JI12TET = 12 * JIVOLT
+-- function _jiv(f) return math.log(f) * JIVOLT end
+-- function _ji12(f) return math.log(f) * JI12TET end
+-- -- public functions
+-- function justvolts(f, off) return _justint(_jiv, f, off) end
+-- function just12(f, off) return _justint(_ji12, f, off) end
+-- function hztovolts(hz, ref)
+--     ref = ref or 261.63 -- optional. defaults to middle-C
+--     return justvolts(hz/ref)
+-- end
 
 -- empty init function in case userscript doesn't define it
 function init() end
-
--- cleanup all unused lua objects before releasing to the userscript
--- call twice to ensure all finalizers are caught
-collectgarbage()
-collectgarbage()
 
 return C


### PR DESCRIPTION
An attempt to address some of #459 .

The general idea is that much of the lua library can be converted into C libraries that interact with the lua C API, or better yet, re-write any arithmetic handling in C directly (though there is little of this).

So far this is just a proof of concept, taking the `bootstrap.lua` and some of the `crowlib.lua` and converting it to C calls. The goal is to reduce runtime RAM usage of the lua machine, by avoiding creation of lua functions, instead linking directly to C function calls.

Below I've converted all of the `bootstrap.lua` file to C API calls, except for `print` which has moved to `crowlib.lua`.
Additionally, I've converted the Just Intonation helper functions into native C functions which interact with the lua VM directly. This should have slightly sped up the functionality, but moreso we've reduced RAM usage at runtime.

These changes took RAM usage after boot from 92.3kB down to 90.1kB. Flash usage is almost identical (about 200bytes more).

While it's only 2kB of savings so far, the idea could be extrapolated to some entire libraries. Specifically I'm thinking it makes sense to do this only for low-level libraries that users are unlikely to ever need to change (though they can still redefine things as they wish at runtime). I'm thinking this makes sense for `quote.lua`, `metro.lua`, `public.lua` and elements of `crowlib.lua` and `ii.lua`. Realistically this can save us in the ballpark of 20-50kB of runtime RAM.

`asl.lua` would be another big area that could be improved. While the runtime is already running in C, the descriptive language in lua is parsed internally and creates big blobs of tables every time we assign a new action. These blobs are themselves later broken down by the Casl.c implementation, so it would be beneficial to optimize this handshake, moving the lua-C api one step higher in the tree of abstraction.

That said, it's not an easy process, and requires some deep thinking to make the API interactions make sense. This is not something I'll have a lot of time for in the foreseeable future, and feels like a poor use of time. I looked for some automated tools to do this, but the only thing I found was https://github.com/davidm/lua2c/ which is based on lua5.1 and is not API compatible with lua5.3 that we're using in crow. The hardest things are obviously iterating over tables, and correctly handling errors so we don't trash the runtime feedback.

On the positive side, I think it's cleared up some of the `lib/lualink.c` file which is a big unwieldy block of function defs to be loaded into the lua VM. It would be nice to segregate the C functions into their own files, collecting related features together, rather than the monolithic connection in lualink.

---

This is probably more of an academic exercise, and I doubt I'll ever find the time to fully roll it out, but it's an interesting path forward to make crow capable of more things. The project feels a little trapped by the uC capabilities (let alone our inability to make more hardware), so this is yet another path that we can go down in the future if our time is best spent pushing this project.

Many more optimizations can be made if we switch some of the core libraries to using `userdata` objects, so we can optimize the C calls without resorting to lua C API manipulations exclusively (`input.lua` is a great example where we do a lot of control flow based on the state of the `Input` table). Again, this is beyond my personal experience right now, so it's non-trivial to make the change.

In the meantime, this has been quite insightful for me. It helps me to see where lua is powerful, and gives me hope that one could make a lua VM with a limited RAM footprint. It requires a lot of careful decisions about where dynamic allocation happens. specifically prioritizing declarative syntax makes it far easier to offload computation (and memory) to the C layer.

Many thoughts, but this is where I'll leave it for now.