### PR TITLE
fix samplerate being halfspeed

### DIFF
--- a/ll/dac8565.c
+++ b/ll/dac8565.c
@@ -40,9 +40,9 @@ void DAC_Init( uint16_t bsize, uint8_t chan_count )
     dac_i2s.Init.Standard     = I2S_STANDARD_PCM_SHORT;
     dac_i2s.Init.DataFormat   = I2S_DATAFORMAT_24B;
     dac_i2s.Init.MCLKOutput   = I2S_MCLKOUTPUT_ENABLE;
-    dac_i2s.Init.AudioFreq    = I2S_AUDIOFREQ_96K;
+    dac_i2s.Init.AudioFreq    = I2S_AUDIOFREQ_192K; // manipulates mclk to hit 48kHz on 4 chans
     dac_i2s.Init.CPOL         = I2S_CPOL_LOW;
-    dac_i2s.Init.ClockSource  = I2S_CLOCK_SYSCLK;
+    dac_i2s.Init.ClockSource  = I2S_CLOCK_PLL;
 
     if(HAL_I2S_Init(&dac_i2s) != HAL_OK){ printf("i2s_init\n"); }
 
@@ -180,8 +180,8 @@ void HAL_I2S_MspInit(I2S_HandleTypeDef *hi2s)
     // I2SCLK = f(PLLI2S clock output) = f(VCO clock) / PLLI2SR
     RCC_ExCLKInitStruct.PeriphClockSelection = RCC_PERIPHCLK_I2S;
     RCC_ExCLKInitStruct.I2sClockSelection = RCC_I2SCLKSOURCE_PLLI2S;
-    RCC_ExCLKInitStruct.PLLI2S.PLLI2SN = 384;
-    RCC_ExCLKInitStruct.PLLI2S.PLLI2SR = 2;
+    RCC_ExCLKInitStruct.PLLI2S.PLLI2SN = 384; // mul factor: 50~432
+    RCC_ExCLKInitStruct.PLLI2S.PLLI2SR = 2; // div factor: 2~7
     HAL_RCCEx_PeriphCLKConfig(&RCC_ExCLKInitStruct);
 
     // SPI/I2S & DMA


### PR DESCRIPTION
Fixes #453 

I'm not sure why this has happened which gives me pause about the solution. What I'm doing now is just increasing the frequency the I2S driver runs at by 2x. Measured samplerate at approximately 48kHz on the scope, and slope times are now accurate compared to the samplerate.

I tried to increase the incoming PLL so the constants were correct in the library, but it seems the PLL is close to maxed out already. Uncertainty why, but this still solves the problem. I've checked that Metro, Clock and Input.stream modes are all running at the correct speeds, so this issue seems to be isolated to just the DAC.

I did a little benchmarking along the way, and discovered that when all 4 channels are running an ASL oscillator, the overhead is 30~35% of available CPU power (oscs at 1k,2k,3k,4k). I was worried it would be worse with the increase of 2x speed, but this seems totally reasonable to me -- It's the primary high-priority CPU task, and leaves plenty of room for the rest of the system.