### PR TITLE
Status_LED: xor flips are throttled, and only sent if USB connected

### DIFF
--- a/ll/status_led.c
+++ b/ll/status_led.c
@@ -1,9 +1,12 @@
 #include "status_led.h"
 
+#include <stdbool.h>
+
 // LED on GPIO A15
 
 static GPIO_InitTypeDef GPIO_IS;
 static LED_SPEED fast_blink;
+static bool do_flip = false;
 
 void status_led_init(void){
     // activate peripheral clock
@@ -21,9 +24,12 @@ void status_led_init(void){
 // call this at a regular interval (designed for 1ms interval)
 uint32_t next_flip = 0;
 void status_led_tick(uint32_t time_now){
-    if(time_now > next_flip){
-        status_led_xor();
+    if(time_now > next_flip // time to animate timer
+    || (do_flip && fast_blink)){ // xor event & USB connected
+        // status_led_xor();
+        HAL_GPIO_TogglePin(GPIOA, GPIO_PIN_15);
         next_flip = time_now + (fast_blink ? 2000 : 500);
+        do_flip = false;
     }
 }
 
@@ -36,5 +42,6 @@ void status_led_set(uint8_t is_on){
 }
 
 void status_led_xor(void){
-    HAL_GPIO_TogglePin(GPIOA, GPIO_PIN_15);
+    // HAL_GPIO_TogglePin(GPIOA, GPIO_PIN_15);
+    do_flip = true;
 }


### PR DESCRIPTION
per discussion in #475 

@tehn this should solve the 2 issues you saw. XOR will only occur once per millisecond tick, and only if the USB connection is active.

no performance penalty for the `xor` calls (they set a boolean flag, rather than writing directly to the hardware pin), and the background loop has an additional conditional which should be near-zero cpu impact as it's just non-zero check.