### PR TITLE
add missing wtape loop_active getter

### DIFF
--- a/lua/ii/wtape.lua
+++ b/lua/ii/wtape.lua
@@ -67,6 +67,7 @@ do return
     }
   , { name = 'loop_active'
     , cmd  = 12
+    , get  = true
     , args = { 'state', s8 }
     , docs = 'Set the state of looping'
     }


### PR DESCRIPTION
Reproduction:
```lua
> ii.wtape.event=function(e,v) print(e.name.."="..v) end

> ii.wtape[1].get("loop_active")

```

After the fix:
```lua
> ii.wtape.event=function(e,v) print(e.name.."="..v) end

> ii.wtape[1].get("loop_active")
loop_active=0.0

> ii.wtape[1].get("loop_active")
loop_active=1.0
```