### PR TITLE
Clock features

### DIFF
--- a/lib/clock.c
+++ b/lib/clock.c
@@ -99,13 +99,14 @@ bool clock_schedule_resume_sleep( int coro_id, float seconds )
     return ll_insert_event(&sleep_head, coro_id, wakeup);
 }
 
-bool clock_schedule_resume_sync( int coro_id, float beats ){
+bool clock_schedule_resume_sync( int coro_id, float beats, float offset ){
     double dbeats = beats;
 
     // modulo sync time against base beat
     double awaken = floor(reference.beat / dbeats);
     awaken *= dbeats;
     awaken += dbeats;
+    awaken += (double)offset;
 
     // check we haven't already passed it in the sub-beat & add another step if we have
     // we have to loop because fractional beats values may occur >2 times within a beat

--- a/lib/clock.c
+++ b/lib/clock.c
@@ -329,3 +329,11 @@ void clock_crow_in_div( float div )
 {
     crow_in_div = 1.0/div;
 }
+
+double clock_get_crow_last_time(void)
+{
+    if( clock_crow_last_time_set == false ){
+        return -1.0; // No clock received yet
+    }
+    return clock_get_time_seconds() - clock_crow_last_time;
+}

--- a/lib/clock.c
+++ b/lib/clock.c
@@ -8,6 +8,7 @@
 #include <stm32f7xx_hal.h> // HAL_GetTick
 #include "clock_ll.h" // linked list for clocks
 
+#include "caw.h" // Caw_printf
 
 ///////////////////////////////
 // private types
@@ -124,10 +125,16 @@ bool clock_schedule_resume_beatsync( int coro_id, float beats ){
 
 void clock_update_reference(double beats, double beat_duration)
 {
+    float prev_beat_duration = reference.beat_duration;
     reference.beat_duration         = beat_duration;
     reference.beat_duration_inverse = (double)1.0 / (double)beat_duration; // for optimized precision_beat_of_now (called every ms)
     reference.last_beat_time        = clock_get_time_seconds(); // seconds since system boot
     reference.beat                  = beats;
+
+    // external clock can easily result in fluctuations below this threshold
+    if(fabsf((float)beat_duration - prev_beat_duration) >= 0.00001){
+        L_queue_tempo_change(60.0 * (float)reference.beat_duration_inverse);
+    }
 }
 
 void clock_update_reference_from(double beats, double beat_duration, clock_source_t source)

--- a/lib/clock.h
+++ b/lib/clock.h
@@ -50,3 +50,4 @@ void clock_crow_init(void);
 void clock_input_handler( int id, float freq ); // Called from Detect lib
 void clock_crow_handle_clock(void);
 void clock_crow_in_div( float div );
+double clock_get_crow_last_time(void);

--- a/lib/clock.h
+++ b/lib/clock.h
@@ -17,7 +17,7 @@ void clock_init( int max_clocks );
 void clock_update(uint32_t time_now);
 
 bool clock_schedule_resume_sleep( int coro_id, float seconds );
-bool clock_schedule_resume_sync( int coro_id, float beats );
+bool clock_schedule_resume_sync( int coro_id, float beats, float sync_beat_offset );
 bool clock_schedule_resume_beatsync( int coro_id, float beats );
 void clock_update_reference( double beats, double beat_duration );
 void clock_update_reference_from( double beats, double beat_duration, clock_source_t source);

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -744,6 +744,11 @@ static int _clock_set_source( lua_State* L )
     lua_pop(L, 1);
     return 0;
 }
+static int _clock_get_crow_last_time( lua_State* L )
+{
+    lua_pushnumber(L, clock_get_crow_last_time());
+    return 1;
+}
 static int _clock_internal_set_tempo( lua_State* L )
 {
     float bpm = luaL_checknumber(L, 1);
@@ -867,6 +872,7 @@ static const struct luaL_Reg libCrow[]=
     , { "clock_get_time_beats"     , _clock_get_time_beats     }
     , { "clock_get_tempo"          , _clock_get_tempo          }
     , { "clock_set_source"         , _clock_set_source         }
+    , { "clock_get_crow_last_time", _clock_get_crow_last_time }
         // clock.internal
     , { "clock_internal_set_tempo" , _clock_internal_set_tempo }
     , { "clock_internal_start"     , _clock_internal_start     }

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -704,11 +704,12 @@ static int _clock_schedule_sync( lua_State* L )
 {
     int coro_id = (int)luaL_checkinteger(L, 1);
     float beats = luaL_checknumber(L, 2);
+    float offset = luaL_optnumber(L, 3, 0);
 
     if (beats <= 0) {
         L_queue_clock_resume(coro_id); // immediate callback
     } else {
-        clock_schedule_resume_sync(coro_id, beats);
+        clock_schedule_resume_sync(coro_id, beats, offset);
     }
     lua_pop(L, 2);
     return 0;

--- a/lib/lualink.c
+++ b/lib/lualink.c
@@ -64,6 +64,7 @@ void L_handle_peak( event_t* e );
 void L_handle_clock_resume( event_t* e );
 void L_handle_clock_start( event_t* e );
 void L_handle_clock_stop( event_t* e );
+void L_handle_tempo_change( event_t* e );
 void L_handle_freq( event_t* e );
 
 void _printf(char* error_message)
@@ -1255,6 +1256,22 @@ void L_handle_clock_stop( event_t* e )
 {
     lua_getglobal(L, "clock_stop_handler");
     if( Lua_call_usercode(L, 0, 0) != LUA_OK ){
+        lua_pop( L, 1 );
+    }
+}
+
+void L_queue_tempo_change( float tempo )
+{
+    event_t e = { .handler = L_handle_tempo_change
+                , .data.f = tempo
+                };
+    event_post(&e);
+}
+void L_handle_tempo_change( event_t* e )
+{
+    lua_getglobal(L, "tempo_change_handler");
+    lua_pushnumber(L, e->data.f);
+    if( Lua_call_usercode(L, 1, 0) != LUA_OK ){
         lua_pop( L, 1 );
     }
 }

--- a/lib/lualink.h
+++ b/lib/lualink.h
@@ -37,6 +37,7 @@ extern void L_queue_ii_followRx( void );
 extern void L_queue_clock_resume( int coro_id );
 extern void L_queue_clock_start( void );
 extern void L_queue_clock_stop( void );
+extern void L_queue_tempo_change( float tempo );
 
 // Callback declarations
 extern float L_handle_ii_followRxTx( uint8_t cmd, int args, float* data );

--- a/lua/clock.lua
+++ b/lua/clock.lua
@@ -96,6 +96,8 @@ end
 clock.get_beats = clock_get_time_beats
 clock.get_beat_sec = function(x) return (x or 1) * 60.0 / clock.tempo end
 
+clock.time_since_last_input = clock_get_crow_last_time
+
 clock.start = function(beat) return clock_internal_start(beat or 0) end
 clock.stop = clock_internal_stop
 

--- a/lua/clock.lua
+++ b/lua/clock.lua
@@ -5,6 +5,7 @@ local clock = { threads = {}
               , transport = {}
               , id = 0
               }
+clock.handlers = clock.transport -- piggyback on existing handler table to save space
 
 --- create a coroutine to run but do not immediately run it;
 -- @tparam function f
@@ -103,6 +104,7 @@ clock.stop = clock_internal_stop
 clock_resume_handler = clock.resume
 function clock_start_handler() if clock.transport.start then clock.transport.start() end end
 function clock_stop_handler()  if clock.transport.stop then clock.transport.stop() end end
+function tempo_change_handler(tempo)  if clock.handlers.tempo_change then clock.handlers.tempo_change(tempo) end end
 
 clock.__newindex = function(self, ix, val)
     if ix == 'tempo' then clock_internal_set_tempo(val) end

--- a/lua/clock.lua
+++ b/lua/clock.lua
@@ -60,7 +60,7 @@ clock.resume = function(coro_id, ...)
     return
   end
 
-  local result, mode, time = coroutine.resume(coro, ...)
+  local result, mode, time, offset = coroutine.resume(coro, ...)
 
   if coroutine.status(coro) == 'dead' then
     if result then
@@ -73,7 +73,7 @@ clock.resume = function(coro_id, ...)
       if mode == 0 then -- SLEEP
         clock_schedule_sleep(coro_id, time)
       elseif mode == 1 then -- SYNC
-        clock_schedule_sync(coro_id, time)
+        clock_schedule_sync(coro_id, time, offset)
       elseif mode == 2 then -- BEATSYNC
         clock_schedule_beat(coro_id, time)
       end


### PR DESCRIPTION
Consider this as a draft.

I've added 3 features to the clock system. I'm happy to make changes, amend this PR to drop some of the features, or split this into multiple PRs. If you don't want these features, that's fine too.

For any features you do want to merge, I can also add the corresponding documentation to the [docs repo](https://github.com/monome/docs). I can also go through the steps to [make a release](https://github.com/monome/crow/blob/main/readme-development.md#making-a-release) if desired.

---
**`clock.sync` offset capability**

e2c23ff adds an optional `offset` parameter to `clock.sync()`, which is intended to work exactly as it does on norns. The implementation closely follows the [norns implementation](https://github.com/monome/norns/blob/main/matron/src/clocks/clock_scheduler.c#L43).

I figure you're familiar with how this works, but let me know if you'd like me to elaborate on this feature.

---
**`clock.handlers.tempo_change` user-defined handler**

ce0028b adds a handler that is called when the clock tempo changes, like `clock.tempo_change_handler` on norns. Since crow [modifies the `clock` metatable](https://github.com/monome/crow/blob/main/lua/clock.lua#L107) to prevent setting new indices, I took the approach of using the existing `clock.transport` table, but added a new key `clock.handlers` that points to this same table. We could simply have `clock.transport.tempo_change` to do away with the new `handlers` key. We could also set `clock.tempo_change_handler` to an empty function that would then always be called when the tempo changes, but this would allow the user to set `clock.tempo_change_handler = function(tempo) ... end` like on norns.

---
**`clock.time_since_last_input()` to check when an external clock trigger was last received**

b661e39 adds a function `clock.time_since_last_input()` which returns the time in seconds since a trigger was received at an input set to drive the clock by `input[n].mode('clock', div)`. If no input has been set to drive the clock, it returns -1.

I wanted to make a script that could be externally clocked, but only if an input was actually receiving a clock. Because there is no "jack detection", the only way I could think to do this is with a timeout that switches back to being unclocked if no external clock is received for some amount of time. I could not figure out a way to access the time that the last external trigger was received, although it is tracked internally in the C layer. I simply added a getter for this value. This enables a "timeout" like this:

```lua
function await_clock()
    input[2].mode( 'change', 3, 0.1, 'rising' )
    input[2].change = function()
        input[2].mode( 'clock', 1/4)
        print('clocked')
        clock_timeout:start()
    end
end

clock_timeout = metro.init{
    event = function()
        if clock.time_since_last_input() > 4 then -- 4 second timeout
            clock_timeout:stop()
            await_clock()
            unclocked()
        end
    end,
    time  = 1.0,
    count = -1
}

function unclocked()
    print('unclocked')
end

await_clock()
```
---

Let me know if you have questions, concerns, or want changes!