### PR TITLE
fix: clean up tempo change handler

### DIFF
--- a/lua/clock.lua
+++ b/lua/clock.lua
@@ -91,6 +91,7 @@ clock.cleanup = function()
   clock.tempo = 120
   clock.transport.start = nil
   clock.transport.stop = nil
+  clock.handlers.tempo_change = nil
 end
 
 clock.get_beats = clock_get_time_beats


### PR DESCRIPTION
In #498, I added `clock.handlers.tempo_change` as a user-defined callback when the tempo changes. I forgot to clean it up in `clock.cleanup`, so the callback was persisting through a `^^clear`. This fixes that bug.